### PR TITLE
[🛠️ Fix: DTA-003] - Restaurar la validación de certificados TLS

### DIFF
--- a/lib/core/network/http_manager.dart
+++ b/lib/core/network/http_manager.dart
@@ -5,10 +5,8 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:developer';
-import 'dart:io';
 
 import 'package:dio/dio.dart';
-import 'package:dio/io.dart';
 
 import 'http_operation.dart';
 
@@ -53,14 +51,15 @@ class HttpManager {
   }) async {
     final setDioOptions = _dioOptions(endpoint, customHeader, clientCode);
 
+    // The adapter is left untouched on purpose. Dio validates the certificate
+    // chain against the system trust store by default, and the backend is
+    // served over HTTPS with a valid certificate, so it needs no help.
+    //
+    // ⚠️ Never override `httpClientAdapter` to accept every certificate
+    // (`badCertificateCallback => true`): it defeats iOS ATS and Android's
+    // network security config, and lets anyone on the same network serve
+    // forged exchange rates. See issue #50.
     final dio = Dio(setDioOptions);
-
-    (dio.httpClientAdapter as IOHttpClientAdapter).onHttpClientCreate =
-        (client) {
-          client.badCertificateCallback =
-              (X509Certificate cert, String host, int port) => true;
-          return client;
-        };
 
     Response? response;
 

--- a/lib/shared/data/datasource/dollar_api/dollar_api_rest.dart
+++ b/lib/shared/data/datasource/dollar_api/dollar_api_rest.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:bcv_tracker_app/shared/data/datasource/datasource.dart';
 import 'package:dio/dio.dart';
@@ -67,7 +68,19 @@ class DollarApiRest implements IDollarApi {
       response = await _client.request(endpoint: _apiUrl + endpoint);
     } on DioException catch (e) {
       // HttpManager accepts every status code, so Dio only throws when there is
-      // no response at all (connectivity, DNS, timeout).
+      // no response at all (connectivity, DNS, timeout, TLS).
+      final cause = e.error;
+      if (cause is HandshakeException || cause is CertificateException) {
+        // Raised when the certificate does not validate against the system
+        // trust store: an interception proxy, a captive portal or a network
+        // serving a forged certificate. Dio's own message is the raw OS error
+        // (`CERTIFICATE_VERIFY_FAILED`), useless to the user.
+        throw const ApiException.network(
+          'No se pudo verificar la identidad del servidor. '
+          'La conexión podría estar siendo interceptada; '
+          'prueba con otra red.',
+        );
+      }
       throw ApiException.network(e.message ?? e.type.name);
     }
 

--- a/test/shared/data/dollar_api_rest_test.dart
+++ b/test/shared/data/dollar_api_rest_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:bcv_tracker_app/core/network/api_exception.dart';
 import 'package:bcv_tracker_app/core/network/http_manager.dart';
 import 'package:bcv_tracker_app/core/network/http_operation.dart';
@@ -148,6 +150,38 @@ void main() {
           isA<ApiException>()
               .having((e) => e.statusCode, 'statusCode', isNull)
               .having((e) => e.message, 'message', 'Connection refused'),
+        ),
+      );
+    });
+
+    test('translates a rejected certificate into a readable message', () async {
+      // What reaches Dio when the chain does not validate against the system
+      // trust store — an interception proxy without its CA installed. The raw
+      // OS error must never reach the user.
+      await expectLater(
+        _api(
+          failure: DioException(
+            requestOptions: RequestOptions(path: '/x'),
+            type: DioExceptionType.unknown,
+            message:
+                'HandshakeException: Handshake error in client '
+                '(OS Error: CERTIFICATE_VERIFY_FAILED: self signed certificate)',
+            error: const HandshakeException('CERTIFICATE_VERIFY_FAILED'),
+          ),
+        ).getCurrentDollar(),
+        throwsA(
+          isA<ApiException>()
+              .having((e) => e.statusCode, 'statusCode', isNull)
+              .having(
+                (e) => e.message,
+                'message',
+                contains('No se pudo verificar la identidad del servidor'),
+              )
+              .having(
+                (e) => e.message,
+                'message',
+                isNot(contains('CERTIFICATE_VERIFY_FAILED')),
+              ),
         ),
       );
     });


### PR DESCRIPTION
# Descripción

`HttpManager` desactivaba por completo la validación de certificados TLS: cada petición reconstruía el adaptador de Dio con un `badCertificateCallback` que devolvía `true` para cualquier certificado. Eso anulaba la cadena de confianza en Android e iOS **por encima** de las protecciones de plataforma (ATS y `networkSecurityConfig`, ambas en su modo seguro en este proyecto), y permitía que cualquiera en la misma red inyectara tasas de cambio falsas sin ninguna señal visible.

Cambios (rama `fix/DTA-003`):

1. **Se elimina el bloque `onHttpClientCreate` / `badCertificateCallback`** de `HttpManager.request()`. El backend se sirve por HTTPS con certificado válido, así que Dio valida contra el almacén de confianza del sistema sin ninguna ayuda: la corrección es quitar el bypass, no reemplazarlo. En su lugar queda un comentario que explica por qué el adaptador no se toca, para que no se reintroduzca.
2. **Se limpian los imports que solo existían para el bypass** (`dart:io` y `package:dio/io.dart`).
3. **Se traduce el fallo de certificado a un error comprensible**: `DollarApiRest._getData` detecta `HandshakeException` / `CertificateException` en `DioException.error` y lanza una `ApiException.network` con un mensaje para el usuario, en vez de propagar el error crudo del sistema operativo (`CERTIFICATE_VERIFY_FAILED: self signed certificate`).
4. **Se cubre el caso negativo con un test**: un certificado rechazado produce el mensaje legible y **no** filtra el texto del error del SO.

No se añadió ninguna vía de excepción para desarrollo: no hacía falta, y un bypass "temporal" es exactamente cómo llegó aquí.

**Fuera de alcance:** *certificate pinning* (hallazgo SEC-02), que merece su propia issue.

Issue de GitHub relacionado: Closes #50

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad (cambio no-breaking que agrega funcionalidad)
- [x] 🛠️ Corrección de errores (cambio no-breaking que arregla un error)
- [ ] ❌ Cambio importante (arreglo o característica que haría que la funcionalidad existente no funcionara como se esperaba)
- [ ] 📝 Actualización de la documentación
- [ ] 🧹 Code refactoring (modificación de la estructura interna del código sin modificar las APIs)
- [ ] ✅ Build configuration change (modificación de los archivos para hacer deploy)
- [ ] 🗑️ Chore (actividades que no modifican la interacción con la app, por ejemplo, modificar el archivo de lints)

## ¿Cómo se ha probado esto?

- [x] `flutter analyze` — 8 issues, todos preexistentes (`withOpacity` deprecado, `unused_element_parameter` en `colors_values.dart`, import innecesario en `converter_page.dart`). Ninguno nuevo, ninguno en los archivos tocados.
- [x] `flutter test` — 44/44 en verde, incluido el nuevo caso `translates a rejected certificate into a readable message`.
- [x] Verificación de que no queda rastro del bypass: `grep -rn "badCertificateCallback\|onHttpClientCreate\|package:dio/io.dart" lib test` solo devuelve el comentario de advertencia añadido.
- [x] Verificación de que las protecciones de plataforma siguen intactas: no hay `usesCleartextTraffic`, `NSAllowsArbitraryLoads` ni `networkSecurityConfig` en `android/` ni `ios/`.
- [ ] **Pendiente de verificación manual en dispositivo** (no ejecutable desde CI, requiere el reviewer):
  - Caso positivo: la app carga las tasas normalmente en Android e iOS contra el backend real.
  - Caso negativo: con un proxy interceptor (mitmproxy / Charles) **sin** su CA instalada, la petición debe **fallar** y mostrar el mensaje "No se pudo verificar la identidad del servidor…". Si sigue funcionando, el bypass no se eliminó del todo.

**Configuración de prueba**:

- Plataforma y versión de SO (Android / iOS): pendiente de la verificación manual descrita arriba.
- Dispositivo o emulador: pendiente.
- Tema (claro/oscuro) e idioma probados: no aplica — el cambio no toca UI; el mensaje de error se pinta con el widget de error ya existente.

## Lista de Verificación

- [x] He agregado las nuevas dependencias (`pubspec.yaml`) en la descripción — no hay dependencias nuevas
- [x] He agregado las nuevas variables de entorno (solo los nombres) a la descripción — no hay variables nuevas
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código, particularmente en áreas difíciles de entender
- [x] He realizado los cambios correspondientes a la documentación
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente con mis cambios
- [ ] La app compila y el flujo afectado se probó en un dispositivo o emulador real — **pendiente**, ver arriba
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas — no aplica: el mensaje se genera en la capa de datos, igual que los demás mensajes de `ApiException` ya existentes
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper de cálculo, incluí sus tests en este mismo PR
- [x] No introduje modelos (`shared/data/model/`) en la UI ni en los controladores
