### PR TITLE
[🗑️ Chore: DTA-002] - Cerrar issues solo al llegar a master

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -32,14 +32,23 @@ Los enlaces son **relativos**, así que funcionan en cualquier clon. `.agents/sk
 
 ## Las reglas también se enlazan, pero con `paths:`
 
-`.claude/rules/*.md` se carga **en cada sesión**, y las 16 reglas suman 1.743 líneas (~27 mil tokens): cargarlas todas siempre inundaría el contexto, y la propia documentación advierte que eso *reduce* la adherencia.
+`.claude/rules/*.md` se carga **en cada sesión**, y las 16 reglas suman 1.841 líneas (~27 mil tokens): cargarlas todas siempre inundaría el contexto, y la propia documentación advierte que eso *reduce* la adherencia.
 
 La salida es el frontmatter `paths:`, que hace que una regla se cargue **solo al leer archivos que coincidan**. El reparto:
 
-- **4 sin `paths:` → siempre en contexto** (695 líneas, ~7 mil tokens): `issue-convention`, `branch-naming`, `commit-convention` y `pull-request`. Son procedimientos de git y GitHub: ningún archivo los dispara, así que no hay patrón que darles.
+- **4 sin `paths:` → siempre en contexto** (718 líneas, ~10 mil tokens): `issue-convention`, `branch-naming`, `commit-convention` y `pull-request`. Son procedimientos de git y GitHub: ningún archivo los dispara, así que no hay patrón que darles.
 - **12 con `paths:` → bajo demanda**: editar `lib/core/i18n/` trae la regla de i18n y nada más; tocar `pubspec.yaml` trae las tres de versionado.
 
 El `paths:` vive en el frontmatter de `.agents/rules/*.md` junto al `description:`. Otros agentes lo ignoran sin problema; Claude Code lo usa para no cargar lo que no toca.
+
+Las tres cifras de arriba son **derivadas**, así que envejecen en cuanto una regla crece — ya pasó dos veces, y la segunda fue al escribir esta misma sección. Recalcúlalas al editar cualquier regla:
+
+```bash
+cat .agents/rules/*.md | wc -l                                             # total
+for f in .agents/rules/*.md; do grep -q '^paths:' "$f" || cat "$f"; done | wc -l  # incondicional
+```
+
+Y para comprobar que ninguna regla quedó con un `paths:` que no empareja con nada —el fallo que dejó a `release-notes.md` inalcanzable— basta con listar los patrones y probarlos contra el árbol.
 
 > Si algún día `pull-request.md` (333 líneas) molesta en contexto, la salida que sugiere la documentación es convertir los procedimientos en skills: una skill se carga por su descripción, no siempre.
 

--- a/.agents/rules/branch-naming.md
+++ b/.agents/rules/branch-naming.md
@@ -102,11 +102,36 @@ Closes #23
 
 Keywords válidas: `close`/`closes`/`closed`, `fix`/`fixes`/`fixed`, `resolve`/`resolves`/`resolved`.
 
-> ⚠️ **Las keywords solo cierran el issue cuando la PR apunta a la rama por defecto del repositorio**, que aquí es `master`. Como el trabajo normal se mergea a `development`, una PR de feature/fix **no** cerrará su issue al mergearse: lo hará más adelante, cuando `development` llegue a `master`. Incluye la keyword igualmente —deja el vínculo registrado y la trazabilidad visible en el issue—, pero **cierra el issue a mano** al mergear a `development` si el trabajo ya está terminado:
+Las keywords solo surten efecto cuando la PR apunta a la **rama por defecto** del repositorio, que aquí es `master`. Eso encaja exactamente con la política de cierre del proyecto, y no hay que sortearlo:
+
+> ## Un issue se cierra cuando el trabajo llega a `master`
 >
-> ```bash
-> gh issue close <N> --comment "Mergeado en development vía PR #<M>"
-> ```
+> **No al mergear a `development`.** La lista de issues abiertos refleja lo que falta por *entregar*, no lo que falta por *integrar*.
+>
+> Consecuencia práctica: incluye la keyword `Closes #N` en toda PR aunque su base sea `development`. No dispara ahí, pero queda registrada — y **todas disparan a la vez** en la promoción de release `development → master`, que sí apunta a la rama por defecto. El cierre es automático y en el momento correcto.
+>
+> **Nunca cierres un issue a mano al mergear a `development`.** Deja un comentario en su lugar (plantilla abajo).
+
+### El comentario al mergear a `development`
+
+El issue sigue abierto, así que el comentario tiene que dejar claro que el trabajo ya existe y dónde. Cuatro cosas, mínimo:
+
+```markdown
+## ✅ Trabajado y mergeado en `development`
+
+- **Rama:** `<tipo>/DTA-<núm>`
+- **PR:** #<N> — mergeada el <AAAA-MM-DD> (`<commit de merge>`)
+- **Base:** `development`
+
+### Qué se entregó
+<tabla de los criterios de aceptación con su estado>
+
+### Por qué sigue abierto
+**Política del repositorio: un issue se cierra cuando el trabajo llega a `master`.**
+Este issue se cierra con la promoción de release.
+```
+
+Sin esa tabla el issue obliga a abrir la PR para saber qué quedó hecho. Con ella, se lee de un vistazo.
 
 ### Si `gh` no está disponible
 

--- a/.agents/rules/pull-request.md
+++ b/.agents/rules/pull-request.md
@@ -324,10 +324,8 @@ Usa la herramienta disponible, priorizando **GitHub CLI**:
 
 Si la rama tiene issue vinculado, asegúrate de que el cuerpo de la PR incluya la keyword de cierre (`Closes #N`) para dejar el vínculo registrado; si no lo tiene (Paso 1b), no la incluyas.
 
-⚠️ Las keywords **solo cierran** el issue cuando la PR apunta a la rama por defecto (`master`). Como las PR normales van a `development`, tras mergear una PR que completa su issue, ciérralo a mano:
+⚠️ Las keywords **solo surten efecto** cuando la PR apunta a la rama por defecto (`master`), y eso es lo que se quiere: **un issue se cierra cuando el trabajo llega a `master`, no al mergear a `development`** — ver `branch-naming.md`.
 
-```bash
-gh issue close <N> --comment "Mergeado en development vía PR #<M>"
-```
+Así que incluye `Closes #N` igualmente: queda registrada y dispara sola en la promoción de release. Tras mergear a `development`, **no cierres el issue**: deja el comentario con rama, PR, commit de merge y el estado de los criterios de aceptación (plantilla en `branch-naming.md`).
 
 Tras subir, devuelve la URL de la PR creada.

--- a/.agents/rules/release-versioning.md
+++ b/.agents/rules/release-versioning.md
@@ -173,7 +173,21 @@ gh pr create --base master --head development \
 - El bump de `pubspec.yaml` (Paso 3) debe ir **dentro** de esa promoción, no después: el tag tiene que apuntar a un commit donde la versión del código ya sea la nueva.
 - Esta PR es la excepción a la regla de "nunca apuntes a `master`" de `pull-request.md`; la otra es un `hotfix/`.
 - **Este merge es el que cierra los issues.** Al llegar a `master`, las keywords `Closes #N` de todas las PR acumuladas surten efecto de golpe, porque `master` es la rama por defecto. Es el momento previsto por la política del repositorio: un issue se cierra cuando su trabajo está en producción (ver `branch-naming.md`).
-- Tras el merge, comprueba que se cerró lo que debía: `gh issue list --state closed --limit 20`. Si algún issue del release sigue abierto, es que su PR no llevaba la keyword — ciérralo a mano indicando la versión que lo entregó.
+- Tras el merge, comprueba que se cerró **lo del release**, no lo que se cerró últimamente. Saca los issues que las PR incluidas decían cerrar y verifica su estado:
+
+  ```bash
+  # issues referenciados por las PR que entran en este release
+  gh pr list --base development --state merged --limit 50 --json body \
+    --jq '.[].body | scan("(?i)clos(?:e|es|ed) #([0-9]+)")' | sort -u > /tmp/esperados
+
+  # cuáles siguen abiertos
+  while read n; do
+    gh issue view "$n" --json number,state \
+      --jq 'select(.state=="OPEN") | "sigue abierto: #\(.number)"'
+  done < /tmp/esperados
+  ```
+
+  Si alguno sigue abierto es que su PR no llevaba la keyword — ciérralo a mano indicando la versión que lo entregó.
 - Un **hotfix** salta este paso: va directo a `master`, y después se propaga a `development` para que la corrección no se pierda.
 
 ## Paso 7 — Crear el GitHub Release (según `triggerMode`)

--- a/.agents/rules/release-versioning.md
+++ b/.agents/rules/release-versioning.md
@@ -172,7 +172,8 @@ gh pr create --base master --head development \
 
 - El bump de `pubspec.yaml` (Paso 3) debe ir **dentro** de esa promoción, no después: el tag tiene que apuntar a un commit donde la versión del código ya sea la nueva.
 - Esta PR es la excepción a la regla de "nunca apuntes a `master`" de `pull-request.md`; la otra es un `hotfix/`.
-- Al mergear a `master`, las keywords de cierre (`Closes #N`) de todas las PR acumuladas **sí** surten efecto, porque `master` es la rama por defecto. Revisa que los issues ya cerrados a mano no queden duplicados.
+- **Este merge es el que cierra los issues.** Al llegar a `master`, las keywords `Closes #N` de todas las PR acumuladas surten efecto de golpe, porque `master` es la rama por defecto. Es el momento previsto por la política del repositorio: un issue se cierra cuando su trabajo está en producción (ver `branch-naming.md`).
+- Tras el merge, comprueba que se cerró lo que debía: `gh issue list --state closed --limit 20`. Si algún issue del release sigue abierto, es que su PR no llevaba la keyword — ciérralo a mano indicando la versión que lo entregó.
 - Un **hotfix** salta este paso: va directo a `master`, y después se propaga a `development` para que la corrección no se pierda.
 
 ## Paso 7 — Crear el GitHub Release (según `triggerMode`)


### PR DESCRIPTION
# Descripción

Alinea `.agents/rules/` con la política adoptada: **un issue se cierra cuando su trabajo llega a `master`**, no al mergear a `development`. La lista de issues abiertos debe reflejar lo que falta por *entregar*, no lo que falta por *integrar*.

Tres reglas decían lo contrario y habrían hecho que el próximo agente cerrara issues un release antes de tiempo:

1. `branch-naming.md` mandaba ejecutar `gh issue close` tras mergear a `development`, dando las keywords de cierre por inútiles.
2. `pull-request.md` repetía la instrucción tras subir la PR.
3. `release-versioning.md` lo asumía, avisando de revisar que los issues cerrados a mano no quedaran duplicados.

La política nueva **deja de sortear a GitHub**. Las keywords solo disparan contra la rama por defecto, que aquí es `master`: un `Closes #N` en una PR basada en `development` queda registrado y dispara después, y **todas disparan juntas** en la promoción de release. Cierre automático y en el momento correcto.

Añade también la plantilla del comentario que se deja en el issue al mergear a `development` — rama, PR, commit de merge y tabla de criterios de aceptación con su estado. Sin esa tabla, el issue obliga a abrir la PR para saber qué quedó hecho.

Closes #48

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad
- [ ] 🛠️ Corrección de errores
- [ ] ❌ Cambio importante
- [x] 📝 Actualización de la documentación
- [ ] 🧹 Code refactoring
- [ ] ✅ Build configuration change
- [x] 🗑️ Chore — convenciones del repositorio

## ¿Cómo se ha probado esto?

- [x] Ninguna regla instruye ya cerrar un issue al mergear a `development` (verificado por grep)
- [x] Las tres reglas describen la misma política sin contradecirse
- [x] Cero enlaces internos rotos entre las 16 reglas
- [x] Precedente aplicado a mano y coherente con la plantilla: #23 y #24 quedaron abiertas con ese comentario tras #47

**Configuración de prueba**: no aplica — no toca `lib/` ni `test/`.

## Lista de Verificación

- [x] He agregado las nuevas dependencias en la descripción — ninguna
- [x] He agregado las nuevas variables de entorno a la descripción — ninguna
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He realizado los cambios correspondientes a la documentación
- [x] Mis cambios no generan nuevas advertencias
- [ ] La app compila y el flujo afectado se probó en dispositivo — no aplica
- [ ] Copy nueva en los 10 idiomas — no aplica
- [ ] Tests de fuente/controlador/helper — no aplica