### PR TITLE
Migrate the app to the versioned backend contract, with visible failures

### DIFF
--- a/lib/config/enviroment/enviroment.dart
+++ b/lib/config/enviroment/enviroment.dart
@@ -1,5 +1,13 @@
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 class Environment {
-  static String currency = dotenv.env['CURRENCY_BACK'] ?? '';
+  /// Base URL of the currency backend, without trailing slashes.
+  ///
+  /// Endpoint paths are absolute (`/api/v1/...`), so a trailing slash in the
+  /// `.env` value would build `//api/v1/...`, which the backend answers with a
+  /// 308 redirect instead of serving the resource.
+  static String get currency => normalizeBaseUrl(dotenv.env['CURRENCY_BACK']);
+
+  static String normalizeBaseUrl(String? value) =>
+      (value ?? '').trim().replaceAll(RegExp(r'/+$'), '');
 }

--- a/lib/core/constants/market_constants.dart
+++ b/lib/core/constants/market_constants.dart
@@ -1,0 +1,50 @@
+/// Markets served by the backend, named exactly as it reports them.
+///
+/// The values mirror `Constants.*_NAME` of `bcv_tracker_backend`, which is what
+/// travels in the `platform` field of every rate.
+class Markets {
+  const Markets._();
+
+  static const String bcv = 'Banco Central de Venezuela';
+  static const String yadio = 'Yadio.io';
+  static const String binance = 'Binance';
+  static const String bybit = 'Bybit';
+  static const String okx = 'OKX';
+  static const String bitget = 'Bitget';
+  static const String airtm = 'Airtm';
+  static const String dolarApi = 'DolarAPI';
+  static const String exchangeMonitor = 'Exchange Monitor';
+
+  /// Markets rendered in the average tab, in display order.
+  ///
+  /// `saved-currencies` answers with every market it knows once `fill_missing`
+  /// is on (nine of them today), so this list is what decides which ones reach
+  /// the UI — and in which order, since the backend orders by database id.
+  static const List<String> averageTab = <String>[
+    bcv,
+    exchangeMonitor,
+    yadio,
+    binance,
+    bybit,
+  ];
+
+  /// Exchange Monitor publishes its own value, an estimated average
+  /// ("Monitor Dólar") and, live, one entry per bank.
+  static const String emOwnCode = 'em';
+  static const String emAverageCode = 'average';
+  static const String emMonitorCode = 'md';
+
+  /// Codes that quote a dollar-equivalent against VES.
+  ///
+  /// Used to average the parallel market: the crypto markets quote USDT/USDC
+  /// and Exchange Monitor uses its own codes, so filtering by `USD` alone —
+  /// as the average card used to do — silently dropped most of them.
+  static const Set<String> dollarEquivalentCodes = <String>{
+    'USD',
+    'USDT',
+    'USDC',
+    emOwnCode,
+    emAverageCode,
+    emMonitorCode,
+  };
+}

--- a/lib/core/helpers/backend_date.dart
+++ b/lib/core/helpers/backend_date.dart
@@ -1,0 +1,46 @@
+/// Reads the timestamps as the backend writes them.
+///
+/// Two shapes travel in the same fields:
+///
+/// - rates read from the database arrive **without** an offset
+///   (`2026-07-27T00:00:53.287063`). Their column is a `DateTime` with no
+///   timezone, so the database normalized the Caracas instant the backend
+///   stamped to its session zone — UTC — and dropped the offset.
+/// - rates fetched live are serialized straight from the backend object and
+///   keep their explicit Caracas offset (`2026-07-26T21:18:42.391560-04:00`).
+///
+/// `DateTime.parse` reads the first shape as **device local time**, so every
+/// stored rate was shown hours off for anyone outside UTC.
+class BackendDate {
+  const BackendDate._();
+
+  /// Trailing `Z`, `+HH:MM`, `-HHMM`… of an ISO-8601 timestamp.
+  static final RegExp _offsetSuffix = RegExp(r'(?:Z|[+-]\d{2}:?\d{2})$');
+
+  /// Instant of a backend timestamp, expressed in the device's local zone.
+  ///
+  /// A timestamp with no offset is read as UTC, which is what the database
+  /// stores; one with an offset is honoured as given. Returns `null` for
+  /// anything unparseable, since every date is optional in the contract.
+  static DateTime? toLocal(Object? raw) {
+    if (raw is! String) return null;
+    final value = raw.trim();
+    if (value.isEmpty) return null;
+
+    final absolute = _offsetSuffix.hasMatch(value) ? value : '${value}Z';
+    return DateTime.tryParse(absolute)?.toLocal();
+  }
+
+  /// The same wall clock the backend published, with no zone conversion.
+  ///
+  /// For a date that names a day instead of an instant — the BCV publishes its
+  /// effective date for Venezuela — converting to the device zone would move
+  /// the day for anyone west of Caracas.
+  static DateTime? asPublished(Object? raw) {
+    if (raw is! String) return null;
+    final value = raw.trim();
+    if (value.isEmpty) return null;
+
+    return DateTime.tryParse(value.replaceFirst(_offsetSuffix, ''));
+  }
+}

--- a/lib/core/helpers/currency_helpers.dart
+++ b/lib/core/helpers/currency_helpers.dart
@@ -1,4 +1,5 @@
 import 'package:bcv_tracker_app/core/constants/constants.dart';
+import 'package:bcv_tracker_app/core/constants/market_constants.dart';
 import 'package:bcv_tracker_app/core/i18n/app_messages.dart';
 import 'package:intl/intl.dart';
 
@@ -60,8 +61,49 @@ class CurrencyHelpers {
     }
   }
 
+  /// Code to show for a rate.
+  ///
+  /// Exchange Monitor identifies its rates with its own codes (`em`, `average`,
+  /// `md`) instead of a currency one, but all of them quote the dollar.
+  static String castCurrencyDisplayCode(String currencyCode) {
+    switch (currencyCode) {
+      case Markets.emOwnCode:
+      case Markets.emAverageCode:
+      case Markets.emMonitorCode:
+        return 'USD';
+      default:
+        return currencyCode;
+    }
+  }
+
+  /// Translated name of a rate, falling back to the name given by the backend.
+  ///
+  /// The backend names rates in Spanish ("Dolar", "Promedio"), so rendering
+  /// them raw left the average tab untranslated in the other nine languages.
+  static String castCurrencyDisplayName(Currency currency) {
+    switch (currency.keyName) {
+      case 'USD':
+        return AppMessages.eeuuDollar;
+      case 'EUR':
+        return AppMessages.europeanEuro;
+      case 'USDT':
+        return 'Tether';
+      case 'USDC':
+        return 'USD Coin';
+      case 'BTC':
+        return 'Bitcoin';
+      case Markets.emAverageCode:
+      case Markets.emMonitorCode:
+        return AppMessages.marketAverage;
+      case Markets.emOwnCode:
+        return Markets.exchangeMonitor;
+      default:
+        return currency.name;
+    }
+  }
+
   static String completeCurrencyExchange(String currencyCode) {
-    return '$currencyCode/VES';
+    return '${castCurrencyDisplayCode(currencyCode)}/VES';
   }
 
   static String castCurrency({required double value}) {
@@ -69,7 +111,7 @@ class CurrencyHelpers {
   }
 
   static String castCurrencySymbolText({required String currencyCode}) {
-    switch (currencyCode) {
+    switch (castCurrencyDisplayCode(currencyCode)) {
       case 'USD':
         return '\$';
       case 'EUR':
@@ -94,7 +136,7 @@ class CurrencyHelpers {
   }
 
   static String castCurrencySymbolIcon({required String currencyCode}) {
-    switch (currencyCode) {
+    switch (castCurrencyDisplayCode(currencyCode)) {
       case 'VES':
         return AppIcons.flagVenezuelaIcon;
       case 'USD':
@@ -118,30 +160,51 @@ class CurrencyHelpers {
     }
   }
 
+  /// Average of the parallel market, in VES per dollar.
+  ///
+  /// Every dollar-equivalent quote counts (see
+  /// [Markets.dollarEquivalentCodes]): the crypto markets quote USDT/USDC and
+  /// Exchange Monitor uses its own codes, so matching `USD` alone left the
+  /// average resting on the few markets that use that exact code. The BCV is
+  /// excluded on purpose: it is the official rate, not a parallel one, and
+  /// averaging it in dragged the figure away from the market.
   static double getAverageValue({
     required List<Currency> currencies,
-    String currencyCode = 'USD',
+    Set<String>? currencyCodes,
+    String excludedPlatform = Markets.bcv,
   }) {
-    if (currencies.isEmpty) {
+    final codes = currencyCodes ?? Markets.dollarEquivalentCodes;
+    final values = currencies
+        .where(
+          (currency) =>
+              currency.platform != excludedPlatform &&
+              codes.contains(currency.keyName),
+        )
+        .map((currency) => currency.value);
+
+    if (values.isEmpty) {
       return 0.0;
     }
-    double sum = 0.0;
-    double count = 0.0;
-    for (var currency in currencies) {
-      if (currency.keyName == currencyCode) {
-        sum += currency.value;
-        count++;
-      }
-    }
-    return sum / count;
+    return values.reduce((a, b) => a + b) / values.length;
   }
 
+  /// Shown instead of a date when there is none to format.
+  static const String emptyDatePlaceholder = '--';
+
+  /// Formats an ISO-8601 date, returning [emptyDatePlaceholder] when the string
+  /// is empty or unparseable.
+  ///
+  /// The BCV date is optional in the backend contract and is also empty while
+  /// the first refresh is in flight, so this must not throw.
   static String parseDate({
     required String date,
     String format = Constants.bcvFormatDate,
     bool addDayName = true,
   }) {
-    final dateTime = DateTime.parse(date);
+    final dateTime = DateTime.tryParse(date);
+    if (dateTime == null) {
+      return emptyDatePlaceholder;
+    }
     final formattedDate = DateFormat(format).format(dateTime);
 
     if (addDayName) {

--- a/lib/core/helpers/currency_helpers.dart
+++ b/lib/core/helpers/currency_helpers.dart
@@ -1,5 +1,6 @@
 import 'package:bcv_tracker_app/core/constants/constants.dart';
 import 'package:bcv_tracker_app/core/constants/market_constants.dart';
+import 'package:bcv_tracker_app/core/helpers/backend_date.dart';
 import 'package:bcv_tracker_app/core/i18n/app_messages.dart';
 import 'package:intl/intl.dart';
 
@@ -191,24 +192,39 @@ class CurrencyHelpers {
   /// Shown instead of a date when there is none to format.
   static const String emptyDatePlaceholder = '--';
 
-  /// Formats an ISO-8601 date, returning [emptyDatePlaceholder] when the string
-  /// is empty or unparseable.
+  /// Formats a date **published** by a source, keeping its wall clock.
   ///
-  /// The BCV date is optional in the backend contract and is also empty while
-  /// the first refresh is in flight, so this must not throw.
+  /// Meant for the BCV effective date, which names a day for Venezuela rather
+  /// than an instant: converting it to the device zone would move it to the
+  /// previous day for anyone west of Caracas. Returns [emptyDatePlaceholder]
+  /// when the string is empty or unparseable — the date is optional in the
+  /// contract and is also empty while the first refresh is in flight.
   static String parseDate({
     required String date,
     String format = Constants.bcvFormatDate,
     bool addDayName = true,
   }) {
-    final dateTime = DateTime.tryParse(date);
+    final dateTime = BackendDate.asPublished(date);
     if (dateTime == null) {
       return emptyDatePlaceholder;
     }
-    final formattedDate = DateFormat(format).format(dateTime);
+    return formatDate(date: dateTime, format: format, addDayName: addDayName);
+  }
+
+  /// Formats an instant in the device's local zone.
+  ///
+  /// Rate timestamps reach here already local ([BackendDate.toLocal] converts
+  /// them while parsing); the `toLocal()` is a guard for any other source.
+  static String formatDate({
+    required DateTime date,
+    String format = Constants.defaultFormatDate,
+    bool addDayName = false,
+  }) {
+    final local = date.isUtc ? date.toLocal() : date;
+    final formattedDate = DateFormat(format).format(local);
 
     if (addDayName) {
-      String dayName = getDayName(dayNumber: dateTime.weekday);
+      String dayName = getDayName(dayNumber: local.weekday);
       return '$dayName, $formattedDate';
     }
     return formattedDate;

--- a/lib/core/i18n/app_messages.dart
+++ b/lib/core/i18n/app_messages.dart
@@ -90,4 +90,10 @@ class AppMessages {
   static String get saturdayDay => 'saturdayDay'.tr;
 
   static String get sundayDay => 'sundayDay'.tr;
+
+  static String get marketAverage => 'marketAverage'.tr;
+
+  static String get loadingError => 'loadingError'.tr;
+
+  static String get retryAction => 'retryAction'.tr;
 }

--- a/lib/core/i18n/languages/de_de.dart
+++ b/lib/core/i18n/languages/de_de.dart
@@ -44,4 +44,7 @@ const Map<String, String> deDe = {
   'fridayDay': 'Freitag',
   'saturdayDay': 'Samstag',
   'sundayDay': 'Sonntag',
+  'loadingError': 'Die Kurse konnten nicht geladen werden',
+  'retryAction': 'Wiederholen',
+  'marketAverage': 'Durchschnitt',
 };

--- a/lib/core/i18n/languages/en_us.dart
+++ b/lib/core/i18n/languages/en_us.dart
@@ -44,4 +44,7 @@ const Map<String, String> enUs = {
   'fridayDay': 'Friday',
   'saturdayDay': 'Saturday',
   'sundayDay': 'Sunday',
+  'loadingError': 'Rates could not be loaded',
+  'retryAction': 'Retry',
+  'marketAverage': 'Average',
 };

--- a/lib/core/i18n/languages/es_es.dart
+++ b/lib/core/i18n/languages/es_es.dart
@@ -44,4 +44,7 @@ const Map<String, String> esEs = {
   'fridayDay': 'Viernes',
   'saturdayDay': 'Sábado',
   'sundayDay': 'Domingo',
+  'loadingError': 'No se pudieron cargar las tasas',
+  'retryAction': 'Reintentar',
+  'marketAverage': 'Promedio',
 };

--- a/lib/core/i18n/languages/fr_fr.dart
+++ b/lib/core/i18n/languages/fr_fr.dart
@@ -44,4 +44,7 @@ const Map<String, String> frFr = {
   'fridayDay': 'Vendredi',
   'saturdayDay': 'Samedi',
   'sundayDay': 'Dimanche',
+  'loadingError': 'Impossible de charger les taux',
+  'retryAction': 'Réessayer',
+  'marketAverage': 'Moyenne',
 };

--- a/lib/core/i18n/languages/it_it.dart
+++ b/lib/core/i18n/languages/it_it.dart
@@ -44,4 +44,7 @@ const Map<String, String> itIt = {
   'fridayDay': 'Venerdì',
   'saturdayDay': 'Sabato',
   'sundayDay': 'Domenica',
+  'loadingError': 'Impossibile caricare i tassi',
+  'retryAction': 'Riprova',
+  'marketAverage': 'Media',
 };

--- a/lib/core/i18n/languages/ja_jp.dart
+++ b/lib/core/i18n/languages/ja_jp.dart
@@ -45,4 +45,7 @@ const Map<String, String> jaJp = {
   'fridayDay': '金曜日',
   'saturdayDay': '土曜日',
   'sundayDay': '日曜日',
+  'loadingError': 'レートを読み込めませんでした',
+  'retryAction': '再試行',
+  'marketAverage': '平均',
 };

--- a/lib/core/i18n/languages/ko_kr.dart
+++ b/lib/core/i18n/languages/ko_kr.dart
@@ -42,5 +42,9 @@ const Map<String, String> koKr = {
   'wednesdayDay': '수요일',
   'thursdayDay': '목요일',
   'fridayDay': '금요일',
-  'saturdayDay': '토요일'
+  'saturdayDay': '토요일',
+  'sundayDay': '일요일',
+  'loadingError': '환율을 불러올 수 없습니다',
+  'retryAction': '다시 시도',
+  'marketAverage': '평균',
 };

--- a/lib/core/i18n/languages/pt_pt.dart
+++ b/lib/core/i18n/languages/pt_pt.dart
@@ -45,4 +45,7 @@ const Map<String, String> ptPt = {
   'fridayDay': 'Sexta-feira',
   'saturdayDay': 'Sábado',
   'sundayDay': 'Domingo',
+  'loadingError': 'Não foi possível carregar as taxas',
+  'retryAction': 'Tentar novamente',
+  'marketAverage': 'Média',
 };

--- a/lib/core/i18n/languages/ru_ru.dart
+++ b/lib/core/i18n/languages/ru_ru.dart
@@ -44,4 +44,7 @@ const Map<String, String> ruRu = {
   'fridayDay': 'Пятница',
   'saturdayDay': 'Суббота',
   'sundayDay': 'Воскресенье',
+  'loadingError': 'Не удалось загрузить курсы',
+  'retryAction': 'Повторить',
+  'marketAverage': 'Среднее',
 };

--- a/lib/core/i18n/languages/zh_cn.dart
+++ b/lib/core/i18n/languages/zh_cn.dart
@@ -44,4 +44,7 @@ const Map<String, String> zhCn = {
   'fridayDay': '星期五',
   'saturdayDay': '星期六',
   'sundayDay': '星期日',
+  'loadingError': '无法加载汇率',
+  'retryAction': '重试',
+  'marketAverage': '平均值',
 };

--- a/lib/core/network/api_exception.dart
+++ b/lib/core/network/api_exception.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+
+/// Failure while talking to the currency backend.
+///
+/// The backend answers every error with the same envelope
+/// (`{"status": "Error", "message": "..."}`) and a meaningful status code —
+/// 404 wrong route, 408 source timeout, 502 source unavailable, 500 internal.
+/// This exception keeps both so the UI can tell the user what happened instead
+/// of failing silently.
+class ApiException implements Exception {
+  const ApiException({required this.message, this.statusCode});
+
+  /// Builds the exception from an error response, reusing the `message` of the
+  /// backend envelope when the body carries one.
+  factory ApiException.fromResponse({int? statusCode, Object? body}) {
+    return ApiException(
+      message: _messageFromBody(body) ?? 'HTTP $statusCode',
+      statusCode: statusCode,
+    );
+  }
+
+  /// The request never produced a response (no connectivity, DNS, timeout).
+  const ApiException.network(this.message) : statusCode = null;
+
+  /// A response arrived but its shape is not the expected contract.
+  const ApiException.malformed(this.message) : statusCode = null;
+
+  final String message;
+
+  /// HTTP status code, or `null` when the request never reached the backend.
+  final int? statusCode;
+
+  static String? _messageFromBody(Object? body) {
+    if (body is! String || body.isEmpty) return null;
+    try {
+      final decoded = json.decode(body);
+      if (decoded is Map && decoded['message'] is String) {
+        final message = (decoded['message'] as String).trim();
+        return message.isEmpty ? null : message;
+      }
+    } catch (_) {
+      // Not JSON (e.g. an HTML error page from the edge): fall back to the code.
+    }
+    return null;
+  }
+
+  @override
+  String toString() =>
+      'ApiException(${statusCode ?? 'no response'}): $message';
+}

--- a/lib/core/network/network.dart
+++ b/lib/core/network/network.dart
@@ -1,2 +1,3 @@
+export 'api_exception.dart';
 export 'http_manager.dart';
 export 'http_operation.dart';

--- a/lib/features/converter/presentation/widget/converter_buttons.dart
+++ b/lib/features/converter/presentation/widget/converter_buttons.dart
@@ -89,7 +89,10 @@ class _CurrencyTileButton extends StatelessWidget {
         child: ListTile(
           trailing: _getIcon(context, isActive),
           leading: _CircleCurrencyTypeWidget(currencyCode: currency.keyName),
-          title: Text("${currency.keyName} ${currency.name}"),
+          title: Text(
+            "${CurrencyHelpers.castCurrencyDisplayCode(currency.keyName)} "
+            "${CurrencyHelpers.castCurrencyDisplayName(currency)}",
+          ),
           subtitle: Text(currency.platform),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(16),

--- a/lib/features/converter/presentation/widget/converter_widgets.dart
+++ b/lib/features/converter/presentation/widget/converter_widgets.dart
@@ -66,7 +66,7 @@ class _CurrencyInputSelectorCard extends StatelessWidget {
         _SelectCurrencyButton(currencyCode: currency.keyName, isInput: isInput),
         Flexible(child: Text(
           currency.keyName != 'VES'
-              ? "${currency.name} - ${currency.platform}"
+              ? "${CurrencyHelpers.castCurrencyDisplayName(currency)} - ${currency.platform}"
               : controller.getRoundedCurrency(),
           style: TextStyle(
             color: ColorValues.textQuaternary(context),

--- a/lib/features/home/presentation/controller/home_controller.dart
+++ b/lib/features/home/presentation/controller/home_controller.dart
@@ -10,6 +10,13 @@ class HomeController extends GetxController {
   String get bcvCurrentDate => _repository.bcvCurrentDate.value;
   bool get isLoading => _repository.isLoading.value;
 
+  /// Detail of the last failed refresh, or `null` if the last one succeeded.
+  String? get errorMessage => _repository.errorMessage.value;
+
+  /// Whether each tab already has real rates to render (see [CurrencyRepository]).
+  bool get hasAverageData => _repository.hasAverageData.value;
+  bool get hasBcvData => _repository.hasBcvData.value;
+
   @override
   void onInit() {
     super.onInit();
@@ -17,6 +24,7 @@ class HomeController extends GetxController {
     ever(_repository.averageCurrencies, (_) => update());
     ever(_repository.bcvCurrencies, (_) => update());
     ever(_repository.isLoading, (_) => update());
+    ever(_repository.errorMessage, (_) => update());
   }
 
   Future<void> refreshHomeData() async {

--- a/lib/features/home/presentation/page/home_page.dart
+++ b/lib/features/home/presentation/page/home_page.dart
@@ -6,7 +6,6 @@ import 'package:get/get_core/src/get_main.dart';
 import 'package:get/get_instance/src/extension_instance.dart';
 import 'package:get/get_state_manager/src/simple/get_state.dart';
 
-import '../../../../core/constants/constants.dart';
 import '../../../../core/helpers/currency_helpers.dart';
 import '../../../../core/i18n/app_messages.dart';
 import '../../../../shared/domain/entities/currency.dart';

--- a/lib/features/home/presentation/widgets/home_body.dart
+++ b/lib/features/home/presentation/widgets/home_body.dart
@@ -43,38 +43,71 @@ class _HomeBodyState extends State<_HomeBody>
 class _HomeBodyAverageCurrency extends StatelessWidget {
   @override
   Widget build(BuildContext context) => GetBuilder<HomeController>(
-    builder: (controller) => CustomRefreshIndicator.adaptive(
-      onRefresh: () async {
-        await controller.refreshHomeData();
-      },
-      child: ListView(
-        children: [
-          _CurrencyDollarAverageCard(),
-          for (var e in controller.averageCurrencies) ...[
-            SizedBox(height: 8),
-            _DollarCurrencyCard(currency: e),
+    builder: (controller) {
+      final String? error = controller.errorMessage;
+      // While the first refresh has not succeeded the list still holds the
+      // skeleton placeholders, so showing them once loading stopped would pass
+      // fake rates off as real ones.
+      final bool showCurrencies = controller.hasAverageData || error == null;
+
+      return CustomRefreshIndicator.adaptive(
+        onRefresh: () async {
+          await controller.refreshHomeData();
+        },
+        child: ListView(
+          // Keeps pull-to-refresh usable when the list is too short to scroll,
+          // which is exactly the case in the error state.
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: [
+            if (error != null) ...[
+              _ErrorAdvisorCard(message: error),
+              SizedBox(height: 8),
+            ],
+            if (showCurrencies) ...[
+              _CurrencyDollarAverageCard(),
+              for (var e in controller.averageCurrencies) ...[
+                SizedBox(height: 8),
+                _DollarCurrencyCard(currency: e),
+              ],
+            ],
+            SizedBox(height: 48),
           ],
-          SizedBox(height: 48),
-        ],
-      ),
-    ),
+        ),
+      );
+    },
   );
 }
 
 class _HomeBodyBCVCurrency extends StatelessWidget {
   @override
   Widget build(BuildContext context) => GetBuilder<HomeController>(
-    builder: (controller) => CustomRefreshIndicator.adaptive(
-      onRefresh: () async {
-        await controller.refreshHomeData();
-      },
-      child: ListView(
-        children: [
-          _BCVAdvisorCard(),
-          SizedBox(height: 16),
-          ...controller.bcvCurrencies.map((e) => _BCVDollarCard(currency: e)),
-        ],
-      ),
-    ),
+    builder: (controller) {
+      final String? error = controller.errorMessage;
+      final bool showCurrencies = controller.hasBcvData || error == null;
+
+      return CustomRefreshIndicator.adaptive(
+        onRefresh: () async {
+          await controller.refreshHomeData();
+        },
+        child: ListView(
+          // Keeps pull-to-refresh usable when the list is too short to scroll,
+          // which is exactly the case in the error state.
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: [
+            if (error != null) ...[
+              _ErrorAdvisorCard(message: error),
+              SizedBox(height: 8),
+            ],
+            if (showCurrencies) ...[
+              _BCVAdvisorCard(),
+              SizedBox(height: 16),
+              ...controller.bcvCurrencies.map(
+                (e) => _BCVDollarCard(currency: e),
+              ),
+            ],
+          ],
+        ),
+      );
+    },
   );
 }

--- a/lib/features/home/presentation/widgets/home_widgets.dart
+++ b/lib/features/home/presentation/widgets/home_widgets.dart
@@ -77,10 +77,8 @@ class _DollarCurrencyCard extends StatelessWidget {
                   Text(AppMessages.lastUpdate),
                   Text(
                     currency.updateDate != null
-                        ? CurrencyHelpers.parseDate(
-                            date: currency.updateDate!.toIso8601String(),
-                            format: Constants.defaultFormatDate,
-                            addDayName: false,
+                        ? CurrencyHelpers.formatDate(
+                            date: currency.updateDate!,
                           )
                         : CurrencyHelpers.emptyDatePlaceholder,
                   ),

--- a/lib/features/home/presentation/widgets/home_widgets.dart
+++ b/lib/features/home/presentation/widgets/home_widgets.dart
@@ -38,7 +38,7 @@ class _DollarCurrencyCard extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
               ),
               subtitle: Text(
-                currency.name,
+                CurrencyHelpers.castCurrencyDisplayName(currency),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
               ),
@@ -82,7 +82,7 @@ class _DollarCurrencyCard extends StatelessWidget {
                             format: Constants.defaultFormatDate,
                             addDayName: false,
                           )
-                        : '--',
+                        : CurrencyHelpers.emptyDatePlaceholder,
                   ),
                 ],
               ),
@@ -177,6 +177,62 @@ class _BCVDollarCard extends StatelessWidget {
       ),
     );
   }
+}
+
+/// Shown when the last refresh failed, with the detail reported by the backend
+/// error envelope and a way to retry.
+class _ErrorAdvisorCard extends StatelessWidget {
+  const _ErrorAdvisorCard({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) => GetBuilder<HomeController>(
+    builder: (controller) => CustomBadged(
+      borderRadius: 12,
+      color: ColorValues.textErrorPrimary(context),
+      hMargin: 3,
+      child: Padding(
+        padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    AppMessages.loadingError,
+                    style: TextStyle(
+                      color: ColorValues.textErrorPrimary(context),
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  Text(
+                    message,
+                    maxLines: 3,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: ColorValues.textSecondary(context),
+                      fontSize: 12,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            TextButton(
+              onPressed: controller.isLoading
+                  ? null
+                  : controller.refreshHomeData,
+              child: Text(
+                AppMessages.retryAction,
+                style: TextStyle(color: ColorValues.textErrorPrimary(context)),
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
 }
 
 class _BCVAdvisorCard extends StatelessWidget {

--- a/lib/shared/data/datasource/dollar_api/dollar_api_rest.dart
+++ b/lib/shared/data/datasource/dollar_api/dollar_api_rest.dart
@@ -1,7 +1,9 @@
 import 'dart:convert';
 
 import 'package:bcv_tracker_app/shared/data/datasource/datasource.dart';
+import 'package:dio/dio.dart';
 
+import '../../../../core/network/api_exception.dart';
 import '../../../../core/network/http_manager.dart';
 import '../../model/model.dart';
 
@@ -17,38 +19,84 @@ class DollarApiRest implements IDollarApi {
 
   @override
   Future<BcvCurrenciesModel> getCurrentBCVDollar() async {
-    try {
-      final response = await _client.request(
-        endpoint: _apiUrl + DollarEndpoints.currentBCVDollar,
+    final data = await _getData(DollarEndpoints.currentBCVDollar);
+
+    if (data is! Map<String, dynamic>) {
+      throw const ApiException.malformed(
+        'La respuesta de bcv/with-memory no trae un objeto en "data".',
       );
+    }
 
-      if (response.statusCode == 200 || response.statusCode == 201) {
-        return BcvCurrenciesModel.fromJson(
-          json.decode(response.data)['data'] as Map<String, dynamic>,
-        );
-      }
-
-      throw Exception(response.statusCode);
+    try {
+      return BcvCurrenciesModel.fromJson(data);
     } catch (e) {
-      rethrow;
+      throw ApiException.malformed(
+        'No se pudo interpretar la respuesta de bcv/with-memory: $e',
+      );
     }
   }
 
   @override
   Future<List<CurrencyModel>> getCurrentDollar() async {
-    try {
-      final response = await _client.request(
-        endpoint: _apiUrl + DollarEndpoints.currentDollar,
+    final data = await _getData(DollarEndpoints.currentDollar);
+
+    if (data is! List) {
+      throw const ApiException.malformed(
+        'La respuesta de saved-currencies no trae una lista en "data".',
       );
-
-      if (response.statusCode == 200 || response.statusCode == 201) {
-        final data = json.decode(response.data)['data'] as List;
-        return data.map((e) => CurrencyModel.fromJson(e)).toList();
-      }
-
-      throw Exception(response.statusCode);
-    } catch (e) {
-      rethrow;
     }
+
+    try {
+      return data
+          .whereType<Map<String, dynamic>>()
+          .map(CurrencyModel.fromJson)
+          .toList();
+    } catch (e) {
+      throw ApiException.malformed(
+        'No se pudo interpretar la respuesta de saved-currencies: $e',
+      );
+    }
+  }
+
+  /// Performs the request and returns the `data` field of the backend envelope
+  /// (`{status, message, data}`), translating every failure into an
+  /// [ApiException] that carries the backend message.
+  Future<Object?> _getData(String endpoint) async {
+    final Response response;
+    try {
+      response = await _client.request(endpoint: _apiUrl + endpoint);
+    } on DioException catch (e) {
+      // HttpManager accepts every status code, so Dio only throws when there is
+      // no response at all (connectivity, DNS, timeout).
+      throw ApiException.network(e.message ?? e.type.name);
+    }
+
+    final body = response.data;
+
+    if (response.statusCode != 200 && response.statusCode != 201) {
+      throw ApiException.fromResponse(
+        statusCode: response.statusCode,
+        body: body,
+      );
+    }
+
+    if (body is! String || body.isEmpty) {
+      throw const ApiException.malformed('El backend respondió con un cuerpo vacío.');
+    }
+
+    final Object? envelope;
+    try {
+      envelope = json.decode(body);
+    } catch (e) {
+      throw ApiException.malformed('El backend respondió con un cuerpo no JSON: $e');
+    }
+
+    if (envelope is! Map<String, dynamic> || !envelope.containsKey('data')) {
+      throw const ApiException.malformed(
+        'El backend respondió sin el campo "data" del envelope.',
+      );
+    }
+
+    return envelope['data'];
   }
 }

--- a/lib/shared/data/datasource/dollar_api/dollar_endpoints.dart
+++ b/lib/shared/data/datasource/dollar_api/dollar_endpoints.dart
@@ -1,10 +1,59 @@
+/// Paths of the currency backend (see `bcv_tracker_backend`).
+///
+/// The backend owns the API version in a router (`api/router/v1.py`) mounted by
+/// `main.py` under `Constants.API_V1_STR`, and each country controller
+/// contributes its own segment (`/venezuela`). The resulting contract is
+/// `/api/{version}/{country}/...`, so both pieces are kept apart here instead of
+/// being baked into every path.
 class DollarEndpoints {
+  static const String _apiVersion = 'v1';
 
-  static const String _apiEndpoints = '/api/venezuela';
+  static const String _country = 'venezuela';
 
-  static const String _currentDollarParams = '?bcv=true&yadio=false&binance=false&fill_missing=true&enforce_bcv_dollar=true&enforce_yadio_dollar=false';
+  static const String _apiEndpoints = '/api/$_apiVersion/$_country';
 
-  static const String currentDollar = '$_apiEndpoints/saved-currencies$_currentDollarParams';
+  /// Sources and filters for `saved-currencies`.
+  ///
+  /// `fill_missing` fetches live every market left at `false`, and there is no
+  /// way to leave a market out: one at `true` is read from the database and one
+  /// at `false` is scraped live, but both come back. So this map does not pick
+  /// *which* markets arrive — [Markets.averageTab] does that on the client —
+  /// it picks **where each one comes from**:
+  ///
+  /// - live (`false`) only the three the app shows as fresh rates. Each live
+  ///   source adds latency and is a failure point: the backend gathers them
+  ///   without `return_exceptions`, so one source answering 502 fails the whole
+  ///   request.
+  /// - from the database (`true`) the rest, which is cheap, plus BCV and
+  ///   Exchange Monitor, refreshed by the backend cron six times a day.
+  ///
+  /// Once the per-market Body (#71) is deployed this whole dance is replaced by
+  /// `off` for the markets we do not want and `average` for the crypto ones.
+  static const Map<String, String> _currentDollarParams = {
+    // Live.
+    'yadio': 'false',
+    'binance': 'false',
+    'bybit': 'false',
+    // From the database.
+    'bcv': 'true',
+    'exchange_monitor': 'true',
+    'okx': 'true',
+    'bitget': 'true',
+    'airtm': 'true',
+    'dolarapi': 'true',
+    'fill_missing': 'true',
+    // Only the official dollar out of the BCV, only the dollar out of Yadio
+    // (it also publishes euro and bitcoin) and only the estimated average of
+    // Exchange Monitor ("Monitor Dólar").
+    'enforce_bcv_dollar': 'true',
+    'enforce_yadio_dollar': 'true',
+    'enforce_em_average': 'true',
+  };
+
+  static final String currentDollar = Uri(
+    path: '$_apiEndpoints/saved-currencies',
+    queryParameters: _currentDollarParams,
+  ).toString();
 
   static const String currentBCVDollar = '$_apiEndpoints/bcv/with-memory';
 }

--- a/lib/shared/data/mapper/currency_normalizer.dart
+++ b/lib/shared/data/mapper/currency_normalizer.dart
@@ -1,0 +1,108 @@
+import '../../../core/constants/market_constants.dart';
+import '../../domain/entities/currency.dart';
+
+/// Turns the raw `saved-currencies` payload into the list the UI can render.
+///
+/// The endpoint returns every market it knows (nine today) with one row per
+/// P2P side, and its database keeps rates keyed by `(code, platform)` — which
+/// makes repeated rows for the same pair possible. This collapses all of that:
+///
+/// 1. keeps only the markets in [Markets.averageTab];
+/// 2. drops repeated `(platform, code, name)` rows, keeping the first one —
+///    the backend orders by descending id, so that is the most recent;
+/// 3. merges the `-buy` / `-sell` sides of a pair into a single averaged rate;
+/// 4. sorts by market, so the order does not depend on database ids.
+class CurrencyNormalizer {
+  const CurrencyNormalizer._();
+
+  static const String _buySuffix = '-buy';
+  static const String _sellSuffix = '-sell';
+
+  static List<Currency> forAverageTab(List<Currency> currencies) {
+    final allowed = currencies.where(
+      (currency) => Markets.averageTab.contains(currency.platform),
+    );
+    final merged = _mergeSides(_dedupe(allowed));
+    merged.sort(_byMarketThenCode);
+    return merged;
+  }
+
+  /// Removes exact repeats of `(platform, code, name)`, keeping the first.
+  static List<Currency> _dedupe(Iterable<Currency> currencies) {
+    final seen = <String>{};
+    return currencies
+        .where(
+          (currency) => seen.add(
+            '${currency.platform}|${currency.keyName}|${currency.name}',
+          ),
+        )
+        .toList();
+  }
+
+  /// Averages the buy and sell sides of the same asset into one rate.
+  static List<Currency> _mergeSides(List<Currency> currencies) {
+    final groups = <String, List<Currency>>{};
+    for (final currency in currencies) {
+      final key =
+          '${currency.platform}|${currency.keyName}|${_baseName(currency.name)}';
+      groups.putIfAbsent(key, () => <Currency>[]).add(currency);
+    }
+    return groups.values.map(_merge).toList();
+  }
+
+  static Currency _merge(List<Currency> group) {
+    final first = group.first;
+    if (group.length == 1) {
+      return first.copyWith(name: _baseName(first.name));
+    }
+
+    final tendencies = group
+        .map((currency) => currency.tendency)
+        .whereType<double>()
+        .toList();
+
+    return Currency(
+      name: _baseName(first.name),
+      keyName: first.keyName,
+      platform: first.platform,
+      value: _mean(group.map((currency) => currency.value)),
+      imgUrl: group
+          .map((currency) => currency.imgUrl)
+          .firstWhere((url) => url != null, orElse: () => null),
+      createDate: _earliest(group.map((currency) => currency.createDate)),
+      updateDate: _latest(group.map((currency) => currency.updateDate)),
+      tendency: tendencies.isEmpty ? null : _mean(tendencies),
+    );
+  }
+
+  /// `Tether-buy` / `Tether-sell` → `Tether`.
+  static String _baseName(String name) {
+    final lower = name.toLowerCase();
+    for (final suffix in const [_buySuffix, _sellSuffix]) {
+      if (lower.endsWith(suffix)) {
+        return name.substring(0, name.length - suffix.length);
+      }
+    }
+    return name;
+  }
+
+  static double _mean(Iterable<double> values) =>
+      values.reduce((a, b) => a + b) / values.length;
+
+  static DateTime? _earliest(Iterable<DateTime?> dates) => dates
+      .whereType<DateTime>()
+      .fold<DateTime?>(null, (a, b) => a == null || b.isBefore(a) ? b : a);
+
+  static DateTime? _latest(Iterable<DateTime?> dates) => dates
+      .whereType<DateTime>()
+      .fold<DateTime?>(null, (a, b) => a == null || b.isAfter(a) ? b : a);
+
+  static int _byMarketThenCode(Currency a, Currency b) {
+    final byMarket = Markets.averageTab
+        .indexOf(a.platform)
+        .compareTo(Markets.averageTab.indexOf(b.platform));
+    if (byMarket != 0) return byMarket;
+    final byCode = a.keyName.compareTo(b.keyName);
+    return byCode != 0 ? byCode : a.name.compareTo(b.name);
+  }
+}

--- a/lib/shared/data/model/bcv_currencies_model.dart
+++ b/lib/shared/data/model/bcv_currencies_model.dart
@@ -4,12 +4,20 @@ import 'currency_model.dart';
 class BcvCurrenciesModel extends BcvCurrencies {
   BcvCurrenciesModel({required super.date, required super.currencies});
 
+  /// Maps a `BcvResponseData` of the backend: `date` is optional and
+  /// `currencies` may be absent if the source degraded.
   factory BcvCurrenciesModel.fromJson(Map<String, dynamic> json) {
-    final date = json['date'];
-    final currencies = (json['currencies'] as List)
-        .map((e) => CurrencyModel.fromJson(e))
-        .toList();
-    return BcvCurrenciesModel(date: date, currencies: currencies);
+    final rawCurrencies = json['currencies'];
+    final currencies = rawCurrencies is List
+        ? rawCurrencies
+              .whereType<Map<String, dynamic>>()
+              .map(CurrencyModel.fromJson)
+              .toList()
+        : <CurrencyModel>[];
+    return BcvCurrenciesModel(
+      date: json['date'] as String?,
+      currencies: currencies,
+    );
   }
 
   BcvCurrencies toEntity() {

--- a/lib/shared/data/model/currency_model.dart
+++ b/lib/shared/data/model/currency_model.dart
@@ -1,3 +1,4 @@
+import 'package:bcv_tracker_app/core/helpers/backend_date.dart';
 import 'package:bcv_tracker_app/shared/domain/entities/entities.dart';
 
 class CurrencyModel extends Currency {
@@ -23,14 +24,13 @@ class CurrencyModel extends Currency {
       platform: json['platform'] as String? ?? '',
       value: (json['value'] as num?)?.toDouble() ?? 0.0,
       imgUrl: _parseImgUrl(json['platform_img']),
-      createDate: _parseDate(json['createDate']),
-      updateDate: _parseDate(json['updateDate']),
+      // Normalized to the device zone here, at the boundary, so the rest of the
+      // app never handles a backend timestamp again (see [BackendDate]).
+      createDate: BackendDate.toLocal(json['createDate']),
+      updateDate: BackendDate.toLocal(json['updateDate']),
       tendency: (json['change'] as num?)?.toDouble(),
     );
   }
-
-  static DateTime? _parseDate(Object? value) =>
-      value is String ? DateTime.tryParse(value) : null;
 
   /// The backend sends an empty string for platforms with no logo mapped
   /// (`PLATFORM_IMAGES.get(platform, "")`); the UI expects `null` there to fall

--- a/lib/shared/data/model/currency_model.dart
+++ b/lib/shared/data/model/currency_model.dart
@@ -12,17 +12,33 @@ class CurrencyModel extends Currency {
     super.tendency,
   });
 
+  /// Maps a `CurrencySchema` of the backend.
+  ///
+  /// `createDate`, `updateDate`, `change` and `platform_img` are optional in the
+  /// contract, so none of them can be dereferenced directly.
   factory CurrencyModel.fromJson(Map<String, dynamic> json) {
     return CurrencyModel(
-      name: json['name'],
-      keyName: json['code'],
-      platform: json['platform'],
-      value: json['value'].toDouble(),
-      imgUrl: json['platform_img'],
-      createDate: DateTime.parse(json['createDate']),
-      updateDate: DateTime.parse(json['updateDate']),
-      tendency: json['change'],
+      name: json['name'] as String? ?? '',
+      keyName: json['code'] as String? ?? '',
+      platform: json['platform'] as String? ?? '',
+      value: (json['value'] as num?)?.toDouble() ?? 0.0,
+      imgUrl: _parseImgUrl(json['platform_img']),
+      createDate: _parseDate(json['createDate']),
+      updateDate: _parseDate(json['updateDate']),
+      tendency: (json['change'] as num?)?.toDouble(),
     );
+  }
+
+  static DateTime? _parseDate(Object? value) =>
+      value is String ? DateTime.tryParse(value) : null;
+
+  /// The backend sends an empty string for platforms with no logo mapped
+  /// (`PLATFORM_IMAGES.get(platform, "")`); the UI expects `null` there to fall
+  /// back to the currency initials instead of requesting an empty URL.
+  static String? _parseImgUrl(Object? value) {
+    if (value is! String) return null;
+    final url = value.trim();
+    return url.isEmpty ? null : url;
   }
 
   Currency toEntity() {

--- a/lib/shared/data/repositories/currency_repository.dart
+++ b/lib/shared/data/repositories/currency_repository.dart
@@ -1,8 +1,10 @@
 import 'dart:developer';
 
 import 'package:get/get.dart';
+import '../../../core/network/api_exception.dart';
 import '../../domain/entities/entities.dart';
 import '../../domain/repositories/dollar_repositories.dart';
+import '../mapper/currency_normalizer.dart';
 
 class CurrencyRepository extends GetxService {
   final IDollarRepository _dollarRepository = Get.find<IDollarRepository>();
@@ -18,6 +20,18 @@ class CurrencyRepository extends GetxService {
   final RxString bcvCurrentDate = ''.obs;
   final RxBool isLoading = false.obs;
 
+  /// Detail of the last failed refresh, or `null` when the last one succeeded.
+  ///
+  /// Without this the failures only reached the console: a broken contract (the
+  /// 404 after the `/api/v1` move, a source answering 502) left the UI showing
+  /// the skeleton placeholders forever, with no way for the user to tell.
+  final RxnString errorMessage = RxnString();
+
+  /// Whether each list already holds real rates. While `false` it still holds
+  /// the `emptySkeletonizer` placeholders, which must not be shown as data.
+  final RxBool hasAverageData = false.obs;
+  final RxBool hasBcvData = false.obs;
+
   @override
   void onReady() {
     super.onReady();
@@ -27,8 +41,12 @@ class CurrencyRepository extends GetxService {
   Future<void> refreshData() async {
     isLoading.value = true;
     try {
+      // eagerError is off by default: both fetches complete even if one fails,
+      // so a partial refresh still lands its data before the error surfaces.
       await Future.wait([getAveragedCurrencies(), getBCVCurrencies()]);
+      errorMessage.value = null;
     } catch (e, s) {
+      errorMessage.value = _describe(e);
       log(
         "Error fetching data: $e",
         name: "CurrencyRepository.refreshData()",
@@ -41,36 +59,25 @@ class CurrencyRepository extends GetxService {
   }
 
   Future<void> getAveragedCurrencies() async {
-    try {
-      final List<Currency> result = await _dollarRepository.getCurrentDollar();
-      averageCurrencies.assignAll(result);
-    } catch (e, s) {
-      log(
-        "Error getting average currencies: $e",
-        name: "CurrencyRepository.getAveragedCurrencies()",
-        error: e,
-        stackTrace: s,
-      );
-      // Optionally keep existing data or show error state
-    }
+    final List<Currency> result = await _dollarRepository.getCurrentDollar();
+    // saved-currencies answers with every market the backend knows, one row per
+    // P2P side and, from the database, occasional repeats; see
+    // [CurrencyNormalizer].
+    averageCurrencies.assignAll(CurrencyNormalizer.forAverageTab(result));
+    hasAverageData.value = true;
   }
 
   Future<void> getBCVCurrencies() async {
-    try {
-      // Logic for BCV needs to check requirements.
-      // The currentBCVDollar endpoint might return list of all bank rates (Official)
-      // We assign it to bcvCurrencies.
-      final BcvCurrencies result = await _dollarRepository
-          .getCurrentBCVDollar();
-      bcvCurrencies.assignAll(result.currencies);
-      bcvCurrentDate.value = result.date;
-    } catch (e, s) {
-      log(
-        "Error getting BCV currencies: $e",
-        name: "CurrencyRepository.getAveragedCurrencies()",
-        error: e,
-        stackTrace: s,
-      );
-    }
+    // The currentBCVDollar endpoint returns every official BCV rate plus the
+    // effective date reported by the institution.
+    final BcvCurrencies result = await _dollarRepository.getCurrentBCVDollar();
+    bcvCurrencies.assignAll(result.currencies);
+    bcvCurrentDate.value = result.date ?? '';
+    hasBcvData.value = true;
   }
+
+  /// User-facing detail of a failure: [ApiException] already carries the
+  /// `message` of the backend error envelope.
+  String _describe(Object error) =>
+      error is ApiException ? error.message : error.toString();
 }

--- a/lib/shared/domain/entities/bcv_currencies.dart
+++ b/lib/shared/domain/entities/bcv_currencies.dart
@@ -1,7 +1,9 @@
 import 'currency.dart';
 
 class BcvCurrencies {
-  final String date;
+  /// Effective date reported by the BCV. Optional in the backend contract
+  /// (`BcvResponseData.date`): it is `null` when no platform date is stored yet.
+  final String? date;
   final List<Currency> currencies;
 
   BcvCurrencies({required this.date, required this.currencies});

--- a/lib/shared/domain/entities/currency.dart
+++ b/lib/shared/domain/entities/currency.dart
@@ -25,6 +25,7 @@ class Currency {
     String? platform,
     double? value,
     String? imgUrl,
+    DateTime? createDate,
     DateTime? updateDate,
     double? tendency,
   }) {
@@ -34,6 +35,7 @@ class Currency {
       platform: platform ?? this.platform,
       value: value ?? this.value,
       imgUrl: imgUrl ?? this.imgUrl,
+      createDate: createDate ?? this.createDate,
       updateDate: updateDate ?? this.updateDate,
       tendency: tendency ?? this.tendency,
     );

--- a/test/core/helpers/backend_date_test.dart
+++ b/test/core/helpers/backend_date_test.dart
@@ -1,0 +1,75 @@
+import 'package:bcv_tracker_app/core/helpers/backend_date.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The assertions compare instants (`toUtc()`) instead of wall clocks, so they
+/// hold on any machine. The suite is also run under a second `TZ` in CI-style
+/// checks to prove the conversion is not a no-op in the author's zone.
+void main() {
+  group('toLocal()', () {
+    test('reads a timestamp with no offset as UTC', () {
+      // What a rate stored in the database looks like.
+      final parsed = BackendDate.toLocal('2026-07-27T00:00:53.287063');
+
+      expect(parsed, isNotNull);
+      expect(parsed!.toUtc(), DateTime.utc(2026, 7, 27, 0, 0, 53, 287, 63));
+      // Returned in the device zone so DateFormat prints local time.
+      expect(parsed.isUtc, isFalse);
+    });
+
+    test('honours an explicit offset', () {
+      // What a rate fetched live looks like: stamped in Caracas.
+      final parsed = BackendDate.toLocal('2026-07-26T21:18:42.391560-04:00');
+
+      expect(parsed!.toUtc(), DateTime.utc(2026, 7, 27, 1, 18, 42, 391, 560));
+      expect(parsed.isUtc, isFalse);
+    });
+
+    test('both shapes of the same instant land on the same moment', () {
+      final fromDatabase = BackendDate.toLocal('2026-07-27T01:18:42');
+      final fromLive = BackendDate.toLocal('2026-07-26T21:18:42-04:00');
+
+      expect(fromDatabase, fromLive);
+    });
+
+    test('accepts the Z suffix and an offset without a colon', () {
+      expect(
+        BackendDate.toLocal('2026-07-27T00:00:53Z')!.toUtc(),
+        DateTime.utc(2026, 7, 27, 0, 0, 53),
+      );
+      expect(
+        BackendDate.toLocal('2026-07-26T20:00:53-0400')!.toUtc(),
+        DateTime.utc(2026, 7, 27, 0, 0, 53),
+      );
+    });
+
+    test('returns null for anything it cannot read', () {
+      expect(BackendDate.toLocal(null), isNull);
+      expect(BackendDate.toLocal(''), isNull);
+      expect(BackendDate.toLocal('   '), isNull);
+      expect(BackendDate.toLocal('no es una fecha'), isNull);
+      expect(BackendDate.toLocal(1753574453), isNull);
+    });
+  });
+
+  group('asPublished()', () {
+    test('keeps the wall clock of a date published with an offset', () {
+      // The BCV effective date: it names a day for Venezuela, so it must read
+      // 2026-07-23 no matter where the device is.
+      final parsed = BackendDate.asPublished('2026-07-23T00:00:00-04:00');
+
+      expect(parsed, DateTime(2026, 7, 23));
+      expect(parsed!.isUtc, isFalse);
+      expect(parsed.hour, 0);
+    });
+
+    test('leaves a plain date untouched', () {
+      expect(BackendDate.asPublished('2026-07-23'), DateTime(2026, 7, 23));
+    });
+
+    test('returns null for anything it cannot read', () {
+      expect(BackendDate.asPublished(null), isNull);
+      expect(BackendDate.asPublished(''), isNull);
+      expect(BackendDate.asPublished('no es una fecha'), isNull);
+    });
+  });
+}

--- a/test/core/helpers/currency_helpers_average_test.dart
+++ b/test/core/helpers/currency_helpers_average_test.dart
@@ -1,0 +1,79 @@
+import 'package:bcv_tracker_app/core/constants/market_constants.dart';
+import 'package:bcv_tracker_app/core/helpers/currency_helpers.dart';
+import 'package:bcv_tracker_app/shared/domain/entities/currency.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Currency _rate(String platform, String code, double value) => Currency(
+  name: code,
+  keyName: code,
+  platform: platform,
+  value: value,
+);
+
+void main() {
+  group('getAverageValue()', () {
+    test('averages every dollar-equivalent quote of the parallel market', () {
+      final average = CurrencyHelpers.getAverageValue(
+        currencies: [
+          _rate(Markets.yadio, 'USD', 840),
+          _rate(Markets.binance, 'USDT', 860),
+          _rate(Markets.bybit, 'USDC', 880),
+          _rate(Markets.exchangeMonitor, Markets.emAverageCode, 820),
+        ],
+      );
+
+      expect(average, 850.0);
+    });
+
+    test('leaves the official BCV rate out of the average', () {
+      final average = CurrencyHelpers.getAverageValue(
+        currencies: [
+          // Far below the market: averaging it in used to drag the figure down.
+          _rate(Markets.bcv, 'USD', 737),
+          _rate(Markets.yadio, 'USD', 840),
+          _rate(Markets.binance, 'USDT', 860),
+        ],
+      );
+
+      expect(average, 850.0);
+    });
+
+    test('returns 0 instead of NaN when nothing matches', () {
+      // The skeleton placeholders match no code: the previous 0/0 rendered
+      // "Bs.S NaN" on the average card while the first refresh was in flight.
+      expect(
+        CurrencyHelpers.getAverageValue(
+          currencies: [_rate('platform', 'keyName', 1.0)],
+        ),
+        0.0,
+      );
+      expect(CurrencyHelpers.getAverageValue(currencies: []), 0.0);
+    });
+  });
+
+  group('castCurrencyDisplayCode()', () {
+    test('maps the Exchange Monitor codes to the dollar', () {
+      expect(CurrencyHelpers.castCurrencyDisplayCode(Markets.emOwnCode), 'USD');
+      expect(
+        CurrencyHelpers.castCurrencyDisplayCode(Markets.emAverageCode),
+        'USD',
+      );
+      expect(
+        CurrencyHelpers.completeCurrencyExchange(Markets.emAverageCode),
+        'USD/VES',
+      );
+      // The dollar symbol reaches those rates too, instead of an empty string.
+      expect(
+        CurrencyHelpers.castCurrencySymbolText(
+          currencyCode: Markets.emAverageCode,
+        ),
+        '\$',
+      );
+    });
+
+    test('leaves a regular code untouched', () {
+      expect(CurrencyHelpers.castCurrencyDisplayCode('USDT'), 'USDT');
+      expect(CurrencyHelpers.completeCurrencyExchange('USDT'), 'USDT/VES');
+    });
+  });
+}

--- a/test/core/helpers/currency_helpers_parse_date_test.dart
+++ b/test/core/helpers/currency_helpers_parse_date_test.dart
@@ -1,5 +1,7 @@
+import 'package:bcv_tracker_app/core/constants/constants.dart';
 import 'package:bcv_tracker_app/core/helpers/currency_helpers.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
 
 void main() {
   group('parseDate()', () {
@@ -19,13 +21,36 @@ void main() {
       );
     });
 
-    test('formats a valid ISO-8601 date', () {
-      final formatted = CurrencyHelpers.parseDate(
-        date: '2026-07-23T00:00:00-04:00',
-        addDayName: false,
+    test('keeps the day the BCV published, in any device zone', () {
+      // Converting this to the device zone would show 2026-07-22 to anyone
+      // west of Caracas: it names a day for Venezuela, not an instant.
+      expect(
+        CurrencyHelpers.parseDate(
+          date: '2026-07-23T00:00:00-04:00',
+          addDayName: false,
+        ),
+        '2026-07-23',
       );
-      expect(formatted, isNot(CurrencyHelpers.emptyDatePlaceholder));
-      expect(formatted, contains('2026'));
+    });
+  });
+
+  group('formatDate()', () {
+    test('prints an instant in the device zone', () {
+      final instant = DateTime.utc(2026, 7, 27, 0, 0, 53).toLocal();
+
+      expect(
+        CurrencyHelpers.formatDate(date: instant),
+        DateFormat(Constants.defaultFormatDate).format(instant),
+      );
+    });
+
+    test('converts a UTC instant instead of printing its UTC clock', () {
+      final utc = DateTime.utc(2026, 7, 27, 0, 0, 53);
+
+      expect(
+        CurrencyHelpers.formatDate(date: utc),
+        DateFormat(Constants.defaultFormatDate).format(utc.toLocal()),
+      );
     });
   });
 }

--- a/test/core/helpers/currency_helpers_parse_date_test.dart
+++ b/test/core/helpers/currency_helpers_parse_date_test.dart
@@ -1,0 +1,31 @@
+import 'package:bcv_tracker_app/core/helpers/currency_helpers.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('parseDate()', () {
+    test('empty string returns the placeholder instead of throwing', () {
+      // The BCV date is empty until the first refresh lands, and stays empty if
+      // the backend has no stored platform date.
+      expect(
+        CurrencyHelpers.parseDate(date: ''),
+        CurrencyHelpers.emptyDatePlaceholder,
+      );
+    });
+
+    test('unparseable string returns the placeholder', () {
+      expect(
+        CurrencyHelpers.parseDate(date: 'no-es-una-fecha'),
+        CurrencyHelpers.emptyDatePlaceholder,
+      );
+    });
+
+    test('formats a valid ISO-8601 date', () {
+      final formatted = CurrencyHelpers.parseDate(
+        date: '2026-07-23T00:00:00-04:00',
+        addDayName: false,
+      );
+      expect(formatted, isNot(CurrencyHelpers.emptyDatePlaceholder));
+      expect(formatted, contains('2026'));
+    });
+  });
+}

--- a/test/shared/data/currency_normalizer_test.dart
+++ b/test/shared/data/currency_normalizer_test.dart
@@ -1,0 +1,143 @@
+import 'package:bcv_tracker_app/core/constants/market_constants.dart';
+import 'package:bcv_tracker_app/shared/data/mapper/currency_normalizer.dart';
+import 'package:bcv_tracker_app/shared/domain/entities/currency.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Currency _rate({
+  required String platform,
+  required String code,
+  required String name,
+  required double value,
+  double? tendency,
+  DateTime? updateDate,
+}) => Currency(
+  name: name,
+  keyName: code,
+  platform: platform,
+  value: value,
+  tendency: tendency,
+  createDate: DateTime(2026, 1, 1),
+  updateDate: updateDate ?? DateTime(2026, 7, 23),
+);
+
+void main() {
+  group('forAverageTab()', () {
+    test('drops the markets outside the allowlist', () {
+      final result = CurrencyNormalizer.forAverageTab([
+        _rate(
+          platform: Markets.okx,
+          code: 'USDT',
+          name: 'Tether-sell',
+          value: 865,
+        ),
+        _rate(
+          platform: Markets.bitget,
+          code: 'USDT',
+          name: 'Tether-sell',
+          value: 857,
+        ),
+        _rate(
+          platform: Markets.airtm,
+          code: 'USD',
+          name: 'Dolar-sell',
+          value: 826,
+        ),
+        _rate(
+          platform: Markets.dolarApi,
+          code: 'USD',
+          name: 'Paralelo',
+          value: 850,
+        ),
+        _rate(platform: Markets.yadio, code: 'USD', name: 'Dolar', value: 844),
+      ]);
+
+      expect(result.map((c) => c.platform), [Markets.yadio]);
+    });
+
+    test('merges the buy and sell sides into one averaged rate', () {
+      final result = CurrencyNormalizer.forAverageTab([
+        _rate(
+          platform: Markets.binance,
+          code: 'USDT',
+          name: 'Tether-buy',
+          value: 860.0,
+          tendency: 1.0,
+          updateDate: DateTime(2026, 7, 23, 10),
+        ),
+        _rate(
+          platform: Markets.binance,
+          code: 'USDT',
+          name: 'Tether-sell',
+          value: 870.0,
+          tendency: 3.0,
+          updateDate: DateTime(2026, 7, 23, 12),
+        ),
+      ]);
+
+      expect(result, hasLength(1));
+      expect(result.single.name, 'Tether');
+      expect(result.single.value, 865.0);
+      expect(result.single.tendency, 2.0);
+      // The merged rate keeps the freshest timestamp of the pair.
+      expect(result.single.updateDate, DateTime(2026, 7, 23, 12));
+      expect(result.single.createDate, isNotNull);
+    });
+
+    test('a lone side still loses its suffix', () {
+      final result = CurrencyNormalizer.forAverageTab([
+        _rate(
+          platform: Markets.binance,
+          code: 'USDC',
+          name: 'Usd coin-sell',
+          value: 853,
+        ),
+      ]);
+
+      expect(result.single.name, 'Usd coin');
+      expect(result.single.value, 853);
+    });
+
+    test('drops repeated database rows keeping the first', () {
+      // The backend keys rates by (code, platform) and orders by descending id,
+      // so repeats of the same triple are older snapshots.
+      final result = CurrencyNormalizer.forAverageTab([
+        _rate(platform: Markets.yadio, code: 'USD', name: 'Dolar', value: 844),
+        _rate(platform: Markets.yadio, code: 'USD', name: 'Dolar', value: 800),
+      ]);
+
+      expect(result, hasLength(1));
+      expect(result.single.value, 844);
+    });
+
+    test('orders by market instead of by database id', () {
+      final result = CurrencyNormalizer.forAverageTab([
+        _rate(
+          platform: Markets.bybit,
+          code: 'USDT',
+          name: 'Tether-sell',
+          value: 856,
+        ),
+        _rate(platform: Markets.yadio, code: 'USD', name: 'Dolar', value: 844),
+        _rate(
+          platform: Markets.exchangeMonitor,
+          code: Markets.emAverageCode,
+          name: 'Promedio',
+          value: 803,
+        ),
+        _rate(platform: Markets.bcv, code: 'USD', name: 'Dolar', value: 737),
+        _rate(
+          platform: Markets.binance,
+          code: 'USDT',
+          name: 'Tether-sell',
+          value: 860,
+        ),
+      ]);
+
+      expect(result.map((c) => c.platform), Markets.averageTab);
+    });
+
+    test('an empty payload does not throw', () {
+      expect(CurrencyNormalizer.forAverageTab([]), isEmpty);
+    });
+  });
+}

--- a/test/shared/data/dollar_api_rest_test.dart
+++ b/test/shared/data/dollar_api_rest_test.dart
@@ -1,0 +1,174 @@
+import 'package:bcv_tracker_app/core/network/api_exception.dart';
+import 'package:bcv_tracker_app/core/network/http_manager.dart';
+import 'package:bcv_tracker_app/core/network/http_operation.dart';
+import 'package:bcv_tracker_app/shared/data/datasource/dollar_api/dollar_api_rest.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Returns a canned response (or failure) instead of hitting the network.
+class _FakeHttpManager extends HttpManager {
+  _FakeHttpManager({this.statusCode = 200, this.responseBody, this.failure});
+
+  final int statusCode;
+  final Object? responseBody;
+  final DioException? failure;
+
+  @override
+  Future<Response> request({
+    required String endpoint,
+    HttpOperation method = HttpOperation.get,
+    Map<String, dynamic>? body,
+    Map<String, dynamic>? customHeader,
+    String? clientCode,
+  }) async {
+    if (failure != null) throw failure!;
+    return Response(
+      requestOptions: RequestOptions(path: endpoint),
+      statusCode: statusCode,
+      data: responseBody,
+    );
+  }
+}
+
+DollarApiRest _api({
+  int statusCode = 200,
+  Object? body,
+  DioException? failure,
+}) => DollarApiRest(
+  apiUrl: 'https://backend.test',
+  client: _FakeHttpManager(
+    statusCode: statusCode,
+    responseBody: body,
+    failure: failure,
+  ),
+);
+
+void main() {
+  group('getCurrentDollar()', () {
+    test('maps the data list of the envelope', () async {
+      final result = await _api(
+        body:
+            '{"status":"Success","message":"ok","data":['
+            '{"code":"USD","name":"Dolar","platform":"Banco Central de Venezuela",'
+            '"value":737.8816,"change":33.08,"createDate":"2026-01-29T18:38:47.617316",'
+            '"updateDate":"2026-07-23T03:46:17.336191","platform_img":"https://logo.test/bcv.png"}]}',
+      ).getCurrentDollar();
+
+      expect(result, hasLength(1));
+      expect(result.first.keyName, 'USD');
+      expect(result.first.value, 737.8816);
+      expect(result.first.tendency, 33.08);
+      expect(result.first.imgUrl, 'https://logo.test/bcv.png');
+      expect(result.first.updateDate, isNotNull);
+    });
+
+    test('keeps the backend message on an error status', () async {
+      await expectLater(
+        _api(
+          statusCode: 502,
+          body:
+              '{"status":"Error","message":"El portal del BCV no está disponible"}',
+        ).getCurrentDollar(),
+        throwsA(
+          isA<ApiException>()
+              .having((e) => e.statusCode, 'statusCode', 502)
+              .having(
+                (e) => e.message,
+                'message',
+                'El portal del BCV no está disponible',
+              ),
+        ),
+      );
+    });
+
+    test('falls back to the status code when the body is not the envelope', () async {
+      // What a wrong route actually returns through the edge: an HTML page.
+      await expectLater(
+        _api(statusCode: 404, body: '<html>404</html>').getCurrentDollar(),
+        throwsA(
+          isA<ApiException>()
+              .having((e) => e.statusCode, 'statusCode', 404)
+              .having((e) => e.message, 'message', 'HTTP 404'),
+        ),
+      );
+    });
+
+    test('reports a malformed body instead of crashing', () async {
+      await expectLater(
+        _api(body: 'not json').getCurrentDollar(),
+        throwsA(isA<ApiException>()),
+      );
+      await expectLater(
+        _api(body: '{"status":"Success","message":"ok"}').getCurrentDollar(),
+        throwsA(isA<ApiException>()),
+      );
+      await expectLater(
+        _api(body: '').getCurrentDollar(),
+        throwsA(isA<ApiException>()),
+      );
+      // `data` present but not a list.
+      await expectLater(
+        _api(body: '{"status":"Success","message":"ok","data":{}}')
+            .getCurrentDollar(),
+        throwsA(isA<ApiException>()),
+      );
+    });
+
+    test('translates a transport failure into ApiException.network', () async {
+      await expectLater(
+        _api(
+          failure: DioException(
+            requestOptions: RequestOptions(path: '/x'),
+            message: 'Connection refused',
+            type: DioExceptionType.connectionError,
+          ),
+        ).getCurrentDollar(),
+        throwsA(
+          isA<ApiException>()
+              .having((e) => e.statusCode, 'statusCode', isNull)
+              .having((e) => e.message, 'message', 'Connection refused'),
+        ),
+      );
+    });
+
+    test('skips optional fields without throwing', () async {
+      final result = await _api(
+        body:
+            '{"status":"Success","message":"ok","data":['
+            '{"code":"em","name":"Exchange monitor","platform":"Exchange Monitor",'
+            '"value":803.58,"change":0,"createDate":null,"updateDate":null,"platform_img":""}]}',
+      ).getCurrentDollar();
+
+      expect(result.first.keyName, 'em');
+      expect(result.first.createDate, isNull);
+      expect(result.first.updateDate, isNull);
+      expect(result.first.tendency, 0.0);
+      // An empty logo must become null so the UI falls back to the initials.
+      expect(result.first.imgUrl, isNull);
+    });
+  });
+
+  group('getCurrentBCVDollar()', () {
+    test('maps date and currencies', () async {
+      final result = await _api(
+        body:
+            '{"status":"Success","message":"ok","data":{"date":"2026-07-23T00:00:00-04:00",'
+            '"currencies":[{"code":"USD","name":"Dolar","platform":"Banco Central de Venezuela",'
+            '"value":737.88,"change":33.08,"createDate":"2026-01-29T18:38:47.617316",'
+            '"updateDate":"2026-07-23T03:46:17.336191","platform_img":"https://logo.test/bcv.png"}]}}',
+      ).getCurrentBCVDollar();
+
+      expect(result.date, '2026-07-23T00:00:00-04:00');
+      expect(result.currencies, hasLength(1));
+    });
+
+    test('accepts a null date and missing currencies', () async {
+      final result = await _api(
+        body: '{"status":"Success","message":"ok","data":{"date":null}}',
+      ).getCurrentBCVDollar();
+
+      expect(result.date, isNull);
+      expect(result.currencies, isEmpty);
+    });
+  });
+}

--- a/test/shared/data/dollar_api_rest_test.dart
+++ b/test/shared/data/dollar_api_rest_test.dart
@@ -59,7 +59,28 @@ void main() {
       expect(result.first.value, 737.8816);
       expect(result.first.tendency, 33.08);
       expect(result.first.imgUrl, 'https://logo.test/bcv.png');
-      expect(result.first.updateDate, isNotNull);
+      // Stored timestamps arrive with no offset and mean UTC; the model hands
+      // them over already converted to the device zone.
+      expect(
+        result.first.updateDate!.toUtc(),
+        DateTime.utc(2026, 7, 23, 3, 46, 17, 336, 191),
+      );
+      expect(result.first.updateDate!.isUtc, isFalse);
+    });
+
+    test('honours the offset of a live rate', () async {
+      final result = await _api(
+        body:
+            '{"status":"Success","message":"ok","data":['
+            '{"code":"USDT","name":"Tether-buy","platform":"Binance","value":860.6,'
+            '"change":0.1,"createDate":"2026-07-26T21:18:42.522524-04:00",'
+            '"updateDate":"2026-07-26T21:18:42.522529-04:00","platform_img":""}]}',
+      ).getCurrentDollar();
+
+      expect(
+        result.first.updateDate!.toUtc(),
+        DateTime.utc(2026, 7, 27, 1, 18, 42, 522, 529),
+      );
     });
 
     test('keeps the backend message on an error status', () async {


### PR DESCRIPTION
The backend moved its business endpoints under `/api/v1` in v2.0.0 and grew from three to nine markets in v2.1.0. The app was still calling the old route, so both of its requests answered **404** — and nothing said so on screen.

## What was broken

| | Before | After |
|---|---|---|
| `…/api/venezuela/bcv/with-memory` | **404** (and a 308 first, from a `//api` built by the trailing slash in `CURRENCY_BACK`) | **200**, 0 redirects |
| Rates reaching the average tab | 21, including six markets the UI never knew | 7 |
| A failed refresh | a line in the console, skeleton placeholders forever | error banner with the backend message and a retry |

## Changes

**Routing** — the path is built as `/api/{version}/{country}` and the query with `Uri`; `CURRENCY_BACK` is stripped of trailing slashes.

**Markets** — the request asks for live data only from Yadio, Binance and Bybit and reads the rest from the database: `fill_missing` returns every market either way, and the backend gathers live sources without `return_exceptions`, so each one is a failure point. `CurrencyNormalizer` then keeps the allowed platforms, drops repeated database rows, merges the `-buy`/`-sell` sides into one averaged rate and sorts by market.

**Errors and parsing** — `ApiException` keeps the message of the backend error envelope and the repository exposes it, so a broken contract is visible instead of silent. Every optional field of the contract is parsed defensively; `parseDate` no longer throws on the empty BCV date, which was a real crash on the BCV tab before the first refresh landed.

**Timestamps** — two shapes travel in the same fields: rates from the database carry no offset and mean UTC, rates fetched live carry `-04:00`. `DateTime.parse` read the first as device local time, so stored rates showed hours off outside UTC. `BackendDate` resolves both to an instant in the device zone. The BCV effective date is deliberately **not** converted: it names a day for Venezuela, and shifting it showed the previous day west of Caracas.

**Presentation** — the Exchange Monitor codes (`em`, `average`, `md`) map to the dollar for symbols and pairs, rate names are translated, and the parallel-market average covers every dollar-equivalent quote while excluding the official BCV rate. It also returned `NaN` when nothing matched.

## Verification

`flutter analyze` reports only the nine warnings that predate the branch. The suite passes in `America/Caracas`, `Europe/Madrid`, `Asia/Tokyo`, `America/Los_Angeles` and `UTC` — the date assertions compare instants, so they do not depend on the machine.

Checked live against production for both endpoints, the happy path and a wrong route.

Not verified: the app was never run on a device, so the error banner and the cards have no visual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)