### PR TITLE
[🛠️ Fix: DTA-006] - Validar CURRENCY_BACK al arrancar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ Entities live in `shared/domain/entities/` and `features/*/domain/entities/`. JS
 
 ## Internationalization
 
-10 languages via GetX `Translations`. Language maps in `lib/core/i18n/languages/` (48 keys, all ten in parity, and `AppMessages` exposes exactly those 48). Use `AppMessages.<key>` for all UI text — never a raw string, and never `'<key>'.tr` in a widget: `app_messages.dart` is the only file that calls `.tr`. A new key goes into all ten files in the same commit, or GetX renders the raw key on screen for the other nine.
+10 languages via GetX `Translations`. Language maps in `lib/core/i18n/languages/` (51 keys, all ten in parity, and `AppMessages` exposes exactly those 51). Use `AppMessages.<key>` for all UI text — never a raw string, and never `'<key>'.tr` in a widget: `app_messages.dart` is the only file that calls `.tr`. A new key goes into all ten files in the same commit, or GetX renders the raw key on screen for the other nine.
 
 ## Routing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ Entities live in `shared/domain/entities/` and `features/*/domain/entities/`. JS
 
 ## Internationalization
 
-10 languages via GetX `Translations`. Language maps in `lib/core/i18n/languages/` (48 keys, all ten in parity, and `AppMessages` exposes exactly those 48). Use `AppMessages.<key>` for all UI text — never a raw string, and never `'<key>'.tr` in a widget: `app_messages.dart` is the only file that calls `.tr`. A new key goes into all ten files in the same commit, or GetX renders the raw key on screen for the other nine.
+10 languages via GetX `Translations`. Language maps in `lib/core/i18n/languages/` (51 keys, all ten in parity, and `AppMessages` exposes exactly those 51). Use `AppMessages.<key>` for all UI text — never a raw string, and never `'<key>'.tr` in a widget: `app_messages.dart` is the only file that calls `.tr`. A new key goes into all ten files in the same commit, or GetX renders the raw key on screen for the other nine.
 
 ## Routing
 

--- a/lib/config/enviroment/enviroment.dart
+++ b/lib/config/enviroment/enviroment.dart
@@ -1,13 +1,96 @@
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
+/// Why the configuration the app was built with cannot be used.
+enum EnvironmentIssue {
+  /// The variable is absent from the `.env`, or holds only whitespace. Also
+  /// what a missing `.env` file altogether looks like from here.
+  missing,
+
+  /// The variable is there but is not an absolute `http`/`https` URL, so Dio
+  /// would build a relative request and fail much later, as a network error.
+  notAbsoluteUrl,
+}
+
+/// A configuration problem detected at startup, before anything tries to use it.
+///
+/// Carries the name of the offending variable and what is wrong with it — never
+/// its value. Printing the configured URL on screen would leak a private
+/// deployment address into a screenshot or a bug report.
+class EnvironmentError {
+  const EnvironmentError({required this.variable, required this.issue});
+
+  /// Name of the environment variable, as written in `.env.example`.
+  final String variable;
+
+  final EnvironmentIssue issue;
+
+  /// Developer-facing diagnostic. Never shown in a release build: it names the
+  /// project's own files, which means nothing to a user.
+  String get developerMessage => switch (issue) {
+    EnvironmentIssue.missing =>
+      'Falta la variable $variable.\n\n'
+          'Copia la plantilla y completa el valor:\n'
+          '    cp .env.example .env\n\n'
+          'Debe ser la URL base del backend, sin barra final.',
+    EnvironmentIssue.notAbsoluteUrl =>
+      '$variable no es una URL absoluta.\n\n'
+          'Tiene que empezar por http:// o https:// e incluir el host, '
+          'sin barra final.\n\n'
+          'Revisa el valor en tu .env (formato en .env.example).',
+  };
+
+  @override
+  String toString() => 'EnvironmentError($variable, ${issue.name})';
+}
+
 class Environment {
+  /// Key of the backend URL in `.env`. Kept as a constant because both the
+  /// getter and the validation name it, and a typo in either would be silent.
+  static const String currencyBackKey = 'CURRENCY_BACK';
+
   /// Base URL of the currency backend, without trailing slashes.
   ///
   /// Endpoint paths are absolute (`/api/v1/...`), so a trailing slash in the
   /// `.env` value would build `//api/v1/...`, which the backend answers with a
   /// 308 redirect instead of serving the resource.
-  static String get currency => normalizeBaseUrl(dotenv.env['CURRENCY_BACK']);
+  static String get currency => normalizeBaseUrl(dotenv.env[currencyBackKey]);
 
   static String normalizeBaseUrl(String? value) =>
       (value ?? '').trim().replaceAll(RegExp(r'/+$'), '');
+
+  /// Checks the configuration the app cannot run without, and returns the first
+  /// problem found — or `null` when everything is in place.
+  ///
+  /// This runs at startup, right after `dotenv.load`, because the alternative is
+  /// failing **late**: with no `CURRENCY_BACK`, [currency] is the empty string,
+  /// Dio builds a request against a relative URL and the user gets a generic
+  /// network error that never mentions that a variable is missing.
+  static EnvironmentError? validate() {
+    final raw = normalizeBaseUrl(dotenv.env[currencyBackKey]);
+
+    if (raw.isEmpty) {
+      return const EnvironmentError(
+        variable: currencyBackKey,
+        issue: EnvironmentIssue.missing,
+      );
+    }
+
+    if (!_isAbsoluteHttpUrl(raw)) {
+      return const EnvironmentError(
+        variable: currencyBackKey,
+        issue: EnvironmentIssue.notAbsoluteUrl,
+      );
+    }
+
+    return null;
+  }
+
+  /// A base URL is only usable when it carries the scheme and the host: without
+  /// them `Uri.parse` still succeeds, and the value silently becomes a path.
+  static bool _isAbsoluteHttpUrl(String value) {
+    final uri = Uri.tryParse(value);
+    if (uri == null) return false;
+    return (uri.scheme == 'http' || uri.scheme == 'https') &&
+        uri.host.isNotEmpty;
+  }
 }

--- a/lib/core/i18n/app_messages.dart
+++ b/lib/core/i18n/app_messages.dart
@@ -98,4 +98,8 @@ class AppMessages {
   static String get retryAction => 'retryAction'.tr;
 
   static String get conversionUnavailable => 'conversionUnavailable'.tr;
+
+  static String get configErrorTitle => 'configErrorTitle'.tr;
+
+  static String get configErrorBody => 'configErrorBody'.tr;
 }

--- a/lib/core/i18n/languages/de_de.dart
+++ b/lib/core/i18n/languages/de_de.dart
@@ -48,4 +48,7 @@ const Map<String, String> deDe = {
   'retryAction': 'Wiederholen',
   'marketAverage': 'Durchschnitt',
   'conversionUnavailable': 'Für diese Umrechnung ist kein Kurs verfügbar',
+  'configErrorTitle': 'Unvollständige Konfiguration',
+  'configErrorBody':
+      'Die App ist nicht korrekt konfiguriert und kann die Kurse nicht abrufen. Wenden Sie sich an die Person, die sie bereitstellt.',
 };

--- a/lib/core/i18n/languages/en_us.dart
+++ b/lib/core/i18n/languages/en_us.dart
@@ -48,4 +48,7 @@ const Map<String, String> enUs = {
   'retryAction': 'Retry',
   'marketAverage': 'Average',
   'conversionUnavailable': 'No rate available for this conversion',
+  'configErrorTitle': 'Incomplete configuration',
+  'configErrorBody':
+      'The app is not configured correctly and cannot fetch the rates. Contact whoever distributes it.',
 };

--- a/lib/core/i18n/languages/es_es.dart
+++ b/lib/core/i18n/languages/es_es.dart
@@ -48,4 +48,7 @@ const Map<String, String> esEs = {
   'retryAction': 'Reintentar',
   'marketAverage': 'Promedio',
   'conversionUnavailable': 'Tasa no disponible para esta conversión',
+  'configErrorTitle': 'Configuración incompleta',
+  'configErrorBody':
+      'La app no se ha configurado correctamente y no puede consultar las tasas. Contacta con quien la distribuye.',
 };

--- a/lib/core/i18n/languages/fr_fr.dart
+++ b/lib/core/i18n/languages/fr_fr.dart
@@ -48,4 +48,7 @@ const Map<String, String> frFr = {
   'retryAction': 'Réessayer',
   'marketAverage': 'Moyenne',
   'conversionUnavailable': 'Taux indisponible pour cette conversion',
+  'configErrorTitle': 'Configuration incomplète',
+  'configErrorBody':
+      'L\'application n\'est pas correctement configurée et ne peut pas récupérer les taux. Contactez la personne qui la distribue.',
 };

--- a/lib/core/i18n/languages/it_it.dart
+++ b/lib/core/i18n/languages/it_it.dart
@@ -48,4 +48,7 @@ const Map<String, String> itIt = {
   'retryAction': 'Riprova',
   'marketAverage': 'Media',
   'conversionUnavailable': 'Tasso non disponibile per questa conversione',
+  'configErrorTitle': 'Configurazione incompleta',
+  'configErrorBody':
+      'L\'app non è configurata correttamente e non può recuperare i tassi. Contatta chi la distribuisce.',
 };

--- a/lib/core/i18n/languages/ja_jp.dart
+++ b/lib/core/i18n/languages/ja_jp.dart
@@ -49,4 +49,7 @@ const Map<String, String> jaJp = {
   'retryAction': '再試行',
   'marketAverage': '平均',
   'conversionUnavailable': 'この換算に利用できるレートがありません',
+  'configErrorTitle': '設定が不完全です',
+  'configErrorBody':
+      'アプリが正しく設定されておらず、レートを取得できません。配布元にお問い合わせください。',
 };

--- a/lib/core/i18n/languages/ko_kr.dart
+++ b/lib/core/i18n/languages/ko_kr.dart
@@ -48,4 +48,7 @@ const Map<String, String> koKr = {
   'retryAction': '다시 시도',
   'marketAverage': '평균',
   'conversionUnavailable': '이 환전에 사용할 수 있는 환율이 없습니다',
+  'configErrorTitle': '설정이 완료되지 않았습니다',
+  'configErrorBody':
+      '앱이 올바르게 설정되지 않아 환율을 가져올 수 없습니다. 배포자에게 문의하세요.',
 };

--- a/lib/core/i18n/languages/pt_pt.dart
+++ b/lib/core/i18n/languages/pt_pt.dart
@@ -49,4 +49,7 @@ const Map<String, String> ptPt = {
   'retryAction': 'Tentar novamente',
   'marketAverage': 'Média',
   'conversionUnavailable': 'Taxa indisponível para esta conversão',
+  'configErrorTitle': 'Configuração incompleta',
+  'configErrorBody':
+      'A aplicação não está configurada corretamente e não consegue obter as taxas. Contacte quem a distribui.',
 };

--- a/lib/core/i18n/languages/ru_ru.dart
+++ b/lib/core/i18n/languages/ru_ru.dart
@@ -48,4 +48,7 @@ const Map<String, String> ruRu = {
   'retryAction': 'Повторить',
   'marketAverage': 'Среднее',
   'conversionUnavailable': 'Курс для этой конвертации недоступен',
+  'configErrorTitle': 'Неполная конфигурация',
+  'configErrorBody':
+      'Приложение настроено неверно и не может получить курсы. Свяжитесь с тем, кто его распространяет.',
 };

--- a/lib/core/i18n/languages/zh_cn.dart
+++ b/lib/core/i18n/languages/zh_cn.dart
@@ -48,4 +48,6 @@ const Map<String, String> zhCn = {
   'retryAction': '重试',
   'marketAverage': '平均值',
   'conversionUnavailable': '此换算暂无可用汇率',
+  'configErrorTitle': '配置不完整',
+  'configErrorBody': '应用未正确配置，无法获取汇率。请联系分发方。',
 };

--- a/lib/features/splash/presentation/page/configuration_error_page.dart
+++ b/lib/features/splash/presentation/page/configuration_error_page.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../../../../config/enviroment/enviroment.dart';
+import '../../../../core/i18n/app_messages.dart';
+
+/// Shown instead of the app when the build has no usable configuration.
+///
+/// It replaces what used to happen: the app started, asked for the rates
+/// against a relative URL and surfaced a generic network error that never
+/// mentioned a missing variable. The two audiences need different things, so
+/// the page serves them differently — the developer gets the diagnostic, the
+/// user gets a plain statement. Neither ever sees the configured URL.
+class ConfigurationErrorPage extends StatelessWidget {
+  const ConfigurationErrorPage({required this.error, super.key});
+
+  final EnvironmentError error;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                const Icon(Icons.settings_ethernet, size: 56),
+                const SizedBox(height: 24),
+                Text(
+                  AppMessages.configErrorTitle,
+                  style: Theme.of(context).textTheme.titleLarge,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  AppMessages.configErrorBody,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                  textAlign: TextAlign.center,
+                ),
+                // The diagnostic names the project's own files and is written
+                // for whoever builds the app, so it is compiled out of release
+                // by `kDebugMode` — a user cannot act on it, and it would only
+                // expose how the app is wired.
+                if (kDebugMode) ...[
+                  const SizedBox(height: 32),
+                  Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      border: Border.all(color: Theme.of(context).dividerColor),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Text(
+                      error.developerMessage,
+                      style: const TextStyle(
+                        fontFamily: 'monospace',
+                        fontSize: 12,
+                      ),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,17 +9,58 @@ import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
 
 import 'config/bindings/initial_bindings.dart';
+import 'config/enviroment/enviroment.dart';
 import 'core/constants/constants.dart';
 import 'core/i18n/app_translations.dart';
+import 'features/splash/presentation/page/configuration_error_page.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await dotenv.load(fileName: ".env");
+
+  // `isOptional` keeps a missing `.env` from throwing: from the app's point of
+  // view an absent file is the same situation as an undefined variable, and the
+  // check below reports it as such instead of crashing with a stack trace.
+  await dotenv.load(fileName: ".env", isOptional: true);
+
+  // Validated before anything can use it: without a backend URL every screen
+  // would fail later as a generic network error that never names the variable.
+  final EnvironmentError? configError = Environment.validate();
+  if (configError != null) {
+    runApp(ConfigurationErrorApp(error: configError));
+    return;
+  }
+
   Get.put(SettingsController());
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
   runApp(const MyApp());
+}
+
+/// Minimal app shown when the configuration is unusable.
+///
+/// It brings up translations and the theme so the page reads like the rest of
+/// the app, but registers no bindings: every dependency below `InitialBinding`
+/// needs the backend URL that is precisely what is missing.
+class ConfigurationErrorApp extends StatelessWidget {
+  const ConfigurationErrorApp({required this.error, super.key});
+
+  final EnvironmentError error;
+
+  @override
+  Widget build(BuildContext context) {
+    return GetMaterialApp(
+      debugShowCheckedModeBanner: false,
+      title: Constants.appTitle,
+      home: ConfigurationErrorPage(error: error),
+      theme: AppTheme.lightTheme,
+      darkTheme: AppTheme.darkTheme,
+      themeMode: ThemeMode.system,
+      locale: Get.deviceLocale,
+      fallbackLocale: const Locale('en', 'US'),
+      translations: AppTranslations(),
+    );
+  }
 }
 
 class MyApp extends StatelessWidget {

--- a/test/config/enviroment/environment_test.dart
+++ b/test/config/enviroment/environment_test.dart
@@ -1,0 +1,120 @@
+import 'package:bcv_tracker_app/config/enviroment/enviroment.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Replaces the contents of the `.env` for the duration of a test.
+void loadEnv(String contents) => dotenv.testLoad(fileInput: contents);
+
+void main() {
+  // An empty file is what a missing `.env` looks like from `Environment`:
+  // `main()` folds the load failure into the same case.
+  tearDown(() => loadEnv(''));
+
+  group('validate() rejects', () {
+    test('a variable that is not defined at all', () {
+      loadEnv('SOME_OTHER_KEY=whatever');
+
+      final error = Environment.validate();
+      expect(error, isNotNull);
+      expect(error!.variable, 'CURRENCY_BACK');
+      expect(error.issue, EnvironmentIssue.missing);
+    });
+
+    test('an empty value', () {
+      loadEnv('CURRENCY_BACK=');
+
+      expect(Environment.validate()?.issue, EnvironmentIssue.missing);
+    });
+
+    test('a value that is only whitespace', () {
+      loadEnv('CURRENCY_BACK="   "');
+
+      expect(Environment.validate()?.issue, EnvironmentIssue.missing);
+    });
+
+    test('a URL with no scheme', () {
+      // The case that used to slip through: Dio builds a relative request and
+      // the failure only shows up later, as a generic network error.
+      loadEnv('CURRENCY_BACK=backend.example.com');
+
+      expect(Environment.validate()?.issue, EnvironmentIssue.notAbsoluteUrl);
+    });
+
+    test('a scheme that is not http or https', () {
+      loadEnv('CURRENCY_BACK=ftp://backend.example.com');
+
+      expect(Environment.validate()?.issue, EnvironmentIssue.notAbsoluteUrl);
+    });
+
+    test('a URL with a scheme but no host', () {
+      // `Uri.parse` accepts this happily, which is why the host is checked.
+      loadEnv('CURRENCY_BACK=https://');
+
+      expect(Environment.validate()?.issue, EnvironmentIssue.notAbsoluteUrl);
+    });
+  });
+
+  group('validate() accepts', () {
+    test('an absolute https URL', () {
+      loadEnv('CURRENCY_BACK=https://backend.example.com');
+
+      expect(Environment.validate(), isNull);
+    });
+
+    test('an absolute http URL, port included', () {
+      // How the backend is reached from an emulator against a local machine.
+      loadEnv('CURRENCY_BACK=http://10.0.2.2:8000');
+
+      expect(Environment.validate(), isNull);
+    });
+
+    test('a URL with trailing slashes, which normalizeBaseUrl trims', () {
+      loadEnv('CURRENCY_BACK=https://backend.example.com//');
+
+      expect(Environment.validate(), isNull);
+      expect(Environment.currency, 'https://backend.example.com');
+    });
+  });
+
+  group('the reported error', () {
+    test('names the variable and how to define it, never its value', () {
+      loadEnv('CURRENCY_BACK=https://private-deploy.internal');
+      // Force the malformed branch with a value that must not be echoed.
+      loadEnv('CURRENCY_BACK=private-deploy.internal');
+
+      final message = Environment.validate()!.developerMessage;
+
+      expect(message, contains('CURRENCY_BACK'));
+      expect(message, contains('.env'));
+      // Printing the configured URL would leak a private deployment address
+      // into any screenshot or bug report.
+      expect(message, isNot(contains('private-deploy.internal')));
+    });
+
+    test('tells a missing variable apart from a malformed one', () {
+      loadEnv('');
+      final missing = Environment.validate()!.developerMessage;
+
+      loadEnv('CURRENCY_BACK=nope');
+      final malformed = Environment.validate()!.developerMessage;
+
+      expect(missing, isNot(malformed));
+      expect(missing, contains('cp .env.example .env'));
+      expect(malformed, contains('https://'));
+    });
+  });
+
+  group('normalizeBaseUrl()', () {
+    test('trims whitespace and every trailing slash', () {
+      expect(
+        Environment.normalizeBaseUrl('  https://backend.example.com///  '),
+        'https://backend.example.com',
+      );
+    });
+
+    test('turns a null or empty value into the empty string', () {
+      expect(Environment.normalizeBaseUrl(null), '');
+      expect(Environment.normalizeBaseUrl('   '), '');
+    });
+  });
+}


### PR DESCRIPTION
# Descripción

`Environment.currency` leía la URL del backend sin validarla. Si `CURRENCY_BACK` no estaba definida, el resultado era la cadena vacía, Dio terminaba construyendo la petición contra una URL relativa y el fallo aparecía **tarde**: llegaba a la UI como un error de red genérico que en ningún momento decía que faltaba una variable de configuración. Un valor sin esquema (`backend.example.com`) fallaba exactamente igual.

Cambios (rama `fix/DTA-006`):

1. **`Environment.validate()`** devuelve el primer problema encontrado, o `null` si todo está en su sitio. Distingue dos casos: variable ausente (que incluye el `.env` inexistente) y valor que no es una URL absoluta `http`/`https` **con host** — `Uri.parse` acepta `https://` sin host tan contento, por eso se comprueba el host aparte.
2. **La validación corre en `main()`**, justo después de `dotenv.load` y **antes** de registrar ninguna dependencia: todo lo que cuelga de `InitialBinding` necesita precisamente la URL que falta.
3. **`dotenv.load(..., isOptional: true)`**: un `.env` ausente ya no lanza `FileNotFoundError`. Desde el punto de vista de la app un archivo que no está es lo mismo que una variable sin definir, y ahora se reporta como tal en vez de reventar con un stack trace.
4. **`ConfigurationErrorPage`** sustituye a la app cuando la configuración no sirve. Atiende a las dos audiencias por separado:
   - **Usuario** (siempre): título y mensaje traducidos, sin jerga.
   - **Desarrollador** (solo bajo `kDebugMode`): el diagnóstico que nombra la variable y dice `cp .env.example .env`. Se compila fuera del build de release porque un usuario no puede actuar sobre él y solo expondría cómo está cableada la app.
   - **Ninguna de las dos muestra la URL configurada.** Imprimirla filtraría una dirección de despliegue privada a cualquier captura o reporte de bug. Hay un test que lo afirma explícitamente.
5. **i18n**: `configErrorTitle` y `configErrorBody` en **los 10 idiomas** en la misma posición relativa, más sus getters en `AppMessages`. Verificado con el script de `i18n-convention.md`: **51 claves, paridad OK**, y `AppMessages` expone exactamente esas 51.
6. **Tests** (`test/config/enviroment/environment_test.dart`, 13 casos): variable ausente, vacía, solo espacios, sin esquema, con esquema no-http, con esquema pero sin host; los casos válidos (https, http con puerto — como se alcanza el backend desde un emulador —, y con barras finales que `normalizeBaseUrl` recorta); y dos casos sobre el mensaje: que nombre la variable y el `.env` **sin** echar el valor configurado, y que distinga variable ausente de variable malformada.

**Fuera de alcance, como indicaba la issue:** no se cambia cómo se cargan las variables ni se añade ninguna nueva.

### Notas

- **No hay variables de entorno nuevas**, así que el checklist de `environment-variables.md` no obliga a tocar `.env.example`, `README.md` ni `codemagic.yaml`. Los tres ya documentan `CURRENCY_BACK` correctamente y siguen consistentes. Lo que sí queda cubierto por fin es el punto 5 de ese checklist ("Validación al arrancar"), que hasta ahora estaba escrito en la regla pero no implementado.
- `ConfigurationErrorPage` se monta como `home:` de una `GetMaterialApp` mínima, igual que `MyApp` hace con `SplashPage`. No se le da ruta en `AppRoutes`/`AppPages` a propósito: no se navega hacia ella, sustituye a la app entera, y esa app alternativa no registra rutas ni bindings.

Issue de GitHub relacionado: Closes #16

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad (cambio no-breaking que agrega funcionalidad)
- [x] 🛠️ Corrección de errores (cambio no-breaking que arregla un error)
- [ ] ❌ Cambio importante (arreglo o característica que haría que la funcionalidad existente no funcionara como se esperaba)
- [ ] 📝 Actualización de la documentación
- [ ] 🧹 Code refactoring (modificación de la estructura interna del código sin modificar las APIs)
- [ ] ✅ Build configuration change (modificación de los archivos para hacer deploy)
- [ ] 🗑️ Chore (actividades que no modifican la interacción con la app, por ejemplo, modificar el archivo de lints)

## ¿Cómo se ha probado esto?

- [x] `flutter test` — toda la suite en verde, con los 13 casos nuevos de `Environment`.
- [x] `flutter analyze` — 8 issues, exactamente los mismos que en `development` (todos preexistentes). **0** en los archivos tocados.
- [x] Paridad i18n verificada con el script de `i18n-convention.md`: 51 claves en los 10 archivos, y `AppMessages` expone exactamente ese conjunto (diferencia: ninguna).
- [x] Verificado que no se introdujo deriva de formato: los archivos que `dart format` marca como cambiados son exactamente los mismos que en `development` antes de este PR.
- [x] Verificado que `.env` está declarado como asset en `pubspec.yaml`, que es lo que hace que `dotenv.load` funcione en un build real.
- [ ] **Pendiente de verificación manual** (requiere el reviewer, en dispositivo o emulador):
  - Renombrar el `.env` y arrancar → debe salir la pantalla de configuración, con el bloque de diagnóstico visible en debug.
  - Poner `CURRENCY_BACK=backend.example.com` (sin esquema) → misma pantalla, con el diagnóstico del caso malformado.
  - Restaurar un `.env` válido → la app arranca con normalidad.
  - Un build de **release** con `.env` roto → debe verse el mensaje de usuario y **no** el bloque de diagnóstico.

**Configuración de prueba**:

- Plataforma y versión de SO (Android / iOS): pendiente de la verificación manual.
- Dispositivo o emulador: pendiente.
- Tema (claro/oscuro) e idioma probados: la pantalla usa `Theme.of(context)` y respeta claro/oscuro. **Ojo con el ruso** (`configErrorBody` es el más largo, 200 caracteres) y el alemán; el texto va centrado dentro de un `SingleChildScrollView`, así que desborda hacia el scroll en vez de romper el layout.

## Lista de Verificación

- [x] He agregado las nuevas dependencias (`pubspec.yaml`) en la descripción — no hay dependencias nuevas
- [x] He agregado las nuevas variables de entorno (solo los nombres) a la descripción — **no hay variables nuevas**; este PR solo valida la que ya existe, `CURRENCY_BACK`
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código, particularmente en áreas difíciles de entender
- [x] He realizado los cambios correspondientes a la documentación
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente con mis cambios
- [ ] La app compila y el flujo afectado se probó en un dispositivo o emulador real — **pendiente**, ver arriba
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas (ver `i18n-convention.md`) — sí, verificado con el script
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper de cálculo, incluí sus tests en este mismo PR (ver `test-coverage.md`)
- [x] No introduje modelos (`shared/data/model/`) en la UI ni en los controladores (ver `entities-vs-models.md`)
