### PR TITLE
[🛠️ Fix: DTA-005] - Evitar la división entre cero del convertidor

### DIFF
--- a/lib/core/i18n/app_messages.dart
+++ b/lib/core/i18n/app_messages.dart
@@ -96,4 +96,6 @@ class AppMessages {
   static String get loadingError => 'loadingError'.tr;
 
   static String get retryAction => 'retryAction'.tr;
+
+  static String get conversionUnavailable => 'conversionUnavailable'.tr;
 }

--- a/lib/core/i18n/languages/de_de.dart
+++ b/lib/core/i18n/languages/de_de.dart
@@ -47,4 +47,5 @@ const Map<String, String> deDe = {
   'loadingError': 'Die Kurse konnten nicht geladen werden',
   'retryAction': 'Wiederholen',
   'marketAverage': 'Durchschnitt',
+  'conversionUnavailable': 'Für diese Umrechnung ist kein Kurs verfügbar',
 };

--- a/lib/core/i18n/languages/en_us.dart
+++ b/lib/core/i18n/languages/en_us.dart
@@ -47,4 +47,5 @@ const Map<String, String> enUs = {
   'loadingError': 'Rates could not be loaded',
   'retryAction': 'Retry',
   'marketAverage': 'Average',
+  'conversionUnavailable': 'No rate available for this conversion',
 };

--- a/lib/core/i18n/languages/es_es.dart
+++ b/lib/core/i18n/languages/es_es.dart
@@ -47,4 +47,5 @@ const Map<String, String> esEs = {
   'loadingError': 'No se pudieron cargar las tasas',
   'retryAction': 'Reintentar',
   'marketAverage': 'Promedio',
+  'conversionUnavailable': 'Tasa no disponible para esta conversión',
 };

--- a/lib/core/i18n/languages/fr_fr.dart
+++ b/lib/core/i18n/languages/fr_fr.dart
@@ -47,4 +47,5 @@ const Map<String, String> frFr = {
   'loadingError': 'Impossible de charger les taux',
   'retryAction': 'Réessayer',
   'marketAverage': 'Moyenne',
+  'conversionUnavailable': 'Taux indisponible pour cette conversion',
 };

--- a/lib/core/i18n/languages/it_it.dart
+++ b/lib/core/i18n/languages/it_it.dart
@@ -47,4 +47,5 @@ const Map<String, String> itIt = {
   'loadingError': 'Impossibile caricare i tassi',
   'retryAction': 'Riprova',
   'marketAverage': 'Media',
+  'conversionUnavailable': 'Tasso non disponibile per questa conversione',
 };

--- a/lib/core/i18n/languages/ja_jp.dart
+++ b/lib/core/i18n/languages/ja_jp.dart
@@ -48,4 +48,5 @@ const Map<String, String> jaJp = {
   'loadingError': 'レートを読み込めませんでした',
   'retryAction': '再試行',
   'marketAverage': '平均',
+  'conversionUnavailable': 'この換算に利用できるレートがありません',
 };

--- a/lib/core/i18n/languages/ko_kr.dart
+++ b/lib/core/i18n/languages/ko_kr.dart
@@ -47,4 +47,5 @@ const Map<String, String> koKr = {
   'loadingError': '환율을 불러올 수 없습니다',
   'retryAction': '다시 시도',
   'marketAverage': '평균',
+  'conversionUnavailable': '이 환전에 사용할 수 있는 환율이 없습니다',
 };

--- a/lib/core/i18n/languages/pt_pt.dart
+++ b/lib/core/i18n/languages/pt_pt.dart
@@ -48,4 +48,5 @@ const Map<String, String> ptPt = {
   'loadingError': 'Não foi possível carregar as taxas',
   'retryAction': 'Tentar novamente',
   'marketAverage': 'Média',
+  'conversionUnavailable': 'Taxa indisponível para esta conversão',
 };

--- a/lib/core/i18n/languages/ru_ru.dart
+++ b/lib/core/i18n/languages/ru_ru.dart
@@ -47,4 +47,5 @@ const Map<String, String> ruRu = {
   'loadingError': 'Не удалось загрузить курсы',
   'retryAction': 'Повторить',
   'marketAverage': 'Среднее',
+  'conversionUnavailable': 'Курс для этой конвертации недоступен',
 };

--- a/lib/core/i18n/languages/zh_cn.dart
+++ b/lib/core/i18n/languages/zh_cn.dart
@@ -47,4 +47,5 @@ const Map<String, String> zhCn = {
   'loadingError': '无法加载汇率',
   'retryAction': '重试',
   'marketAverage': '平均值',
+  'conversionUnavailable': '此换算暂无可用汇率',
 };

--- a/lib/features/converter/presentation/controller/converter_controller.dart
+++ b/lib/features/converter/presentation/controller/converter_controller.dart
@@ -113,6 +113,26 @@ class ConverterController extends GetxController {
   String getRoundedCurrency() =>
       "${fromCurrency.originalValue} ≈ ${toCurrency.originalValue}";
 
+  /// Whether the pair currently selected cannot produce a conversion.
+  ///
+  /// A rate of `0.0` reaches the app through ordinary paths — [Currency.empty]
+  /// declares `value: 0.00`, and the backend answers with a market that has no
+  /// data yet — and dividing doubles by zero does not throw in Dart: it yields
+  /// `Infinity`, or `NaN` when the dividend is zero too. The views read this
+  /// getter to say so instead of painting a meaningless number.
+  bool get isConversionUnavailable =>
+      !_isUsableRate(fromCurrency.currency.value) ||
+      !_isUsableRate(toCurrency.currency.value);
+
+  /// A rate can only take part in the conversion when it is finite and not
+  /// zero: zero cannot divide, and a non-finite rate poisons every result it
+  /// touches.
+  static bool _isUsableRate(double rate) => rate.isFinite && rate != 0.0;
+
+  /// Last line of defence before a value reaches the UI: `Infinity` and `NaN`
+  /// are formatted verbatim by `toString()`, so they never leave this class.
+  static double _sanitize(double value) => value.isFinite ? value : 0.0;
+
   bool? selectCurrency(Currency selected, {required bool isInput}) {
     final Currency current = isInput
         ? fromCurrency.currency
@@ -158,7 +178,11 @@ class ConverterController extends GetxController {
       final double toRate = newTo.value;
       final double fromRate = newFrom.value;
 
-      final double fromAmount = (toAmount * toRate) / fromRate;
+      // Same guard as [calculator]: this branch divides too, so a market with
+      // no rate would put `Infinity` in the input field.
+      final double fromAmount = _isUsableRate(fromRate) && _isUsableRate(toRate)
+          ? _sanitize((toAmount * toRate) / fromRate)
+          : 0.0;
       fromCurrency = fromCurrency.copyWith(convertedValue: fromAmount);
     } else {
       // Logic: Reset "From" to 1 (standard behavior), calculate "To"
@@ -200,7 +224,16 @@ class ConverterController extends GetxController {
     final double fromRate = fromCurrency.currency.value;
     final double toRate = toCurrency.currency.value;
 
-    final double result = (amount * fromRate) / toRate;
+    if (!_isUsableRate(fromRate) || !_isUsableRate(toRate)) {
+      // Dividing here would hand `Infinity` (or `NaN`) straight to the view.
+      // Zero is the honest placeholder; [isConversionUnavailable] is what tells
+      // the user the pair has no rate to convert with.
+      toCurrency = toCurrency.copyWith(convertedValue: 0.0);
+      update();
+      return;
+    }
+
+    final double result = _sanitize((amount * fromRate) / toRate);
 
     toCurrency = toCurrency.copyWith(convertedValue: result);
     update();

--- a/lib/features/converter/presentation/widget/converter_widgets.dart
+++ b/lib/features/converter/presentation/widget/converter_widgets.dart
@@ -41,6 +41,34 @@ class _CurrencyInputCard extends StatelessWidget {
               isInput: isInput,
               amount: currency.convertedValue.toString(),
             ),
+            // A market with no rate yields 0.0 instead of a conversion, and a
+            // bare 0 reads like a legitimate result. Only the output card says
+            // so: repeating it on both sides is noise.
+            if (!isInput && controller.isConversionUnavailable) ...[
+              const SizedBox(height: 8),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.error_outline,
+                    size: 16,
+                    color: ColorValues.textWarningPrimary(context),
+                  ),
+                  const SizedBox(width: 8),
+                  Flexible(
+                    child: Text(
+                      AppMessages.conversionUnavailable,
+                      style: TextStyle(
+                        color: ColorValues.textWarningPrimary(context),
+                        fontSize: 12,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+            ],
           ],
         ),
       ),

--- a/test/features/converter/converter_controller_calculator_test.dart
+++ b/test/features/converter/converter_controller_calculator_test.dart
@@ -33,6 +33,15 @@ void main() {
     value: 36.5,
   );
 
+  // A market the backend knows about but has no rate for yet. `Currency.empty`
+  // ships the same `value: 0.00`, so this is not a synthetic case.
+  const zeroRate = Currency(
+    name: 'No data',
+    keyName: 'ZRO',
+    platform: 'Test',
+    value: 0.0,
+  );
+
   setUp(() {
     Get.testMode = true;
     Get.put<IDollarRepository>(_FakeDollarRepository());
@@ -138,6 +147,81 @@ void main() {
       arrangeCurrencies(from: vesRate, to: usdRate);
       controller.calculator('50');
       expect(controller.toCurrency.currency.keyName, 'USD');
+    });
+  });
+
+  // Dividing doubles by zero does not throw in Dart: it evaluates to
+  // `Infinity`, or to `NaN` when the dividend is zero as well. Both used to
+  // reach `convertedValue` and get printed verbatim by the view.
+  group('calculator() with an unusable rate', () {
+    test('a zero destination rate does not produce Infinity', () {
+      arrangeCurrencies(from: vesRate, to: zeroRate);
+      controller.calculator('100');
+
+      expect(controller.toCurrency.convertedValue.isFinite, isTrue);
+      expect(controller.toCurrency.convertedValue, 0.0);
+    });
+
+    test('a zero source rate does not produce a meaningless result', () {
+      arrangeCurrencies(from: zeroRate, to: usdRate);
+      controller.calculator('100');
+
+      expect(controller.toCurrency.convertedValue.isFinite, isTrue);
+      expect(controller.toCurrency.convertedValue, 0.0);
+    });
+
+    test('both rates at zero do not produce NaN', () {
+      arrangeCurrencies(from: zeroRate, to: zeroRate);
+      controller.calculator('100');
+
+      expect(controller.toCurrency.convertedValue.isNaN, isFalse);
+      expect(controller.toCurrency.convertedValue, 0.0);
+    });
+
+    test('the typed amount is still echoed on the input side', () {
+      // The user's own number must not be swallowed by the guard: only the
+      // conversion is unavailable, not the input.
+      arrangeCurrencies(from: vesRate, to: zeroRate);
+      controller.calculator('100');
+
+      expect(controller.fromCurrency.convertedValue, 100.0);
+    });
+
+    test('an unusable rate raises isConversionUnavailable', () {
+      arrangeCurrencies(from: vesRate, to: zeroRate);
+      expect(controller.isConversionUnavailable, isTrue);
+
+      arrangeCurrencies(from: zeroRate, to: usdRate);
+      expect(controller.isConversionUnavailable, isTrue);
+    });
+
+    test('a normal pair leaves isConversionUnavailable down', () {
+      arrangeCurrencies(from: vesRate, to: usdRate);
+      controller.calculator('100');
+
+      expect(controller.isConversionUnavailable, isFalse);
+      expect(controller.toCurrency.convertedValue.isFinite, isTrue);
+    });
+
+    test('swapping into a zero rate does not produce Infinity', () {
+      // swapCurrencies() re-invokes calculator() with the converted value, so
+      // it walks the same division.
+      arrangeCurrencies(from: zeroRate, to: usdRate);
+      controller.swapCurrencies();
+
+      expect(controller.toCurrency.convertedValue.isFinite, isTrue);
+      expect(controller.toCurrency.currency.keyName, 'ZRO');
+    });
+
+    test('selecting an output against a zero source does not divide by it', () {
+      // The reverse calculation of selectCurrency() divides by the source rate.
+      // Picking VES as output keeps the zero-rate currency as the source, so
+      // the pivot rule does not replace it and the division is reached.
+      arrangeCurrencies(from: zeroRate, to: usdRate);
+      controller.selectCurrency(vesRate, isInput: false);
+
+      expect(controller.fromCurrency.convertedValue.isFinite, isTrue);
+      expect(controller.fromCurrency.convertedValue, 0.0);
     });
   });
 }


### PR DESCRIPTION
# Descripción

`ConverterController.calculator()` dividía entre la tasa destino sin verificarla:

```dart
final double result = (amount * fromRate) / toRate;   // toRate puede ser 0.0
```

En Dart la división de `double` entre cero **no lanza excepción**: devuelve `Infinity`, o `NaN` cuando el dividendo también es cero. Ese valor se propagaba a `toCurrency.convertedValue` y la vista lo imprimía tal cual (`_CurrencyInputCard` pinta `currency.convertedValue.toString()`), así que la calculadora mostraba literalmente `Infinity` en pantalla.

El caso es alcanzable: `Currency.empty` declara `value: 0.00`, y una moneda puede llegar con valor cero si el backend devuelve una fuente sin datos.

Cambios (rama `fix/DTA-005`):

1. **Guard antes de dividir en `calculator()`**: si la tasa origen o la destino no son usables (cero o no finitas), no se divide; el resultado queda en `0.0` y se marca la conversión como no disponible.
2. **El mismo guard en el cálculo inverso de `selectCurrency()`** (`(toAmount * toRate) / fromRate`, línea 161 del original), que tenía exactamente el mismo agujero y que la issue no mencionaba explícitamente pero cae bajo el criterio de "por cualquier otra vía".
3. **Saneado del resultado** (`_sanitize`): última línea de defensa, `Infinity`/`NaN` no salen del controlador por ninguna ruta antes de formatearse.
4. **Estado claro para el usuario**: `isConversionUnavailable` es un getter **derivado** de las tasas del par seleccionado — no un flag que haya que mantener sincronizado, así que es correcto en todas las rutas (`calculator`, `swapCurrencies`, `selectCurrency`) sin cablearlo en cada una. La tarjeta de salida muestra un aviso con icono cuando está activo: un `0` pelado se lee como un resultado legítimo, y ése era justamente el riesgo.
5. **i18n**: clave `conversionUnavailable` añadida a **los 10 idiomas** en la misma posición relativa, más su getter en `AppMessages`. Paridad verificada con el script de `i18n-convention.md`: **49 claves, paridad OK** en los 10 archivos.
6. **Tests** (8 casos nuevos): tasa destino cero, tasa origen cero, ambas en cero (el caso `NaN`), el monto tecleado que debe seguir llegando al lado de entrada, `isConversionUnavailable` arriba y abajo, el camino de `swapCurrencies` y el cálculo inverso de `selectCurrency`.

Detalle de implementación: el aviso usa `ColorValues.textWarningPrimary` (que resuelve a `warning.shade400`) y **no** `fgWarningPrimary`, porque ese último resuelve en oscuro a `AppColors.warning`, la constante con el alpha roto que corrige #51. Así el aviso se ve correctamente tanto antes como después de que #51 se mergee.

Issue de GitHub relacionado: Closes #15

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad (cambio no-breaking que agrega funcionalidad)
- [x] 🛠️ Corrección de errores (cambio no-breaking que arregla un error)
- [ ] ❌ Cambio importante (arreglo o característica que haría que la funcionalidad existente no funcionara como se esperaba)
- [ ] 📝 Actualización de la documentación
- [ ] 🧹 Code refactoring (modificación de la estructura interna del código sin modificar las APIs)
- [ ] ✅ Build configuration change (modificación de los archivos para hacer deploy)
- [ ] 🗑️ Chore (actividades que no modifican la interacción con la app, por ejemplo, modificar el archivo de lints)

## ¿Cómo se ha probado esto?

- [x] `flutter test` — toda la suite en verde; el grupo del convertidor pasa de 10 a **18** casos.
- [x] **Verificado que los tests atrapan el bug**: neutralizando los dos guards (dejando el getter para que compile), fallan 4 de los casos nuevos. Los tests no son decorativos.
- [x] `flutter analyze` — 9 issues, exactamente los mismos que en `development` (todos preexistentes). **0** en los archivos tocados.
- [x] Paridad i18n verificada con el script de `i18n-convention.md`: 49 claves en los 10 archivos, sin desincronización.
- [x] Verificado que no se introdujo deriva de formato: los dos archivos que `dart format` marca como cambiados (`converter_widgets.dart` y el test) ya lo estaban en `development` antes de este PR; el resto queda limpio.
- [ ] **Pendiente de verificación manual** (requiere el reviewer, en dispositivo o emulador): seleccionar un mercado sin datos como destino y confirmar que aparece el aviso y **no** `Infinity`; probar también el swap y el selector de salida.

**Configuración de prueba**:

- Plataforma y versión de SO (Android / iOS): pendiente de la verificación manual.
- Dispositivo o emulador: pendiente.
- Tema (claro/oscuro) e idioma probados: el aviso se probará en claro y oscuro. **Ojo con el alemán** (`Für diese Umrechnung ist kein Kurs verfügbar`) y el ruso, que son los más largos; el texto va en `Flexible` con `maxLines: 2` y `overflow: ellipsis` precisamente por eso.

## Lista de Verificación

- [x] He agregado las nuevas dependencias (`pubspec.yaml`) en la descripción — no hay dependencias nuevas
- [x] He agregado las nuevas variables de entorno (solo los nombres) a la descripción — no hay variables nuevas
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código, particularmente en áreas difíciles de entender
- [x] He realizado los cambios correspondientes a la documentación
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente con mis cambios
- [ ] La app compila y el flujo afectado se probó en un dispositivo o emulador real — **pendiente**, ver arriba
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas (ver `i18n-convention.md`) — sí, verificado con el script
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper de cálculo, incluí sus tests en este mismo PR (ver `test-coverage.md`)
- [x] No introduje modelos (`shared/data/model/`) en la UI ni en los controladores (ver `entities-vs-models.md`)
