### PR TITLE
Adopt the per-market Body of backend v3.0.0 and let the user pick markets

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -67,7 +67,7 @@ workflows:
     publishing:
       email:
         recipients:
-          - jtexeira@estei.app
+          - javiertxr@gmail.com
         notify:
           success: true
           failure: true
@@ -157,7 +157,7 @@ workflows:
     publishing:
       email:
         recipients:
-          - jtexeira@estei.app
+          - javiertxr@gmail.com
         notify:
           success: true
           failure: true
@@ -258,7 +258,7 @@ workflows:
     publishing:
       email:
         recipients:
-          - jtexeira@estei.app
+          - javiertxr@gmail.com
         notify:
           success: true
           failure: true

--- a/lib/config/bindings/initial_bindings.dart
+++ b/lib/config/bindings/initial_bindings.dart
@@ -30,7 +30,14 @@ class InitialBinding extends Bindings {
     Get.lazyPut<SettingsController>(() => SettingsController(), fenix: true);
 
     // New Injections
-    Get.put<CurrencyRepository>(CurrencyRepository(), permanent: true);
+    final SettingsController settings = Get.find<SettingsController>();
+    final CurrencyRepository currencies = Get.put<CurrencyRepository>(
+      CurrencyRepository(selection: () => settings.marketSelection),
+      permanent: true,
+    );
+    // Following or dropping a market changes the request itself, so the rates
+    // are fetched again as soon as the choice changes.
+    ever(settings.selectedMarketKeys, (_) => currencies.refreshData());
     Get.lazyPut<HomeController>(() => HomeController(), fenix: true);
     Get.lazyPut<ConverterController>(() => ConverterController(), fenix: true);
   }

--- a/lib/core/constants/market_constants.dart
+++ b/lib/core/constants/market_constants.dart
@@ -1,11 +1,40 @@
-/// Markets served by the backend, named exactly as it reports them.
+import '../../shared/domain/entities/market.dart';
+
+/// Catalogue of the markets the app can request, and the modes it uses.
 ///
-/// The values mirror `Constants.*_NAME` of `bcv_tracker_backend`, which is what
-/// travels in the `platform` field of every rate.
+/// Mirrors `MarketName` / `MarketMode` of the backend
+/// (`api/models/market_request.py`). Each market type accepts only some modes,
+/// and asking for one it does not allow answers `422`:
+///
+/// - BCV, Yadio, Airtm, DolarAPI → `off`, `solo-dolar`, `todas`,
+///   `bd-solo-dolar`, `bd-todas`
+/// - Binance, Bybit, OKX, Bitget → `off`, `average`, `ambas`, `bd-todas`
+/// - Exchange Monitor → `off`, `own`, `own+monitor`, `bd-todas`
 class Markets {
   const Markets._();
 
+  // --- Modes of the state machine -------------------------------------------
+  static const String modeOff = 'off';
+  static const String modeLiveDollar = 'solo-dolar';
+  static const String modeLiveAll = 'todas';
+  static const String modeDbDollar = 'bd-solo-dolar';
+  static const String modeDbAll = 'bd-todas';
+
+  /// Crypto only: one averaged rate per asset, `(buy + sell) / 2`.
+  static const String modeAverage = 'average';
+
+  /// Crypto only: both sides of every asset.
+  static const String modeBoth = 'ambas';
+
+  /// Exchange Monitor only: its own value.
+  static const String modeEmOwn = 'own';
+
+  /// Exchange Monitor only: its own value plus its estimated average.
+  static const String modeEmOwnMonitor = 'own+monitor';
+
+  // --- Platform names, as they travel in the `platform` field ---------------
   static const String bcv = 'Banco Central de Venezuela';
+  static const String exchangeMonitor = 'Exchange Monitor';
   static const String yadio = 'Yadio.io';
   static const String binance = 'Binance';
   static const String bybit = 'Bybit';
@@ -13,20 +42,62 @@ class Markets {
   static const String bitget = 'Bitget';
   static const String airtm = 'Airtm';
   static const String dolarApi = 'DolarAPI';
-  static const String exchangeMonitor = 'Exchange Monitor';
 
-  /// Markets rendered in the average tab, in display order.
+  // --- Keys of the Body -----------------------------------------------------
+  static const String bcvKey = 'bcv';
+  static const String exchangeMonitorKey = 'exchange_monitor';
+  static const String yadioKey = 'yadio';
+  static const String binanceKey = 'binance';
+  static const String bybitKey = 'bybit';
+  static const String okxKey = 'okx';
+  static const String bitgetKey = 'bitget';
+  static const String airtmKey = 'airtm';
+  static const String dolarApiKey = 'dolarapi';
+
+  /// Every market the app can request, in display order.
   ///
-  /// `saved-currencies` answers with every market it knows once `fill_missing`
-  /// is on (nine of them today), so this list is what decides which ones reach
-  /// the UI — and in which order, since the backend orders by database id.
-  static const List<String> averageTab = <String>[
-    bcv,
-    exchangeMonitor,
-    yadio,
-    binance,
-    bybit,
+  /// The mode of each one is the cheapest that still answers what the UI shows:
+  /// the BCV from the database, since the backend cron refreshes it once a day
+  /// at midnight Venezuela time, and the rest live so their rate and its ROC
+  /// are current. Crypto markets use `average` because reading them from the
+  /// database would collapse buy and sell — the backend keys its rows by
+  /// `(code, platform)`, so only the last side written survives.
+  static const List<Market> catalog = <Market>[
+    Market(key: bcvKey, platform: bcv, mode: modeDbDollar),
+    // No mode returns only the estimated average, so this brings its own value
+    // too and [emAverageCode] keeps just "Monitor Dólar".
+    Market(
+      key: exchangeMonitorKey,
+      platform: exchangeMonitor,
+      mode: modeEmOwnMonitor,
+    ),
+    Market(key: yadioKey, platform: yadio, mode: modeLiveDollar),
+    Market(key: binanceKey, platform: binance, mode: modeAverage),
+    Market(key: bybitKey, platform: bybit, mode: modeAverage),
+    Market(key: okxKey, platform: okx, mode: modeAverage),
+    Market(key: bitgetKey, platform: bitget, mode: modeAverage),
+    Market(key: airtmKey, platform: airtm, mode: modeLiveDollar),
+    Market(key: dolarApiKey, platform: dolarApi, mode: modeLiveDollar),
   ];
+
+  /// Markets selected out of the box: the reference rates of the parallel
+  /// market plus the official one. The rest are opt-in from the settings.
+  static const Set<String> defaultKeys = <String>{
+    bcvKey,
+    exchangeMonitorKey,
+    yadioKey,
+    binanceKey,
+    bybitKey,
+  };
+
+  static MarketSelection get defaultSelection => selectionOf(defaultKeys);
+
+  /// Selection with the catalogue markets whose key is in [keys], keeping the
+  /// catalogue order. Unknown keys are ignored, so a preference saved by an
+  /// older version cannot break the request.
+  static MarketSelection selectionOf(Set<String> keys) => MarketSelection(
+    catalog.where((market) => keys.contains(market.key)).toList(),
+  );
 
   /// Exchange Monitor publishes its own value, an estimated average
   /// ("Monitor Dólar") and, live, one entry per bank.
@@ -37,8 +108,8 @@ class Markets {
   /// Codes that quote a dollar-equivalent against VES.
   ///
   /// Used to average the parallel market: the crypto markets quote USDT/USDC
-  /// and Exchange Monitor uses its own codes, so filtering by `USD` alone —
-  /// as the average card used to do — silently dropped most of them.
+  /// and Exchange Monitor uses its own codes, so filtering by `USD` alone
+  /// silently dropped most of them.
   static const Set<String> dollarEquivalentCodes = <String>{
     'USD',
     'USDT',

--- a/lib/core/constants/market_constants.dart
+++ b/lib/core/constants/market_constants.dart
@@ -63,15 +63,21 @@ class Markets {
   /// database would collapse buy and sell — the backend keys its rows by
   /// `(code, platform)`, so only the last side written survives.
   static const List<Market> catalog = <Market>[
-    Market(key: bcvKey, platform: bcv, mode: modeDbDollar),
+    Market(key: bcvKey, platform: bcv, mode: modeDbDollar, shortName: 'BCV'),
     // No mode returns only the estimated average, so this brings its own value
     // too and [emAverageCode] keeps just "Monitor Dólar".
     Market(
       key: exchangeMonitorKey,
       platform: exchangeMonitor,
       mode: modeEmOwnMonitor,
+      shortName: 'Monitor',
     ),
-    Market(key: yadioKey, platform: yadio, mode: modeLiveDollar),
+    Market(
+      key: yadioKey,
+      platform: yadio,
+      mode: modeLiveDollar,
+      shortName: 'Yadio',
+    ),
     Market(key: binanceKey, platform: binance, mode: modeAverage),
     Market(key: bybitKey, platform: bybit, mode: modeAverage),
     Market(key: okxKey, platform: okx, mode: modeAverage),

--- a/lib/core/i18n/app_messages.dart
+++ b/lib/core/i18n/app_messages.dart
@@ -91,6 +91,8 @@ class AppMessages {
 
   static String get sundayDay => 'sundayDay'.tr;
 
+  static String get followedMarkets => 'followedMarkets'.tr;
+
   static String get marketAverage => 'marketAverage'.tr;
 
   static String get loadingError => 'loadingError'.tr;

--- a/lib/core/i18n/languages/de_de.dart
+++ b/lib/core/i18n/languages/de_de.dart
@@ -47,4 +47,5 @@ const Map<String, String> deDe = {
   'loadingError': 'Die Kurse konnten nicht geladen werden',
   'retryAction': 'Wiederholen',
   'marketAverage': 'Durchschnitt',
+  'followedMarkets': 'Verfolgte Märkte',
 };

--- a/lib/core/i18n/languages/en_us.dart
+++ b/lib/core/i18n/languages/en_us.dart
@@ -47,4 +47,5 @@ const Map<String, String> enUs = {
   'loadingError': 'Rates could not be loaded',
   'retryAction': 'Retry',
   'marketAverage': 'Average',
+  'followedMarkets': 'Followed markets',
 };

--- a/lib/core/i18n/languages/es_es.dart
+++ b/lib/core/i18n/languages/es_es.dart
@@ -47,4 +47,5 @@ const Map<String, String> esEs = {
   'loadingError': 'No se pudieron cargar las tasas',
   'retryAction': 'Reintentar',
   'marketAverage': 'Promedio',
+  'followedMarkets': 'Mercados seguidos',
 };

--- a/lib/core/i18n/languages/fr_fr.dart
+++ b/lib/core/i18n/languages/fr_fr.dart
@@ -47,4 +47,5 @@ const Map<String, String> frFr = {
   'loadingError': 'Impossible de charger les taux',
   'retryAction': 'Réessayer',
   'marketAverage': 'Moyenne',
+  'followedMarkets': 'Marchés suivis',
 };

--- a/lib/core/i18n/languages/it_it.dart
+++ b/lib/core/i18n/languages/it_it.dart
@@ -47,4 +47,5 @@ const Map<String, String> itIt = {
   'loadingError': 'Impossibile caricare i tassi',
   'retryAction': 'Riprova',
   'marketAverage': 'Media',
+  'followedMarkets': 'Mercati seguiti',
 };

--- a/lib/core/i18n/languages/ja_jp.dart
+++ b/lib/core/i18n/languages/ja_jp.dart
@@ -1,4 +1,3 @@
-
 const Map<String, String> jaJp = {
   "homeView": "ホーム",
   "converterView": "コンバーター",
@@ -48,4 +47,5 @@ const Map<String, String> jaJp = {
   'loadingError': 'レートを読み込めませんでした',
   'retryAction': '再試行',
   'marketAverage': '平均',
+  'followedMarkets': '追跡する市場',
 };

--- a/lib/core/i18n/languages/ko_kr.dart
+++ b/lib/core/i18n/languages/ko_kr.dart
@@ -47,4 +47,5 @@ const Map<String, String> koKr = {
   'loadingError': '환율을 불러올 수 없습니다',
   'retryAction': '다시 시도',
   'marketAverage': '평균',
+  'followedMarkets': '추적 시장',
 };

--- a/lib/core/i18n/languages/pt_pt.dart
+++ b/lib/core/i18n/languages/pt_pt.dart
@@ -1,4 +1,3 @@
-
 const Map<String, String> ptPt = {
   "homeView": "Início",
   "converterView": "Converter",
@@ -48,4 +47,5 @@ const Map<String, String> ptPt = {
   'loadingError': 'Não foi possível carregar as taxas',
   'retryAction': 'Tentar novamente',
   'marketAverage': 'Média',
+  'followedMarkets': 'Mercados seguidos',
 };

--- a/lib/core/i18n/languages/ru_ru.dart
+++ b/lib/core/i18n/languages/ru_ru.dart
@@ -47,4 +47,5 @@ const Map<String, String> ruRu = {
   'loadingError': 'Не удалось загрузить курсы',
   'retryAction': 'Повторить',
   'marketAverage': 'Среднее',
+  'followedMarkets': 'Отслеживаемые рынки',
 };

--- a/lib/core/i18n/languages/zh_cn.dart
+++ b/lib/core/i18n/languages/zh_cn.dart
@@ -47,4 +47,5 @@ const Map<String, String> zhCn = {
   'loadingError': '无法加载汇率',
   'retryAction': '重试',
   'marketAverage': '平均值',
+  'followedMarkets': '关注的市场',
 };

--- a/lib/core/network/api_exception.dart
+++ b/lib/core/network/api_exception.dart
@@ -34,9 +34,8 @@ class ApiException implements Exception {
     if (body is! String || body.isEmpty) return null;
     try {
       final decoded = json.decode(body);
-      if (decoded is Map && decoded['message'] is String) {
-        final message = (decoded['message'] as String).trim();
-        return message.isEmpty ? null : message;
+      if (decoded is Map) {
+        return _text(decoded['message']) ?? _detail(decoded['detail']);
       }
     } catch (_) {
       // Not JSON (e.g. an HTML error page from the edge): fall back to the code.
@@ -44,7 +43,30 @@ class ApiException implements Exception {
     return null;
   }
 
+  /// Reads the `detail` FastAPI answers with when the Body fails validation.
+  ///
+  /// That response is built by FastAPI itself, so it never reaches the error
+  /// envelope of the backend and carries no `message`. Since v3.0.0 it is how a
+  /// mode that a market does not allow arrives, and without this the user only
+  /// saw "HTTP 422".
+  static String? _detail(Object? detail) {
+    if (detail is String) return _text(detail);
+    if (detail is List) {
+      final messages = detail
+          .whereType<Map>()
+          .map((entry) => _text(entry['msg']))
+          .whereType<String>();
+      if (messages.isNotEmpty) return messages.join(' · ');
+    }
+    return null;
+  }
+
+  static String? _text(Object? value) {
+    if (value is! String) return null;
+    final text = value.trim();
+    return text.isEmpty ? null : text;
+  }
+
   @override
-  String toString() =>
-      'ApiException(${statusCode ?? 'no response'}): $message';
+  String toString() => 'ApiException(${statusCode ?? 'no response'}): $message';
 }

--- a/lib/features/settings/presentation/page/settings_modal.dart
+++ b/lib/features/settings/presentation/page/settings_modal.dart
@@ -3,8 +3,10 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 import '../../../../config/theme/colors/colors_values.dart';
+import '../../../../core/constants/market_constants.dart';
 import '../../../../core/i18n/app_messages.dart';
 import '../../../../shared/domain/entities/language.dart';
+import '../../../../shared/domain/entities/market.dart';
 import '../../../../shared/presentation/controller/settings_controller.dart';
 import '../../../../shared/presentation/widgets/base_modal.dart';
 

--- a/lib/features/settings/presentation/widgets/settings_body.dart
+++ b/lib/features/settings/presentation/widgets/settings_body.dart
@@ -13,6 +13,8 @@ class _SettingsBody extends StatelessWidget {
       children: [
         _SettingsSectionTitle(title: AppMessages.defaultMarket),
         const _MarketSelector(),
+        _SettingsSectionTitle(title: AppMessages.followedMarkets),
+        const _FollowedMarketsSelector(),
         _SettingsSectionTitle(title: AppMessages.language),
         const _LanguageSelector(),
         _SettingsSectionTitle(title: AppMessages.theme),
@@ -21,4 +23,3 @@ class _SettingsBody extends StatelessWidget {
     );
   }
 }
-

--- a/lib/features/settings/presentation/widgets/settings_buttons.dart
+++ b/lib/features/settings/presentation/widgets/settings_buttons.dart
@@ -32,6 +32,54 @@ class _MarketDefaultButton extends StatelessWidget {
   );
 }
 
+/// Chip that follows or drops a market. Sized to its label, unlike
+/// [_MarketDefaultButton], because the catalogue holds nine of them.
+class _MarketToggleButton extends StatelessWidget {
+  const _MarketToggleButton({
+    required this.label,
+    required this.onTap,
+    required this.isSelected,
+  });
+
+  final String label;
+  final VoidCallback onTap;
+  final bool isSelected;
+
+  @override
+  Widget build(BuildContext context) => CustomBadgedButton(
+    onTap: onTap,
+    borderRadius: 8,
+    color: isSelected
+        ? ColorValues.utilityInfo(context)
+        : ColorValues.utilityGrey500(context),
+    child: Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            isSelected ? Icons.check_circle : Icons.add_circle_outline,
+            size: 16,
+            color: isSelected
+                ? ColorValues.textBrandTertiary(context)
+                : ColorValues.utilityGrey500(context),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: TextStyle(
+              color: isSelected
+                  ? ColorValues.textBrandTertiary(context)
+                  : ColorValues.utilityGrey500(context),
+              fontSize: 15,
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
 class _ThemeButton extends StatelessWidget {
   final String label;
   final VoidCallback onTap;

--- a/lib/features/settings/presentation/widgets/settings_widgets.dart
+++ b/lib/features/settings/presentation/widgets/settings_widgets.dart
@@ -36,6 +36,35 @@ class _MarketSelector extends StatelessWidget {
   );
 }
 
+/// Markets the average tab follows.
+///
+/// Since backend v3.0.0 the request declares a mode per market and leaves the
+/// rest `off`, so following one more market is one more entry in the Body.
+class _FollowedMarketsSelector extends StatelessWidget {
+  const _FollowedMarketsSelector();
+
+  @override
+  Widget build(BuildContext context) => GetBuilder<SettingsController>(
+    builder: (SettingsController controller) => Obx(
+      () => Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        children: [
+          for (final Market market in Markets.catalog)
+            _MarketToggleButton(
+              label: market.shortName,
+              isSelected: controller.isMarketSelected(market.key),
+              onTap: () => controller.setMarketSelected(
+                market.key,
+                !controller.isMarketSelected(market.key),
+              ),
+            ),
+        ],
+      ),
+    ),
+  );
+}
+
 class _ThemeSelector extends StatelessWidget {
   const _ThemeSelector();
 

--- a/lib/shared/data/datasource/dollar_api/dollar_api.dart
+++ b/lib/shared/data/datasource/dollar_api/dollar_api.dart
@@ -1,9 +1,9 @@
-
+import '../../../domain/entities/market.dart';
 import '../../model/model.dart';
 
 abstract class IDollarApi {
-
   Future<BcvCurrenciesModel> getCurrentBCVDollar();
 
-  Future<List<CurrencyModel>> getCurrentDollar();
+  /// Rates of the markets in [selection], each one in the mode it declares.
+  Future<List<CurrencyModel>> getCurrentDollar(MarketSelection selection);
 }

--- a/lib/shared/data/datasource/dollar_api/dollar_api_rest.dart
+++ b/lib/shared/data/datasource/dollar_api/dollar_api_rest.dart
@@ -5,14 +5,14 @@ import 'package:dio/dio.dart';
 
 import '../../../../core/network/api_exception.dart';
 import '../../../../core/network/http_manager.dart';
+import '../../../../core/network/http_operation.dart';
+import '../../../domain/entities/market.dart';
 import '../../model/model.dart';
 
 class DollarApiRest implements IDollarApi {
-  DollarApiRest({
-    required String apiUrl,
-    HttpManager? client,
-  }) : _apiUrl = apiUrl,
-       _client = client ?? HttpManager();
+  DollarApiRest({required String apiUrl, HttpManager? client})
+    : _apiUrl = apiUrl,
+      _client = client ?? HttpManager();
 
   final String _apiUrl;
   final HttpManager _client;
@@ -37,8 +37,17 @@ class DollarApiRest implements IDollarApi {
   }
 
   @override
-  Future<List<CurrencyModel>> getCurrentDollar() async {
-    final data = await _getData(DollarEndpoints.currentDollar);
+  Future<List<CurrencyModel>> getCurrentDollar(
+    MarketSelection selection,
+  ) async {
+    // POST since backend v3.0.0: the markets and their modes travel in the
+    // Body. A market left out of it is `off`, so the request already asks for
+    // exactly what the UI renders.
+    final data = await _getData(
+      DollarEndpoints.currentDollar,
+      method: HttpOperation.post,
+      body: selection.toJson(),
+    );
 
     if (data is! List) {
       throw const ApiException.malformed(
@@ -61,34 +70,46 @@ class DollarApiRest implements IDollarApi {
   /// Performs the request and returns the `data` field of the backend envelope
   /// (`{status, message, data}`), translating every failure into an
   /// [ApiException] that carries the backend message.
-  Future<Object?> _getData(String endpoint) async {
+  Future<Object?> _getData(
+    String endpoint, {
+    HttpOperation method = HttpOperation.get,
+    Map<String, dynamic>? body,
+  }) async {
     final Response response;
     try {
-      response = await _client.request(endpoint: _apiUrl + endpoint);
+      response = await _client.request(
+        endpoint: _apiUrl + endpoint,
+        method: method,
+        body: body,
+      );
     } on DioException catch (e) {
       // HttpManager accepts every status code, so Dio only throws when there is
       // no response at all (connectivity, DNS, timeout).
       throw ApiException.network(e.message ?? e.type.name);
     }
 
-    final body = response.data;
+    final payload = response.data;
 
     if (response.statusCode != 200 && response.statusCode != 201) {
       throw ApiException.fromResponse(
         statusCode: response.statusCode,
-        body: body,
+        body: payload,
       );
     }
 
-    if (body is! String || body.isEmpty) {
-      throw const ApiException.malformed('El backend respondió con un cuerpo vacío.');
+    if (payload is! String || payload.isEmpty) {
+      throw const ApiException.malformed(
+        'El backend respondió con un cuerpo vacío.',
+      );
     }
 
     final Object? envelope;
     try {
-      envelope = json.decode(body);
+      envelope = json.decode(payload);
     } catch (e) {
-      throw ApiException.malformed('El backend respondió con un cuerpo no JSON: $e');
+      throw ApiException.malformed(
+        'El backend respondió con un cuerpo no JSON: $e',
+      );
     }
 
     if (envelope is! Map<String, dynamic> || !envelope.containsKey('data')) {

--- a/lib/shared/data/datasource/dollar_api/dollar_endpoints.dart
+++ b/lib/shared/data/datasource/dollar_api/dollar_endpoints.dart
@@ -12,48 +12,10 @@ class DollarEndpoints {
 
   static const String _apiEndpoints = '/api/$_apiVersion/$_country';
 
-  /// Sources and filters for `saved-currencies`.
-  ///
-  /// `fill_missing` fetches live every market left at `false`, and there is no
-  /// way to leave a market out: one at `true` is read from the database and one
-  /// at `false` is scraped live, but both come back. So this map does not pick
-  /// *which* markets arrive — [Markets.averageTab] does that on the client —
-  /// it picks **where each one comes from**:
-  ///
-  /// - live (`false`) only the three the app shows as fresh rates. Each live
-  ///   source adds latency and is a failure point: the backend gathers them
-  ///   without `return_exceptions`, so one source answering 502 fails the whole
-  ///   request.
-  /// - from the database (`true`) the rest, which is cheap, plus BCV and
-  ///   Exchange Monitor, refreshed by the backend cron six times a day.
-  ///
-  /// Once the per-market Body (#71) is deployed this whole dance is replaced by
-  /// `off` for the markets we do not want and `average` for the crypto ones.
-  static const Map<String, String> _currentDollarParams = {
-    // Live.
-    'yadio': 'false',
-    'binance': 'false',
-    'bybit': 'false',
-    // From the database.
-    'bcv': 'true',
-    'exchange_monitor': 'true',
-    'okx': 'true',
-    'bitget': 'true',
-    'airtm': 'true',
-    'dolarapi': 'true',
-    'fill_missing': 'true',
-    // Only the official dollar out of the BCV, only the dollar out of Yadio
-    // (it also publishes euro and bitcoin) and only the estimated average of
-    // Exchange Monitor ("Monitor Dólar").
-    'enforce_bcv_dollar': 'true',
-    'enforce_yadio_dollar': 'true',
-    'enforce_em_average': 'true',
-  };
-
-  static final String currentDollar = Uri(
-    path: '$_apiEndpoints/saved-currencies',
-    queryParameters: _currentDollarParams,
-  ).toString();
+  /// Rates of the selected markets. **POST since backend v3.0.0**: it takes a
+  /// per-market Body (`MarketSelection`) instead of the old query flags, so the
+  /// request carries no query string — see `MarketSelection.toJson()`.
+  static const String currentDollar = '$_apiEndpoints/saved-currencies';
 
   static const String currentBCVDollar = '$_apiEndpoints/bcv/with-memory';
 }

--- a/lib/shared/data/mapper/currency_normalizer.dart
+++ b/lib/shared/data/mapper/currency_normalizer.dart
@@ -1,29 +1,38 @@
-import '../../../core/constants/market_constants.dart';
 import '../../domain/entities/currency.dart';
+import '../../domain/entities/market.dart';
 
 /// Turns the raw `saved-currencies` payload into the list the UI can render.
 ///
-/// The endpoint returns every market it knows (nine today) with one row per
-/// P2P side, and its database keeps rates keyed by `(code, platform)` — which
-/// makes repeated rows for the same pair possible. This collapses all of that:
+/// The Body already asks for the requested markets only, so this closes the
+/// gaps the contract leaves open:
 ///
-/// 1. keeps only the markets in [Markets.averageTab];
+/// 1. keeps only the platforms of [MarketSelection], as a guard against a
+///    market answering with a platform that was not requested;
 /// 2. drops repeated `(platform, code, name)` rows, keeping the first one —
-///    the backend orders by descending id, so that is the most recent;
-/// 3. merges the `-buy` / `-sell` sides of a pair into a single averaged rate;
-/// 4. sorts by market, so the order does not depend on database ids.
+///    reads from the database come ordered by descending id, so that is the
+///    most recent;
+/// 3. merges the `-buy` / `-sell` sides of a pair into a single averaged rate,
+///    which is what Airtm returns and what any market in `ambas` would;
+/// 4. sorts by the order of the selection, so it does not depend on the order
+///    the backend concatenates database reads and live fetches in.
 class CurrencyNormalizer {
   const CurrencyNormalizer._();
 
   static const String _buySuffix = '-buy';
   static const String _sellSuffix = '-sell';
 
-  static List<Currency> forAverageTab(List<Currency> currencies) {
+  static List<Currency> forAverageTab(
+    List<Currency> currencies,
+    MarketSelection selection,
+  ) {
+    final platforms = selection.platforms;
+    final order = [for (final market in selection.markets) market.platform];
+
     final allowed = currencies.where(
-      (currency) => Markets.averageTab.contains(currency.platform),
+      (currency) => platforms.contains(currency.platform),
     );
     final merged = _mergeSides(_dedupe(allowed));
-    merged.sort(_byMarketThenCode);
+    merged.sort((a, b) => _byMarketThenCode(a, b, order));
     return merged;
   }
 
@@ -97,10 +106,10 @@ class CurrencyNormalizer {
       .whereType<DateTime>()
       .fold<DateTime?>(null, (a, b) => a == null || b.isAfter(a) ? b : a);
 
-  static int _byMarketThenCode(Currency a, Currency b) {
-    final byMarket = Markets.averageTab
+  static int _byMarketThenCode(Currency a, Currency b, List<String> order) {
+    final byMarket = order
         .indexOf(a.platform)
-        .compareTo(Markets.averageTab.indexOf(b.platform));
+        .compareTo(order.indexOf(b.platform));
     if (byMarket != 0) return byMarket;
     final byCode = a.keyName.compareTo(b.keyName);
     return byCode != 0 ? byCode : a.name.compareTo(b.name);

--- a/lib/shared/data/mapper/currency_normalizer.dart
+++ b/lib/shared/data/mapper/currency_normalizer.dart
@@ -1,3 +1,4 @@
+import '../../../core/constants/market_constants.dart';
 import '../../domain/entities/currency.dart';
 import '../../domain/entities/market.dart';
 
@@ -8,13 +9,20 @@ import '../../domain/entities/market.dart';
 ///
 /// 1. keeps only the platforms of [MarketSelection], as a guard against a
 ///    market answering with a platform that was not requested;
-/// 2. drops repeated `(platform, code, name)` rows, keeping the first one —
+/// 2. keeps a single Exchange Monitor rate — the one filter the Body cannot
+///    express, see [_withoutRedundantExchangeMonitor];
+/// 3. drops repeated `(platform, code, name)` rows, keeping the first one —
 ///    reads from the database come ordered by descending id, so that is the
 ///    most recent;
-/// 3. merges the `-buy` / `-sell` sides of a pair into a single averaged rate,
+/// 4. merges the `-buy` / `-sell` sides of a pair into a single averaged rate,
 ///    which is what Airtm returns and what any market in `ambas` would;
-/// 4. sorts by the order of the selection, so it does not depend on the order
+/// 5. sorts by the order of the selection, so it does not depend on the order
 ///    the backend concatenates database reads and live fetches in.
+///
+/// Steps 3 and 4 are guards for most markets: with the modes the catalogue
+/// uses, the backend already returns the latest row per `(code, platform)` and
+/// crypto arrives averaged. They still do real work for Airtm, and they cover
+/// any market switched to `ambas` or `bd-todas`.
 class CurrencyNormalizer {
   const CurrencyNormalizer._();
 
@@ -31,9 +39,34 @@ class CurrencyNormalizer {
     final allowed = currencies.where(
       (currency) => platforms.contains(currency.platform),
     );
-    final merged = _mergeSides(_dedupe(allowed));
+    final merged = _mergeSides(
+      _dedupe(_withoutRedundantExchangeMonitor(allowed)),
+    );
     merged.sort((a, b) => _byMarketThenCode(a, b, order));
     return merged;
+  }
+
+  /// Keeps only the estimated average of Exchange Monitor, when it is there.
+  ///
+  /// No mode returns just that rate: `own+monitor` and `bd-todas` bring its own
+  /// value (`em`) alongside the average (`average`), and the old contract
+  /// trimmed it server side with `enforce_em_average`. The other rows are only
+  /// dropped if the average is present, so a market asked in `own` still shows.
+  static Iterable<Currency> _withoutRedundantExchangeMonitor(
+    Iterable<Currency> currencies,
+  ) {
+    final hasAverage = currencies.any(
+      (currency) =>
+          currency.platform == Markets.exchangeMonitor &&
+          currency.keyName == Markets.emAverageCode,
+    );
+    if (!hasAverage) return currencies;
+
+    return currencies.where(
+      (currency) =>
+          currency.platform != Markets.exchangeMonitor ||
+          currency.keyName == Markets.emAverageCode,
+    );
   }
 
   /// Removes exact repeats of `(platform, code, name)`, keeping the first.

--- a/lib/shared/data/repositories/currency_repository.dart
+++ b/lib/shared/data/repositories/currency_repository.dart
@@ -8,6 +8,16 @@ import '../../domain/repositories/dollar_repositories.dart';
 import '../mapper/currency_normalizer.dart';
 
 class CurrencyRepository extends GetxService {
+  /// [selection] resolves which markets to ask for on every refresh. The
+  /// binding wires it to the user's choice; without it the catalogue default
+  /// is used, which keeps the service usable on its own.
+  CurrencyRepository({MarketSelection Function()? selection})
+    : _selection = selection ?? _defaultSelection;
+
+  static MarketSelection _defaultSelection() => Markets.defaultSelection;
+
+  final MarketSelection Function() _selection;
+
   final IDollarRepository _dollarRepository = Get.find<IDollarRepository>();
 
   final RxList<Currency> averageCurrencies = List.generate(
@@ -60,7 +70,7 @@ class CurrencyRepository extends GetxService {
   }
 
   Future<void> getAveragedCurrencies() async {
-    final MarketSelection selection = Markets.defaultSelection;
+    final MarketSelection selection = _selection();
     final List<Currency> result = await _dollarRepository.getCurrentDollar(
       selection,
     );

--- a/lib/shared/data/repositories/currency_repository.dart
+++ b/lib/shared/data/repositories/currency_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:developer';
 
 import 'package:get/get.dart';
+import '../../../core/constants/market_constants.dart';
 import '../../../core/network/api_exception.dart';
 import '../../domain/entities/entities.dart';
 import '../../domain/repositories/dollar_repositories.dart';
@@ -59,11 +60,13 @@ class CurrencyRepository extends GetxService {
   }
 
   Future<void> getAveragedCurrencies() async {
-    final List<Currency> result = await _dollarRepository.getCurrentDollar();
-    // saved-currencies answers with every market the backend knows, one row per
-    // P2P side and, from the database, occasional repeats; see
-    // [CurrencyNormalizer].
-    averageCurrencies.assignAll(CurrencyNormalizer.forAverageTab(result));
+    final MarketSelection selection = Markets.defaultSelection;
+    final List<Currency> result = await _dollarRepository.getCurrentDollar(
+      selection,
+    );
+    averageCurrencies.assignAll(
+      CurrencyNormalizer.forAverageTab(result, selection),
+    );
     hasAverageData.value = true;
   }
 

--- a/lib/shared/data/repositories/currency_repository.dart
+++ b/lib/shared/data/repositories/currency_repository.dart
@@ -64,6 +64,17 @@ class CurrencyRepository extends GetxService {
     final List<Currency> result = await _dollarRepository.getCurrentDollar(
       selection,
     );
+
+    if (result.isEmpty && !selection.isEmpty) {
+      // A Body the backend cannot read answers 200 with an empty list instead
+      // of failing, so an empty answer to a non-empty selection is worth a line
+      // in the log: from the UI it is indistinguishable from "no rates".
+      log(
+        'saved-currencies devolvió una lista vacía para ${selection.toJson()}',
+        name: "CurrencyRepository.getAveragedCurrencies()",
+      );
+    }
+
     averageCurrencies.assignAll(
       CurrencyNormalizer.forAverageTab(result, selection),
     );

--- a/lib/shared/data/repositories/dollar_repositories.dart
+++ b/lib/shared/data/repositories/dollar_repositories.dart
@@ -19,9 +19,9 @@ class DollarRepository implements IDollarRepository {
   }
 
   @override
-  Future<List<Currency>> getCurrentDollar() async {
+  Future<List<Currency>> getCurrentDollar(MarketSelection selection) async {
     try {
-      final data = await _dollarApi.getCurrentDollar();
+      final data = await _dollarApi.getCurrentDollar(selection);
       return data.map((e) => e.toEntity()).toList();
     } catch (e) {
       rethrow;

--- a/lib/shared/domain/entities/entities.dart
+++ b/lib/shared/domain/entities/entities.dart
@@ -1,3 +1,4 @@
 export 'bcv_currencies.dart';
 export 'currency.dart';
 export 'language.dart';
+export 'market.dart';

--- a/lib/shared/domain/entities/market.dart
+++ b/lib/shared/domain/entities/market.dart
@@ -1,0 +1,40 @@
+/// A rate source of the backend and the mode the app asks it in.
+///
+/// Since v3.0.0 the backend selects sources with a per-market state machine
+/// instead of query flags: every market declares a `mode` and the ones left out
+/// of the request are `off`. See `api/models/market_request.py` in the backend.
+class Market {
+  const Market({required this.key, required this.platform, required this.mode});
+
+  /// Key inside the `markets` Body — the backend's `MarketName`.
+  final String key;
+
+  /// Value the market puts in the `platform` field of the rates it returns.
+  /// It is not the same string as [key], and it is also what the UI shows.
+  final String platform;
+
+  /// Mode requested for this market, out of the ones its type allows.
+  final String mode;
+
+  Market copyWith({String? mode}) =>
+      Market(key: key, platform: platform, mode: mode ?? this.mode);
+}
+
+/// The set of markets a request asks for, ready to travel as the Body.
+class MarketSelection {
+  const MarketSelection(this.markets);
+
+  /// Markets to request, in the order the UI renders them.
+  final List<Market> markets;
+
+  bool get isEmpty => markets.isEmpty;
+
+  /// Platforms the answer may contain, to keep anything else out of the UI.
+  Set<String> get platforms => {for (final market in markets) market.platform};
+
+  /// `{"markets": {"bcv": "bd-solo-dolar", …}}` — a market that is absent is
+  /// `off` for the backend, which is exactly what "not selected" means here.
+  Map<String, dynamic> toJson() => {
+    'markets': {for (final market in markets) market.key: market.mode},
+  };
+}

--- a/lib/shared/domain/entities/market.dart
+++ b/lib/shared/domain/entities/market.dart
@@ -4,7 +4,12 @@
 /// instead of query flags: every market declares a `mode` and the ones left out
 /// of the request are `off`. See `api/models/market_request.py` in the backend.
 class Market {
-  const Market({required this.key, required this.platform, required this.mode});
+  const Market({
+    required this.key,
+    required this.platform,
+    required this.mode,
+    String? shortName,
+  }) : _shortName = shortName;
 
   /// Key inside the `markets` Body — the backend's `MarketName`.
   final String key;
@@ -13,11 +18,21 @@ class Market {
   /// It is not the same string as [key], and it is also what the UI shows.
   final String platform;
 
+  final String? _shortName;
+
+  /// Name for tight spots, where [platform] does not fit. Not translated:
+  /// every market is a brand or an institution.
+  String get shortName => _shortName ?? platform;
+
   /// Mode requested for this market, out of the ones its type allows.
   final String mode;
 
-  Market copyWith({String? mode}) =>
-      Market(key: key, platform: platform, mode: mode ?? this.mode);
+  Market copyWith({String? mode}) => Market(
+    key: key,
+    platform: platform,
+    mode: mode ?? this.mode,
+    shortName: _shortName,
+  );
 }
 
 /// The set of markets a request asks for, ready to travel as the Body.

--- a/lib/shared/domain/repositories/dollar_repositories.dart
+++ b/lib/shared/domain/repositories/dollar_repositories.dart
@@ -1,9 +1,8 @@
-
 import '../entities/entities.dart';
 
 abstract class IDollarRepository {
-
   Future<BcvCurrencies> getCurrentBCVDollar();
 
-  Future<List<Currency>> getCurrentDollar();
+  /// Rates of the markets in [selection], each one in the mode it declares.
+  Future<List<Currency>> getCurrentDollar(MarketSelection selection);
 }

--- a/lib/shared/presentation/controller/settings_controller.dart
+++ b/lib/shared/presentation/controller/settings_controller.dart
@@ -2,16 +2,25 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../../core/constants/market_constants.dart';
 import '../../domain/entities/language.dart';
+import '../../domain/entities/market.dart';
 
 class SettingsController extends GetxController {
   RxInt favMarketIndex = 0.obs;
   var favBrightness = ThemeMode.system.obs;
   var favLanguageCode = 'es_ES'.obs;
 
+  /// Keys of the markets the average tab asks for.
+  ///
+  /// Since backend v3.0.0 a market left out of the request is `off`, so this is
+  /// all it takes to let the user pick which ones to follow.
+  final RxSet<String> selectedMarketKeys = Markets.defaultKeys.toSet().obs;
+
   static const String _themeKey = 'theme_mode';
   static const String _langKey = 'language_code';
   static const String _favMarketKey = 'fav_market';
+  static const String _marketsKey = 'selected_markets';
 
   List<LanguageOption> languageOptions = [
     LanguageOption(code: 'es_ES', name: 'Español', flag: '🇪🇸'),
@@ -40,11 +49,14 @@ class SettingsController extends GetxController {
     if (marketIndex != null) {
       favMarketIndex.value = marketIndex;
     }
-    
+
     // Cargar Tema
     final themeName = prefs.getString(_themeKey);
     if (themeName != null) {
-      favBrightness.value = ThemeMode.values.firstWhere((e) => e.name == themeName, orElse: () => ThemeMode.system);
+      favBrightness.value = ThemeMode.values.firstWhere(
+        (e) => e.name == themeName,
+        orElse: () => ThemeMode.system,
+      );
     }
     Get.changeThemeMode(favBrightness.value);
 
@@ -55,6 +67,43 @@ class SettingsController extends GetxController {
       var localeParts = langCode.split('_');
       Get.updateLocale(Locale(localeParts[0], localeParts[1]));
     }
+
+    // Cargar mercados seguidos. Se descartan las claves que el catálogo ya no
+    // conoce y una selección vacía, para no dejar la pestaña sin tasas.
+    final markets = prefs.getStringList(_marketsKey);
+    if (markets != null) {
+      final known = markets
+          .where((key) => Markets.catalog.any((market) => market.key == key))
+          .toSet();
+      if (known.isNotEmpty) {
+        selectedMarketKeys.assignAll(known);
+      }
+    }
+  }
+
+  /// Markets to request, resolved against the catalogue.
+  MarketSelection get marketSelection =>
+      Markets.selectionOf(selectedMarketKeys);
+
+  bool isMarketSelected(String key) => selectedMarketKeys.contains(key);
+
+  /// Adds or removes a market. Removing the last one is refused: an empty
+  /// selection would leave the average tab with nothing to show.
+  void setMarketSelected(String key, bool selected) {
+    if (selected == isMarketSelected(key)) return;
+    if (!selected && selectedMarketKeys.length == 1) return;
+
+    if (selected) {
+      selectedMarketKeys.add(key);
+    } else {
+      selectedMarketKeys.remove(key);
+    }
+    _persistMarkets();
+  }
+
+  void _persistMarkets() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_marketsKey, selectedMarketKeys.toList());
   }
 
   void setFavMarket(int index) async {
@@ -64,7 +113,6 @@ class SettingsController extends GetxController {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_favMarketKey, index);
   }
-
 
   void setFavLanguage(String code) async {
     if (favLanguageCode.value == code) return;

--- a/test/core/helpers/currency_helpers_average_test.dart
+++ b/test/core/helpers/currency_helpers_average_test.dart
@@ -3,12 +3,8 @@ import 'package:bcv_tracker_app/core/helpers/currency_helpers.dart';
 import 'package:bcv_tracker_app/shared/domain/entities/currency.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-Currency _rate(String platform, String code, double value) => Currency(
-  name: code,
-  keyName: code,
-  platform: platform,
-  value: value,
-);
+Currency _rate(String platform, String code, double value) =>
+    Currency(name: code, keyName: code, platform: platform, value: value);
 
 void main() {
   group('getAverageValue()', () {

--- a/test/features/converter/converter_controller_calculator_test.dart
+++ b/test/features/converter/converter_controller_calculator_test.dart
@@ -3,6 +3,7 @@ import 'package:bcv_tracker_app/features/converter/presentation/controller/conve
 import 'package:bcv_tracker_app/shared/data/repositories/currency_repository.dart';
 import 'package:bcv_tracker_app/shared/domain/entities/bcv_currencies.dart';
 import 'package:bcv_tracker_app/shared/domain/entities/currency.dart';
+import 'package:bcv_tracker_app/shared/domain/entities/market.dart';
 import 'package:bcv_tracker_app/shared/domain/repositories/dollar_repositories.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
@@ -13,7 +14,8 @@ class _FakeDollarRepository implements IDollarRepository {
       BcvCurrencies(date: '2024-01-01', currencies: []);
 
   @override
-  Future<List<Currency>> getCurrentDollar() async => [];
+  Future<List<Currency>> getCurrentDollar(MarketSelection selection) async =>
+      [];
 }
 
 void main() {
@@ -48,10 +50,14 @@ void main() {
     double fromConverted = 1.0,
     double toConverted = 36.5,
   }) {
-    controller.fromCurrency =
-        ConvertibleCurrency(currency: from, convertedValue: fromConverted);
-    controller.toCurrency =
-        ConvertibleCurrency(currency: to, convertedValue: toConverted);
+    controller.fromCurrency = ConvertibleCurrency(
+      currency: from,
+      convertedValue: fromConverted,
+    );
+    controller.toCurrency = ConvertibleCurrency(
+      currency: to,
+      convertedValue: toConverted,
+    );
   }
 
   group('calculator()', () {

--- a/test/shared/data/currency_normalizer_test.dart
+++ b/test/shared/data/currency_normalizer_test.dart
@@ -1,7 +1,12 @@
 import 'package:bcv_tracker_app/core/constants/market_constants.dart';
 import 'package:bcv_tracker_app/shared/data/mapper/currency_normalizer.dart';
 import 'package:bcv_tracker_app/shared/domain/entities/currency.dart';
+import 'package:bcv_tracker_app/shared/domain/entities/market.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+/// Markets requested out of the box: BCV, Exchange Monitor, Yadio, Binance and
+/// Bybit. OKX, Bitget, Airtm and DolarAPI stay out unless the user adds them.
+final MarketSelection _selection = Markets.defaultSelection;
 
 Currency _rate({
   required String platform,
@@ -49,7 +54,7 @@ void main() {
           value: 850,
         ),
         _rate(platform: Markets.yadio, code: 'USD', name: 'Dolar', value: 844),
-      ]);
+      ], _selection);
 
       expect(result.map((c) => c.platform), [Markets.yadio]);
     });
@@ -72,7 +77,7 @@ void main() {
           tendency: 3.0,
           updateDate: DateTime(2026, 7, 23, 12),
         ),
-      ]);
+      ], _selection);
 
       expect(result, hasLength(1));
       expect(result.single.name, 'Tether');
@@ -91,7 +96,7 @@ void main() {
           name: 'Usd coin-sell',
           value: 853,
         ),
-      ]);
+      ], _selection);
 
       expect(result.single.name, 'Usd coin');
       expect(result.single.value, 853);
@@ -103,7 +108,7 @@ void main() {
       final result = CurrencyNormalizer.forAverageTab([
         _rate(platform: Markets.yadio, code: 'USD', name: 'Dolar', value: 844),
         _rate(platform: Markets.yadio, code: 'USD', name: 'Dolar', value: 800),
-      ]);
+      ], _selection);
 
       expect(result, hasLength(1));
       expect(result.single.value, 844);
@@ -131,13 +136,16 @@ void main() {
           name: 'Tether-sell',
           value: 860,
         ),
-      ]);
+      ], _selection);
 
-      expect(result.map((c) => c.platform), Markets.averageTab);
+      expect(
+        result.map((c) => c.platform),
+        _selection.markets.map((market) => market.platform),
+      );
     });
 
     test('an empty payload does not throw', () {
-      expect(CurrencyNormalizer.forAverageTab([]), isEmpty);
+      expect(CurrencyNormalizer.forAverageTab([], _selection), isEmpty);
     });
   });
 }

--- a/test/shared/data/currency_normalizer_test.dart
+++ b/test/shared/data/currency_normalizer_test.dart
@@ -144,6 +144,42 @@ void main() {
       );
     });
 
+    test('keeps only the estimated average of Exchange Monitor', () {
+      // No mode returns just the average: own+monitor brings the own value too,
+      // and the old contract trimmed it with enforce_em_average.
+      final result = CurrencyNormalizer.forAverageTab([
+        _rate(
+          platform: Markets.exchangeMonitor,
+          code: Markets.emOwnCode,
+          name: 'Exchange monitor',
+          value: 814,
+        ),
+        _rate(
+          platform: Markets.exchangeMonitor,
+          code: Markets.emAverageCode,
+          name: 'Promedio',
+          value: 803,
+        ),
+      ], _selection);
+
+      expect(result, hasLength(1));
+      expect(result.single.keyName, Markets.emAverageCode);
+    });
+
+    test('keeps the own value when the average is not there', () {
+      // A market asked in `own` must not vanish from the list.
+      final result = CurrencyNormalizer.forAverageTab([
+        _rate(
+          platform: Markets.exchangeMonitor,
+          code: Markets.emOwnCode,
+          name: 'Exchange monitor',
+          value: 814,
+        ),
+      ], _selection);
+
+      expect(result.single.keyName, Markets.emOwnCode);
+    });
+
     test('an empty payload does not throw', () {
       expect(CurrencyNormalizer.forAverageTab([], _selection), isEmpty);
     });

--- a/test/shared/data/dollar_api_rest_test.dart
+++ b/test/shared/data/dollar_api_rest_test.dart
@@ -1,3 +1,4 @@
+import 'package:bcv_tracker_app/core/constants/market_constants.dart';
 import 'package:bcv_tracker_app/core/network/api_exception.dart';
 import 'package:bcv_tracker_app/core/network/http_manager.dart';
 import 'package:bcv_tracker_app/core/network/http_operation.dart';
@@ -52,7 +53,7 @@ void main() {
             '{"code":"USD","name":"Dolar","platform":"Banco Central de Venezuela",'
             '"value":737.8816,"change":33.08,"createDate":"2026-01-29T18:38:47.617316",'
             '"updateDate":"2026-07-23T03:46:17.336191","platform_img":"https://logo.test/bcv.png"}]}',
-      ).getCurrentDollar();
+      ).getCurrentDollar(Markets.defaultSelection);
 
       expect(result, hasLength(1));
       expect(result.first.keyName, 'USD');
@@ -75,7 +76,7 @@ void main() {
             '{"code":"USDT","name":"Tether-buy","platform":"Binance","value":860.6,'
             '"change":0.1,"createDate":"2026-07-26T21:18:42.522524-04:00",'
             '"updateDate":"2026-07-26T21:18:42.522529-04:00","platform_img":""}]}',
-      ).getCurrentDollar();
+      ).getCurrentDollar(Markets.defaultSelection);
 
       expect(
         result.first.updateDate!.toUtc(),
@@ -89,7 +90,7 @@ void main() {
           statusCode: 502,
           body:
               '{"status":"Error","message":"El portal del BCV no está disponible"}',
-        ).getCurrentDollar(),
+        ).getCurrentDollar(Markets.defaultSelection),
         throwsA(
           isA<ApiException>()
               .having((e) => e.statusCode, 'statusCode', 502)
@@ -102,35 +103,44 @@ void main() {
       );
     });
 
-    test('falls back to the status code when the body is not the envelope', () async {
-      // What a wrong route actually returns through the edge: an HTML page.
-      await expectLater(
-        _api(statusCode: 404, body: '<html>404</html>').getCurrentDollar(),
-        throwsA(
-          isA<ApiException>()
-              .having((e) => e.statusCode, 'statusCode', 404)
-              .having((e) => e.message, 'message', 'HTTP 404'),
-        ),
-      );
-    });
+    test(
+      'falls back to the status code when the body is not the envelope',
+      () async {
+        // What a wrong route actually returns through the edge: an HTML page.
+        await expectLater(
+          _api(
+            statusCode: 404,
+            body: '<html>404</html>',
+          ).getCurrentDollar(Markets.defaultSelection),
+          throwsA(
+            isA<ApiException>()
+                .having((e) => e.statusCode, 'statusCode', 404)
+                .having((e) => e.message, 'message', 'HTTP 404'),
+          ),
+        );
+      },
+    );
 
     test('reports a malformed body instead of crashing', () async {
       await expectLater(
-        _api(body: 'not json').getCurrentDollar(),
+        _api(body: 'not json').getCurrentDollar(Markets.defaultSelection),
         throwsA(isA<ApiException>()),
       );
       await expectLater(
-        _api(body: '{"status":"Success","message":"ok"}').getCurrentDollar(),
+        _api(
+          body: '{"status":"Success","message":"ok"}',
+        ).getCurrentDollar(Markets.defaultSelection),
         throwsA(isA<ApiException>()),
       );
       await expectLater(
-        _api(body: '').getCurrentDollar(),
+        _api(body: '').getCurrentDollar(Markets.defaultSelection),
         throwsA(isA<ApiException>()),
       );
       // `data` present but not a list.
       await expectLater(
-        _api(body: '{"status":"Success","message":"ok","data":{}}')
-            .getCurrentDollar(),
+        _api(
+          body: '{"status":"Success","message":"ok","data":{}}',
+        ).getCurrentDollar(Markets.defaultSelection),
         throwsA(isA<ApiException>()),
       );
     });
@@ -143,7 +153,7 @@ void main() {
             message: 'Connection refused',
             type: DioExceptionType.connectionError,
           ),
-        ).getCurrentDollar(),
+        ).getCurrentDollar(Markets.defaultSelection),
         throwsA(
           isA<ApiException>()
               .having((e) => e.statusCode, 'statusCode', isNull)
@@ -158,7 +168,7 @@ void main() {
             '{"status":"Success","message":"ok","data":['
             '{"code":"em","name":"Exchange monitor","platform":"Exchange Monitor",'
             '"value":803.58,"change":0,"createDate":null,"updateDate":null,"platform_img":""}]}',
-      ).getCurrentDollar();
+      ).getCurrentDollar(Markets.defaultSelection);
 
       expect(result.first.keyName, 'em');
       expect(result.first.createDate, isNull);

--- a/test/shared/data/dollar_api_rest_test.dart
+++ b/test/shared/data/dollar_api_rest_test.dart
@@ -6,13 +6,18 @@ import 'package:bcv_tracker_app/shared/data/datasource/dollar_api/dollar_api_res
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-/// Returns a canned response (or failure) instead of hitting the network.
+/// Returns a canned response (or failure) instead of hitting the network, and
+/// records the request so the tests can pin the contract that was sent.
 class _FakeHttpManager extends HttpManager {
   _FakeHttpManager({this.statusCode = 200, this.responseBody, this.failure});
 
   final int statusCode;
   final Object? responseBody;
   final DioException? failure;
+
+  String? sentEndpoint;
+  HttpOperation? sentMethod;
+  Map<String, dynamic>? sentBody;
 
   @override
   Future<Response> request({
@@ -22,6 +27,9 @@ class _FakeHttpManager extends HttpManager {
     Map<String, dynamic>? customHeader,
     String? clientCode,
   }) async {
+    sentEndpoint = endpoint;
+    sentMethod = method;
+    sentBody = body;
     if (failure != null) throw failure!;
     return Response(
       requestOptions: RequestOptions(path: endpoint),
@@ -45,6 +53,49 @@ DollarApiRest _api({
 );
 
 void main() {
+  group('the request the backend receives', () {
+    test('is a POST carrying the per-market Body', () async {
+      final client = _FakeHttpManager(
+        responseBody: '{"status":"Success","message":"ok","data":[]}',
+      );
+      await DollarApiRest(
+        apiUrl: 'https://backend.test',
+        client: client,
+      ).getCurrentDollar(
+        Markets.selectionOf({Markets.bcvKey, Markets.binanceKey}),
+      );
+
+      expect(client.sentMethod, HttpOperation.post);
+      expect(client.sentEndpoint, endsWith('/saved-currencies'));
+      // A market absent from the Body is `off`: the request asks for exactly
+      // the two markets selected, in the modes the catalogue declares.
+      expect(client.sentBody, {
+        'markets': {
+          Markets.bcvKey: Markets.modeDbDollar,
+          Markets.binanceKey: Markets.modeAverage,
+        },
+      });
+    });
+
+    test('targets the versioned path of the country controller', () async {
+      final client = _FakeHttpManager(
+        responseBody:
+            '{"status":"Success","message":"ok","data":{"date":null,"currencies":[]}}',
+      );
+      await DollarApiRest(
+        apiUrl: 'https://backend.test',
+        client: client,
+      ).getCurrentBCVDollar();
+
+      expect(
+        client.sentEndpoint,
+        'https://backend.test/api/v1/venezuela/bcv/with-memory',
+      );
+      expect(client.sentMethod, HttpOperation.get);
+      expect(client.sentBody, isNull);
+    });
+  });
+
   group('getCurrentDollar()', () {
     test('maps the data list of the envelope', () async {
       final result = await _api(

--- a/test/shared/data/dollar_api_rest_test.dart
+++ b/test/shared/data/dollar_api_rest_test.dart
@@ -121,6 +121,41 @@ void main() {
       },
     );
 
+    test('reads the validation detail of FastAPI on a 422', () async {
+      // A mode a market does not allow: this response is built by FastAPI, so
+      // it never goes through the error envelope of the backend.
+      await expectLater(
+        _api(
+          statusCode: 422,
+          body:
+              '{"detail":[{"type":"value_error","loc":["body","markets"],'
+              '"msg":"Value error, El modo \'solo-dolar\' no es válido para el '
+              'mercado \'binance\'."}]}',
+        ).getCurrentDollar(Markets.defaultSelection),
+        throwsA(
+          isA<ApiException>()
+              .having((e) => e.statusCode, 'statusCode', 422)
+              .having((e) => e.message, 'message', contains('no es válido')),
+        ),
+      );
+    });
+
+    test('reads a detail that comes as a plain string', () async {
+      await expectLater(
+        _api(
+          statusCode: 405,
+          body: '{"detail":"Method Not Allowed"}',
+        ).getCurrentDollar(Markets.defaultSelection),
+        throwsA(
+          isA<ApiException>().having(
+            (e) => e.message,
+            'message',
+            'Method Not Allowed',
+          ),
+        ),
+      );
+    });
+
     test('reports a malformed body instead of crashing', () async {
       await expectLater(
         _api(body: 'not json').getCurrentDollar(Markets.defaultSelection),

--- a/test/shared/domain/market_selection_test.dart
+++ b/test/shared/domain/market_selection_test.dart
@@ -1,0 +1,123 @@
+import 'package:bcv_tracker_app/core/constants/market_constants.dart';
+import 'package:bcv_tracker_app/shared/domain/entities/market.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Markets.catalog', () {
+    test('asks every market in a mode its type allows', () {
+      // Asking for a mode outside these sets answers 422; the sets mirror
+      // ALLOWED_MODES of api/models/market_request.py.
+      const fiat = {
+        Markets.modeLiveDollar,
+        Markets.modeLiveAll,
+        Markets.modeDbDollar,
+        Markets.modeDbAll,
+      };
+      const crypto = {Markets.modeAverage, Markets.modeBoth, Markets.modeDbAll};
+      const exchangeMonitor = {
+        Markets.modeEmOwn,
+        Markets.modeEmOwnMonitor,
+        Markets.modeDbAll,
+      };
+
+      const allowedByKey = <String, Set<String>>{
+        Markets.bcvKey: fiat,
+        Markets.yadioKey: fiat,
+        Markets.airtmKey: fiat,
+        Markets.dolarApiKey: fiat,
+        Markets.binanceKey: crypto,
+        Markets.bybitKey: crypto,
+        Markets.okxKey: crypto,
+        Markets.bitgetKey: crypto,
+        Markets.exchangeMonitorKey: exchangeMonitor,
+      };
+
+      expect(
+        Markets.catalog.map((market) => market.key).toSet(),
+        allowedByKey.keys.toSet(),
+        reason: 'the catalogue must cover every market of the backend',
+      );
+      for (final market in Markets.catalog) {
+        expect(
+          allowedByKey[market.key],
+          contains(market.mode),
+          reason: '${market.key} cannot be asked in ${market.mode}',
+        );
+      }
+    });
+
+    test('has one entry per key and per platform', () {
+      expect(
+        Markets.catalog.map((market) => market.key).toSet(),
+        hasLength(Markets.catalog.length),
+      );
+      expect(
+        Markets.catalog.map((market) => market.platform).toSet(),
+        hasLength(Markets.catalog.length),
+      );
+    });
+  });
+
+  group('Markets.selectionOf()', () {
+    test('keeps the catalogue order, not the order of the keys', () {
+      final selection = Markets.selectionOf({
+        Markets.bybitKey,
+        Markets.bcvKey,
+        Markets.yadioKey,
+      });
+
+      expect(selection.markets.map((market) => market.key), [
+        Markets.bcvKey,
+        Markets.yadioKey,
+        Markets.bybitKey,
+      ]);
+    });
+
+    test('ignores a key it does not know', () {
+      // A preference saved by an older version must not break the request.
+      final selection = Markets.selectionOf({Markets.bcvKey, 'mercado-viejo'});
+
+      expect(selection.markets.map((market) => market.key), [Markets.bcvKey]);
+    });
+
+    test('an empty set produces an empty selection', () {
+      expect(Markets.selectionOf(const {}).isEmpty, isTrue);
+    });
+  });
+
+  group('MarketSelection', () {
+    test('serializes as the markets map of the Body', () {
+      expect(Markets.defaultSelection.toJson(), {
+        'markets': {
+          Markets.bcvKey: Markets.modeDbDollar,
+          Markets.exchangeMonitorKey: Markets.modeEmOwnMonitor,
+          Markets.yadioKey: Markets.modeLiveDollar,
+          Markets.binanceKey: Markets.modeAverage,
+          Markets.bybitKey: Markets.modeAverage,
+        },
+      });
+    });
+
+    test('exposes the platforms its markets answer with', () {
+      expect(Markets.defaultSelection.platforms, {
+        Markets.bcv,
+        Markets.exchangeMonitor,
+        Markets.yadio,
+        Markets.binance,
+        Markets.bybit,
+      });
+    });
+
+    test('a market keeps its platform name apart from its Body key', () {
+      const market = Market(
+        key: Markets.bcvKey,
+        platform: Markets.bcv,
+        mode: Markets.modeDbDollar,
+      );
+
+      expect(market.key, 'bcv');
+      expect(market.platform, 'Banco Central de Venezuela');
+      expect(market.copyWith(mode: Markets.modeDbAll).mode, Markets.modeDbAll);
+    });
+  });
+}

--- a/test/shared/presentation/settings_markets_test.dart
+++ b/test/shared/presentation/settings_markets_test.dart
@@ -1,0 +1,103 @@
+import 'package:bcv_tracker_app/core/constants/market_constants.dart';
+import 'package:bcv_tracker_app/shared/presentation/controller/settings_controller.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Builds the controller and lets its asynchronous preference load finish.
+Future<SettingsController> _loaded() async {
+  final controller = SettingsController();
+  controller.onInit();
+  await Future<void>.delayed(Duration.zero);
+  return controller;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  Get.testMode = true;
+
+  setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
+
+  group('followed markets', () {
+    test('starts on the catalogue default', () async {
+      final controller = await _loaded();
+
+      expect(controller.selectedMarketKeys, Markets.defaultKeys);
+      expect(
+        controller.marketSelection.markets.map((market) => market.key),
+        Markets.defaultSelection.markets.map((market) => market.key),
+      );
+    });
+
+    test('following a market adds it to the request', () async {
+      final controller = await _loaded();
+
+      controller.setMarketSelected(Markets.okxKey, true);
+
+      expect(controller.isMarketSelected(Markets.okxKey), isTrue);
+      expect(
+        controller.marketSelection.toJson(),
+        containsPair(
+          'markets',
+          containsPair(Markets.okxKey, Markets.modeAverage),
+        ),
+      );
+    });
+
+    test('dropping a market takes it out of the request', () async {
+      final controller = await _loaded();
+
+      controller.setMarketSelected(Markets.bybitKey, false);
+
+      expect(controller.isMarketSelected(Markets.bybitKey), isFalse);
+      expect(
+        (controller.marketSelection.toJson()['markets'] as Map),
+        isNot(contains(Markets.bybitKey)),
+      );
+    });
+
+    test('refuses to drop the last market', () async {
+      final controller = await _loaded();
+      for (final key in Markets.defaultKeys.skip(1)) {
+        controller.setMarketSelected(key, false);
+      }
+
+      final last = controller.selectedMarketKeys.single;
+      controller.setMarketSelected(last, false);
+
+      // An empty selection would answer an empty list and leave the tab blank.
+      expect(controller.selectedMarketKeys, {last});
+    });
+
+    test('remembers the choice', () async {
+      final controller = await _loaded();
+      controller.setMarketSelected(Markets.okxKey, true);
+      controller.setMarketSelected(Markets.bcvKey, false);
+      await Future<void>.delayed(Duration.zero);
+
+      final reopened = await _loaded();
+
+      expect(reopened.selectedMarketKeys, controller.selectedMarketKeys);
+    });
+
+    test('ignores a saved market the catalogue no longer knows', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'selected_markets': <String>[Markets.bcvKey, 'mercado-viejo'],
+      });
+
+      final controller = await _loaded();
+
+      expect(controller.selectedMarketKeys, {Markets.bcvKey});
+    });
+
+    test('falls back to the default if nothing saved is known', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'selected_markets': <String>['mercado-viejo'],
+      });
+
+      final controller = await _loaded();
+
+      expect(controller.selectedMarketKeys, Markets.defaultKeys);
+    });
+  });
+}


### PR DESCRIPTION
Stacked on #8 (`fix/api-v1-migration`); review that one first.

Backend v3.0.0 is deployed and `saved-currencies` is **POST only**, so the app's GET answers `405 Method Not Allowed`. The endpoint no longer takes query flags: it takes a Body that declares a mode per market, and a market left out of it is `off`.

## What the new contract buys

Measured against production with the default selection:

| | Old contract | Now |
|---|---|---|
| Rates fetched → shown | 21 → 7 | **8 → 7** |
| Time | ~6.4 s | **~1.3 s** |
| Duplicated database rows | merged on the client | resolved in SQL by the backend |
| `-buy` / `-sell` | merged on the client | `average` returns one averaged rate per asset, with its ROC |

## Changes, one commit per phase

**A — the request** (`1ee2b5a`). `Markets` models the catalogue: each market carries its Body key, the platform name it reports and the mode it is asked in. The mode is the cheapest that still answers what is shown — the BCV from the database, the rest live. Crypto uses `average`: reading it from the database would collapse buy and sell, since the backend keys its rows by `(code, platform)`.

**B — Exchange Monitor** (`e32a953`). The one filter the Body cannot express: no mode returns only the estimated average, so `own+monitor` also brings the own value, and `enforce_em_average` has no replacement. The own value is dropped only when the average is present, so a market asked in `own` still shows. The dedupe and the buy/sell merge stay as guards — Airtm does answer with both sides.

**C — rejected Body** (`6e33c47`). A Body that fails validation is answered by FastAPI itself, so it carries a `detail` and never reaches the error envelope: reading it turns "HTTP 422" into *"El modo 'solo-dolar' no es válido para el mercado 'binance'"*. An unreadable Body is not rejected at all — it answers 200 with an empty list, which now leaves a line in the log.

**D — tests** (`11dc2ce`). The fake client records the request, so the tests state what the backend receives: the verb, the path and the exact markets map. `market_selection_test` checks the catalogue against `ALLOWED_MODES` of the backend, so a drift fails here instead of in production with a 422.

**E — markets the user picks** (`40b74e1`). Following one more market is one more entry in the Body, so the choice needs no backend work: the settings modal lists the nine markets as chips, the choice is persisted and changing it refetches. Dropping the last one is refused, since an empty selection answers an empty list. `CurrencyRepository` takes the selection as a function, so the service still works alone and the wiring stays in the binding.

## Verification

64 tests pass in `America/Caracas` and `Europe/Madrid`. `flutter analyze` reports only the nine warnings that predate the work.

Live against production: 8 rates in ~1.3 s for the default selection, 16 for the nine markets, and a rejected mode that explains itself.

## Worth a look before merging

- **Which markets ship selected**: BCV, Exchange Monitor, Yadio, Binance and Bybit. OKX, Bitget, Airtm and DolarAPI are one tap away in the settings.
- **Thin markets skew the average card**: OKX and Bitget quote USDC around 700–750 against ~860 elsewhere, and the parallel average counts every dollar-equivalent quote. A user who follows them will see the headline figure drop.
- Not verified: the app was never run on a device, so the market chips have no visual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)