### PR TITLE
[🛠️ Fix: DTA-004] - Corregir el alpha del color de warning

### DIFF
--- a/lib/config/theme/colors/colors_constants.dart
+++ b/lib/config/theme/colors/colors_constants.dart
@@ -112,7 +112,10 @@ class AppColors {
     900: Color(0xFF710D06),
   });
 
-  static const int _warningValue = 0xFFFF980;
+  // 8 digits, always: `0xAARRGGBB`. A 7-digit literal is still a valid int, so
+  // the compiler stays silent while Dart reads the missing digit as alpha —
+  // this one used to be `0xFFFF980`, which rendered at 6 % opacity.
+  static const int _warningValue = 0xFFFF9800;
   static const MaterialColor warning =
       MaterialColor(_warningValue, <int, Color>{
         50: Color(0xFFFFF3E0),

--- a/test/config/theme/colors_constants_test.dart
+++ b/test/config/theme/colors_constants_test.dart
@@ -1,0 +1,74 @@
+import 'package:bcv_tracker_app/config/theme/colors/colors_constants.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Every palette exposed by [AppColors], by the name it carries in the class.
+const Map<String, MaterialColor> _palettes = <String, MaterialColor>{
+  'primary': AppColors.primary,
+  'secondary': AppColors.secondary,
+  'midnight': AppColors.midnight,
+  'accent': AppColors.accent,
+  'grey': AppColors.grey,
+  'success': AppColors.success,
+  'error': AppColors.error,
+  'warning': AppColors.warning,
+  'info': AppColors.info,
+};
+
+const List<int> _shades = <int>[
+  50,
+  100,
+  200,
+  300,
+  400,
+  500,
+  600,
+  700,
+  800,
+  900,
+];
+
+void main() {
+  // A colour literal is written `0xAARRGGBB`. Drop a digit and the result is
+  // still a valid int, so nothing fails to compile — Dart just reads the
+  // shifted value and the missing digit lands in the alpha channel. That is how
+  // `_warningValue` shipped as `0xFFFF980` (alpha 0x0F, ~6 % opacity) and went
+  // unnoticed until someone looked at the dark theme. These tests are the guard
+  // the compiler cannot be.
+  group('AppColors opacity', () {
+    test('every palette base colour is fully opaque', () {
+      _palettes.forEach((name, palette) {
+        expect(
+          palette.a,
+          1.0,
+          reason:
+              'AppColors.$name is not fully opaque: its literal is likely '
+              'missing a digit (it must be 8, as 0xAARRGGBB).',
+        );
+      });
+    });
+
+    test('every shade of every palette is fully opaque', () {
+      _palettes.forEach((name, palette) {
+        for (final shade in _shades) {
+          expect(
+            palette[shade]!.a,
+            1.0,
+            reason:
+                'AppColors.$name.shade$shade is not fully opaque: its literal '
+                'is likely missing a digit (it must be 8, as 0xAARRGGBB).',
+          );
+        }
+      });
+    });
+
+    test('warning holds the orange of its own ramp', () {
+      // The ramp itself pins the value down: 400 is 0xFFFFA726 and 600 is
+      // 0xFFF57C00, so 500 could only ever have been 0xFFFF9800.
+      // Compared as packed ARGB: `AppColors.warning` is a MaterialColor, which
+      // never equals a plain Color even when it paints the same pixels.
+      expect(AppColors.warning.toARGB32(), 0xFFFF9800);
+      expect(AppColors.warning.shade500.toARGB32(), 0xFFFF9800);
+    });
+  });
+}


### PR DESCRIPTION
# Descripción

El color base de la rampa de warning tenía **7 dígitos hexadecimales en vez de 8** (`0xFFFF980`). Dart lo lee como `0x0FFFF980`, es decir alpha `0x0F` ≈ **6 % de opacidad**: un naranja prácticamente invisible. Como `_warningValue` es a la vez `AppColors.warning` y su `shade500`, el defecto se propagaba a `_borderWarningSolid.dark` y `_fgWarningPrimary.dark` en `colors_values.dart`, así que en tema oscuro los bordes y el texto de aviso se pintaban casi transparentes.

Es un defecto que el compilador no puede atrapar: `0xFFFF980` es un entero perfectamente válido.

Cambios (rama `fix/DTA-004`):

1. **`_warningValue`: `0xFFFF980` → `0xFFFF9800`.** La propia rampa fija el valor sin ambigüedad — el `400` es `0xFFFFA726` y el `600` es `0xFFF57C00`, así que el `500` solo podía ser `0xFFFF9800`. Queda un comentario en el sitio recordando que el literal siempre lleva 8 dígitos.
2. **Auditoría de todos los literales hexadecimales de `lib/`**: se revisaron uno a uno con `grep -rnoE "0x[0-9a-fA-F]+" --include="*.dart" lib` filtrando por longitud. Este era el único malformado. Los dos únicos otros resultados (`currency.dart:49` y `:58`) son falsos positivos del grep: salen de la URL `https://placehold.co/600x400/png`, no son colores.
3. **Test de regresión** (`test/config/theme/colors_constants_test.dart`): recorre las **9 paletas** de `AppColors` y sus **10 tonos** cada una, y afirma opacidad total. Un literal al que se le caiga un dígito ahora rompe la suite en vez de la pantalla. Incluye además una aserción explícita del valor de `warning`.

**Fuera de alcance:** el valor duplicado entre rampas (`accent.shade500` == `warning.shade400` == `0xFFFFA726`, hallazgo MNT-11) queda anotado en #44 y no se toca aquí.

> ⚠️ Conviene mergear esto **antes** de #44: esa issue deriva un `ColorScheme` de la paleta actual, y si se deriva del valor roto el alpha se propaga al tema entero y cuesta mucho más rastrearlo.

Issue de GitHub relacionado: Closes #51

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad (cambio no-breaking que agrega funcionalidad)
- [x] 🛠️ Corrección de errores (cambio no-breaking que arregla un error)
- [ ] ❌ Cambio importante (arreglo o característica que haría que la funcionalidad existente no funcionara como se esperaba)
- [ ] 📝 Actualización de la documentación
- [ ] 🧹 Code refactoring (modificación de la estructura interna del código sin modificar las APIs)
- [ ] ✅ Build configuration change (modificación de los archivos para hacer deploy)
- [ ] 🗑️ Chore (actividades que no modifican la interacción con la app, por ejemplo, modificar el archivo de lints)

## ¿Cómo se ha probado esto?

- [x] `flutter test` — 46/46 en verde, incluidos los 3 casos nuevos de `AppColors opacity`.
- [x] Verificado que el test **falla** con el valor viejo: antes del fix, `every palette base colour is fully opaque` y `every shade…` reportan `AppColors.warning` con alpha ≠ 1.0.
- [x] `flutter analyze` — 9 issues, exactamente los mismos que en `development` (todos preexistentes: `withOpacity` deprecado, `unused_element_parameter`, `onHttpClientCreate` deprecado, import innecesario). Ninguno nuevo.
- [x] Auditoría de literales hexadecimales descrita arriba.
- [ ] **Pendiente de verificación visual** (requiere el reviewer, en dispositivo o emulador): que los bordes y el texto de warning se vean opacos en **tema oscuro** y sigan correctos en **tema claro**.

**Configuración de prueba**:

- Plataforma y versión de SO (Android / iOS): pendiente de la verificación visual.
- Dispositivo o emulador: pendiente.
- Tema (claro/oscuro) e idioma probados: el cambio es específico de **tema oscuro** (es donde se referencia `AppColors.warning` sin tono); el claro usa `shade600` y no estaba afectado. Independiente del idioma.

## Lista de Verificación

- [x] He agregado las nuevas dependencias (`pubspec.yaml`) en la descripción — no hay dependencias nuevas
- [x] He agregado las nuevas variables de entorno (solo los nombres) a la descripción — no hay variables nuevas
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código, particularmente en áreas difíciles de entender
- [x] He realizado los cambios correspondientes a la documentación
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente con mis cambios
- [ ] La app compila y el flujo afectado se probó en un dispositivo o emulador real — **pendiente**, ver arriba
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas — no aplica, no hay copy nueva
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper de cálculo, incluí sus tests en este mismo PR — no aplica; aun así se añadió test de regresión de la constante
- [x] No introduje modelos (`shared/data/model/`) en la UI ni en los controladores
