### PR TITLE
[🛠️ Fix: DTA-008] - Convertir la lista del BCV en toEntity()

### DIFF
--- a/lib/shared/data/model/bcv_currencies_model.dart
+++ b/lib/shared/data/model/bcv_currencies_model.dart
@@ -2,7 +2,20 @@ import '../../domain/entities/bcv_currencies.dart';
 import 'currency_model.dart';
 
 class BcvCurrenciesModel extends BcvCurrencies {
-  BcvCurrenciesModel({required super.date, required super.currencies});
+  BcvCurrenciesModel({
+    required super.date,
+    required List<CurrencyModel> currencies,
+  }) : currencyModels = currencies,
+       super(currencies: currencies);
+
+  /// The deserialised rows, kept at their real type.
+  ///
+  /// The inherited `currencies` is declared `List<Currency>`, which is exactly
+  /// what hid the leak: a `List<CurrencyModel>` satisfies it, so the compiler
+  /// could not tell whether [toEntity] had converted anything. Reading the
+  /// models from here makes the conversion below type-checked instead of a
+  /// convention someone has to remember.
+  final List<CurrencyModel> currencyModels;
 
   /// Maps a `BcvResponseData` of the backend: `date` is optional and
   /// `currencies` may be absent if the source degraded.
@@ -20,7 +33,19 @@ class BcvCurrenciesModel extends BcvCurrencies {
     );
   }
 
+  /// Converts to the domain entity, **including every element of the list**.
+  ///
+  /// Handing `currencies` over untouched used to compile perfectly — a
+  /// `List<CurrencyModel>` satisfies a `List<Currency>` because the model
+  /// extends the entity — and let objects of the data layer travel all the way
+  /// into `CurrencyRepository.bcvCurrencies`, which the whole BCV UI reads.
+  /// Nothing would have failed until `CurrencyModel` grew state of its own.
   BcvCurrencies toEntity() {
-    return BcvCurrencies(date: date, currencies: currencies);
+    return BcvCurrencies(
+      date: date,
+      currencies: currencyModels
+          .map((CurrencyModel model) => model.toEntity())
+          .toList(),
+    );
   }
 }

--- a/test/shared/data/bcv_currencies_model_test.dart
+++ b/test/shared/data/bcv_currencies_model_test.dart
@@ -1,0 +1,99 @@
+import 'dart:convert';
+
+import 'package:bcv_tracker_app/shared/data/model/bcv_currencies_model.dart';
+import 'package:bcv_tracker_app/shared/data/model/currency_model.dart';
+import 'package:bcv_tracker_app/shared/domain/entities/bcv_currencies.dart';
+import 'package:bcv_tracker_app/shared/domain/entities/currency.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A `BcvResponseData` payload with two rates, shaped like the backend's.
+Map<String, dynamic> _payload() =>
+    json.decode(
+          '{"date":"2026-07-23T00:00:00-04:00","currencies":['
+          '{"code":"USD","name":"Dolar","platform":"Banco Central de Venezuela",'
+          '"value":737.88,"change":33.08,"createDate":"2026-01-29T18:38:47.617316",'
+          '"updateDate":"2026-07-23T03:46:17.336191","platform_img":"https://logo.test/bcv.png"},'
+          '{"code":"EUR","name":"Euro","platform":"Banco Central de Venezuela",'
+          '"value":812.10,"change":-1.2,"createDate":null,"updateDate":null,'
+          '"platform_img":""}]}',
+        )
+        as Map<String, dynamic>;
+
+void main() {
+  group('BcvCurrenciesModel.toEntity()', () {
+    test('converts every element of the list, not just the wrapper', () {
+      final entity = BcvCurrenciesModel.fromJson(_payload()).toEntity();
+
+      // Checked by runtime type on purpose. `CurrencyModel extends Currency`,
+      // so `isA<Currency>()` and any value comparison pass just as happily with
+      // the leak present — the only thing that tells them apart is the exact
+      // type of the object that crossed the boundary.
+      for (final Currency currency in entity.currencies) {
+        expect(currency.runtimeType, Currency);
+        expect(currency, isNot(isA<CurrencyModel>()));
+      }
+    });
+
+    test('keeps the mapped values while changing the type', () {
+      final entity = BcvCurrenciesModel.fromJson(_payload()).toEntity();
+
+      expect(entity.date, '2026-07-23T00:00:00-04:00');
+      expect(entity.currencies, hasLength(2));
+
+      final usd = entity.currencies.first;
+      expect(usd.keyName, 'USD');
+      expect(usd.value, 737.88);
+      expect(usd.tendency, 33.08);
+      expect(usd.imgUrl, 'https://logo.test/bcv.png');
+      expect(
+        usd.updateDate!.toUtc(),
+        DateTime.utc(2026, 7, 23, 3, 46, 17, 336, 191),
+      );
+
+      final eur = entity.currencies.last;
+      expect(eur.keyName, 'EUR');
+      expect(eur.createDate, isNull);
+      // An empty logo becomes null so the UI falls back to the initials.
+      expect(eur.imgUrl, isNull);
+    });
+
+    test('the returned object is the entity, not the model', () {
+      final entity = BcvCurrenciesModel.fromJson(_payload()).toEntity();
+
+      expect(entity.runtimeType, BcvCurrencies);
+      expect(entity, isNot(isA<BcvCurrenciesModel>()));
+    });
+
+    test('a degraded payload with no currencies converts to an empty list', () {
+      final entity = BcvCurrenciesModel.fromJson(
+        json.decode('{"date":null}') as Map<String, dynamic>,
+      ).toEntity();
+
+      expect(entity.date, isNull);
+      expect(entity.currencies, isEmpty);
+    });
+
+    test('rows that are not objects are dropped instead of throwing', () {
+      final entity = BcvCurrenciesModel.fromJson(
+        json.decode('{"date":null,"currencies":[null,42,"nope"]}')
+            as Map<String, dynamic>,
+      ).toEntity();
+
+      expect(entity.currencies, isEmpty);
+    });
+  });
+
+  group('CurrencyModel.toEntity()', () {
+    test('returns an entity, since the list conversion leans on it', () {
+      final model = CurrencyModel.fromJson(
+        json.decode(
+              '{"code":"USD","name":"Dolar","platform":"BCV","value":1.0,'
+              '"change":0,"createDate":null,"updateDate":null,"platform_img":""}',
+            )
+            as Map<String, dynamic>,
+      );
+
+      expect(model.toEntity().runtimeType, Currency);
+    });
+  });
+}


### PR DESCRIPTION
# Descripción

`BcvCurrenciesModel.toEntity()` construía la entidad **sin convertir los elementos de la lista**:

```dart
BcvCurrencies toEntity() {
  return BcvCurrencies(date: date, currencies: currencies);  // ← List<CurrencyModel>
}
```

Los modelos cruzaban la frontera de datos intactos y llegaban al estado compartido sin filtro: `CurrencyRepository.getBCVCurrencies()` hace `bcvCurrencies.assignAll(result.currencies)`, y ese observable es el que consume toda la UI del BCV. El compilador no podía detectarlo porque `CurrencyModel extends Currency`: una `List<CurrencyModel>` satisface una `List<Currency>`. El contraste estaba en el mismo repositorio — `DollarRepository.getCurrentDollar` sí hace `data.map((e) => e.toEntity()).toList()`.

Cambios (rama `fix/DTA-008`):

1. **`toEntity()` mapea cada elemento**, igual que ya hacía el otro camino del repositorio.
2. **`currencyModels`, un campo tipado con las filas deserializadas.** Esto es lo que va más allá de la corrección literal, y creo que vale la pena: el `currencies` heredado está declarado `List<Currency>`, y **eso es exactamente lo que ocultaba la fuga**. Leyendo los modelos desde su propio campo, la conversión pasa a estar comprobada por el compilador en vez de ser una convención que alguien tiene que recordar. Si mañana alguien vuelve a pasar la lista sin mapear, ya no compila.
3. **Auditoría del resto de `toEntity()` del proyecto** (criterio de la issue): solo hay dos. `CurrencyModel.toEntity()` convierte campos escalares y no tiene colecciones, así que estaba bien. Verificado además que **ningún archivo fuera de `lib/shared/data/` importa un modelo**, que es la regla 1 de `entities-vs-models.md`.
4. **Tests de mapeo** (6 casos): la conversión de cada elemento, los valores que deben sobrevivir al cambio de tipo, que el objeto devuelto sea la entidad y no el modelo, el payload degradado sin `currencies`, y las filas que no son objetos.

### Por qué los tests comprueban `runtimeType`

Tal como advierte la issue, la verificación tiene que ser por **tipo en tiempo de ejecución** (`expect(currency.runtimeType, Currency)`), no por igualdad de valores ni con `isA<Currency>()`: por la herencia, ambos pasan igual de contentos con la fuga presente. Lo único que distingue los dos casos es el tipo exacto del objeto que cruzó la frontera. Verificado empíricamente: devolviendo la lista sin mapear, el caso `converts every element of the list` falla; los demás pasan.

**Fuera de alcance, como indicaba la issue:** no se cambia el contrato de los modelos ni la forma de las entidades. Este fix no espera a #20 (que reescribe `CurrencyModel.fromJson` cuando el backend normalice moneda y plataforma) porque #20 está bloqueada por el backend.

Issue de GitHub relacionado: Closes #53

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad (cambio no-breaking que agrega funcionalidad)
- [x] 🛠️ Corrección de errores (cambio no-breaking que arregla un error)
- [ ] ❌ Cambio importante (arreglo o característica que haría que la funcionalidad existente no funcionara como se esperaba)
- [ ] 📝 Actualización de la documentación
- [ ] 🧹 Code refactoring (modificación de la estructura interna del código sin modificar las APIs)
- [ ] ✅ Build configuration change (modificación de los archivos para hacer deploy)
- [ ] 🗑️ Chore (actividades que no modifican la interacción con la app, por ejemplo, modificar el archivo de lints)

## ¿Cómo se ha probado esto?

- [x] `flutter test` — toda la suite en verde, con los 6 casos nuevos.
- [x] **Verificado que los tests atrapan la fuga**: devolviendo `currencyModels` sin mapear, falla el caso que comprueba el `runtimeType`.
- [x] `flutter analyze` — 8 issues, exactamente los mismos que en `development` (todos preexistentes). **0** nuevos.
- [x] Auditoría de `toEntity()` y de imports de modelos, descrita arriba.
- [x] `dart format` limpio en los dos archivos tocados.
- [ ] **Pendiente de verificación manual** (requiere el reviewer): abrir la pestaña del BCV y confirmar que las tasas se siguen mostrando igual. El cambio es de tipos, así que no debería haber diferencia visible — y precisamente por eso conviene comprobarlo.

**Configuración de prueba**:

- Plataforma y versión de SO (Android / iOS): pendiente de la verificación manual.
- Dispositivo o emulador: pendiente.
- Tema (claro/oscuro) e idioma probados: no aplica, el cambio no toca UI ni copy.

## Lista de Verificación

- [x] He agregado las nuevas dependencias (`pubspec.yaml`) en la descripción — no hay dependencias nuevas
- [x] He agregado las nuevas variables de entorno (solo los nombres) a la descripción — no hay variables nuevas
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código, particularmente en áreas difíciles de entender
- [x] He realizado los cambios correspondientes a la documentación
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente con mis cambios
- [ ] La app compila y el flujo afectado se probó en un dispositivo o emulador real — **pendiente**, ver arriba
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas (ver `i18n-convention.md`) — no aplica, no hay copy nueva
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper de cálculo, incluí sus tests en este mismo PR (ver `test-coverage.md`)
- [x] No introduje modelos (`shared/data/model/`) en la UI ni en los controladores (ver `entities-vs-models.md`) — es justamente lo que este PR elimina
