### PR TITLE
[🛠️ Fix: DTA-009] - Reportar un .env ilegible en vez de crashear

### DIFF
--- a/lib/config/enviroment/enviroment.dart
+++ b/lib/config/enviroment/enviroment.dart
@@ -1,9 +1,16 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 /// Why the configuration the app was built with cannot be used.
 enum EnvironmentIssue {
-  /// The variable is absent from the `.env`, or holds only whitespace. Also
-  /// what a missing `.env` file altogether looks like from here.
+  /// The `.env` itself could not be read: absent, empty, or not bundled.
+  ///
+  /// Reported apart from [missing] because the fix is different — you copy the
+  /// template, you do not edit it.
+  envFileUnavailable,
+
+  /// The file loaded, but the variable is absent from it or holds only
+  /// whitespace.
   missing,
 
   /// The variable is there but is not an absolute `http`/`https` URL, so Dio
@@ -27,6 +34,12 @@ class EnvironmentError {
   /// Developer-facing diagnostic. Never shown in a release build: it names the
   /// project's own files, which means nothing to a user.
   String get developerMessage => switch (issue) {
+    EnvironmentIssue.envFileUnavailable =>
+      'No se pudo leer el archivo .env.\n\n'
+          'Falta, está vacío, o no se empaquetó como asset.\n\n'
+          'Crea uno a partir de la plantilla:\n'
+          '    cp .env.example .env\n\n'
+          'y define $variable dentro.',
     EnvironmentIssue.missing =>
       'Falta la variable $variable.\n\n'
           'Copia la plantilla y completa el valor:\n'
@@ -53,10 +66,47 @@ class Environment {
   /// Endpoint paths are absolute (`/api/v1/...`), so a trailing slash in the
   /// `.env` value would build `//api/v1/...`, which the backend answers with a
   /// 308 redirect instead of serving the resource.
-  static String get currency => normalizeBaseUrl(dotenv.env[currencyBackKey]);
+  static String get currency => normalizeBaseUrl(_read(currencyBackKey));
+
+  /// Reads a variable without assuming the file loaded.
+  ///
+  /// After a failed [load] `dotenv.env` throws `NotInitializedError`, which
+  /// would turn a reported configuration problem back into a crash.
+  static String? _read(String key) =>
+      dotenv.isInitialized ? dotenv.env[key] : null;
 
   static String normalizeBaseUrl(String? value) =>
       (value ?? '').trim().replaceAll(RegExp(r'/+$'), '');
+
+  static bool _envFileAvailable = false;
+
+  /// Whether the `.env` could be read on the last [load].
+  static bool get isEnvFileAvailable => _envFileAvailable;
+
+  /// Loads the `.env`, and **never throws**: an unreadable file is a
+  /// configuration problem for [validate] to report, not a reason to die
+  /// before the first frame.
+  ///
+  /// `dotenv.load(isOptional: true)` is not enough on its own. It only swallows
+  /// `FileNotFoundError`, and `flutter_dotenv` raises `EmptyEnvFileError` — a
+  /// plain `Error`, not a `FlutterError` — when the file is there but empty,
+  /// which a failed `echo` in CI or a bare `touch .env` produces easily. That
+  /// one used to escape and crash the app on startup.
+  static Future<void> load({String fileName = '.env'}) async {
+    try {
+      await dotenv.load(fileName: fileName);
+      _envFileAvailable = true;
+    } catch (_) {
+      // FileNotFoundError, EmptyEnvFileError, or anything else the asset bundle
+      // raises. All of them mean the same thing to the app: no configuration.
+      _envFileAvailable = false;
+    }
+  }
+
+  /// Lets a test place the app in the "env file unreadable" state, which is
+  /// otherwise only reachable through the asset bundle.
+  @visibleForTesting
+  static void debugSetEnvFileAvailable(bool value) => _envFileAvailable = value;
 
   /// Checks the configuration the app cannot run without, and returns the first
   /// problem found — or `null` when everything is in place.
@@ -66,7 +116,14 @@ class Environment {
   /// Dio builds a request against a relative URL and the user gets a generic
   /// network error that never mentions that a variable is missing.
   static EnvironmentError? validate() {
-    final raw = normalizeBaseUrl(dotenv.env[currencyBackKey]);
+    if (!_envFileAvailable) {
+      return const EnvironmentError(
+        variable: currencyBackKey,
+        issue: EnvironmentIssue.envFileUnavailable,
+      );
+    }
+
+    final raw = normalizeBaseUrl(_read(currencyBackKey));
 
     if (raw.isEmpty) {
       return const EnvironmentError(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,6 @@ import 'package:bcv_tracker_app/features/splash/presentation/page/splash_page.da
 import 'package:bcv_tracker_app/shared/presentation/controller/settings_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
@@ -17,10 +16,10 @@ import 'features/splash/presentation/page/configuration_error_page.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  // `isOptional` keeps a missing `.env` from throwing: from the app's point of
-  // view an absent file is the same situation as an undefined variable, and the
-  // check below reports it as such instead of crashing with a stack trace.
-  await dotenv.load(fileName: ".env", isOptional: true);
+  // Loading is delegated to Environment, which never throws: an unreadable
+  // `.env` is a configuration problem to report, not a crash before the first
+  // frame. See Environment.load for why `isOptional` alone did not cover it.
+  await Environment.load();
 
   // Validated before anything can use it: without a backend URL every screen
   // would fail later as a generic network error that never names the variable.

--- a/test/config/enviroment/environment_empty_env_test.dart
+++ b/test/config/enviroment/environment_empty_env_test.dart
@@ -1,0 +1,51 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:bcv_tracker_app/config/enviroment/enviroment.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The `.env` exists but is empty — a bare `touch .env`, or an `echo` that
+/// failed in CI and left the file at zero bytes.
+///
+/// Kept in its own file because it mocks the asset bundle for every key, which
+/// would interfere with the rest of the `Environment` tests.
+void main() {
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    binding.defaultBinaryMessenger.setMockMessageHandler('flutter/assets', (
+      ByteData? message,
+    ) async {
+      return ByteData.sublistView(Uint8List.fromList(utf8.encode('')));
+    });
+  });
+
+  tearDown(() {
+    binding.defaultBinaryMessenger.setMockMessageHandler(
+      'flutter/assets',
+      null,
+    );
+  });
+
+  test('an empty .env is reported, not thrown', () async {
+    // `flutter_dotenv` raises `EmptyEnvFileError` here, and that one is a plain
+    // `Error` rather than a `FlutterError`, so `load(isOptional: true)` never
+    // caught it: the exception escaped `main()` and killed the app before the
+    // first frame, with no message for the user and no log for the developer.
+    await expectLater(Environment.load(), completes);
+
+    expect(Environment.isEnvFileAvailable, isFalse);
+    expect(Environment.validate()?.issue, EnvironmentIssue.envFileUnavailable);
+  });
+
+  test('the app can still read currency afterwards', () async {
+    // A failed load leaves dotenv uninitialised, and `dotenv.env` throws in
+    // that state — which would turn the reported problem back into a crash on
+    // the way to the configuration error screen.
+    await Environment.load();
+
+    expect(() => Environment.currency, returnsNormally);
+    expect(Environment.currency, '');
+  });
+}

--- a/test/config/enviroment/environment_test.dart
+++ b/test/config/enviroment/environment_test.dart
@@ -2,13 +2,91 @@ import 'package:bcv_tracker_app/config/enviroment/enviroment.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-/// Replaces the contents of the `.env` for the duration of a test.
-void loadEnv(String contents) => dotenv.testLoad(fileInput: contents);
+/// Replaces the contents of the `.env` for the duration of a test, and marks
+/// the file as readable — the state `Environment.load()` leaves behind when the
+/// asset is there.
+void loadEnv(String contents) {
+  dotenv.testLoad(fileInput: contents);
+  Environment.debugSetEnvFileAvailable(true);
+}
 
 void main() {
-  // An empty file is what a missing `.env` looks like from `Environment`:
-  // `main()` folds the load failure into the same case.
   tearDown(() => loadEnv(''));
+
+  group('load()', () {
+    // Exercises the real dotenv path rather than the test seam, so the
+    // "never throws" contract is checked against an actual bundle failure.
+    test('reports a file that is not there instead of throwing', () async {
+      await expectLater(
+        Environment.load(fileName: 'assets/no-such-file.env'),
+        completes,
+      );
+
+      expect(Environment.isEnvFileAvailable, isFalse);
+      expect(
+        Environment.validate()?.issue,
+        EnvironmentIssue.envFileUnavailable,
+      );
+    });
+
+    test('leaves currency readable, not throwing NotInitializedError', () {
+      // A failed load can leave dotenv uninitialised, and `dotenv.env` throws
+      // in that state — which would turn the reported problem back into a
+      // crash on the way to the error screen.
+      Environment.debugSetEnvFileAvailable(false);
+
+      expect(() => Environment.currency, returnsNormally);
+    });
+  });
+
+  group('an unreadable .env', () {
+    test('is reported instead of crashing the app', () {
+      // `flutter_dotenv` raises `EmptyEnvFileError` for a file that exists but
+      // is empty, and that one is a plain `Error`, not a `FlutterError`, so
+      // `load(isOptional: true)` never swallowed it. It used to escape
+      // `main()` and take the app down before the first frame.
+      loadEnv('CURRENCY_BACK=https://backend.example.com');
+      Environment.debugSetEnvFileAvailable(false);
+
+      final error = Environment.validate();
+      expect(error, isNotNull);
+      expect(error!.issue, EnvironmentIssue.envFileUnavailable);
+    });
+
+    test('is told apart from a variable that is merely missing', () {
+      Environment.debugSetEnvFileAvailable(false);
+      final fileMessage = Environment.validate()!.developerMessage;
+
+      loadEnv('');
+      final variableMessage = Environment.validate()!.developerMessage;
+
+      // The two are fixed differently: you copy the template, or you edit it.
+      expect(fileMessage, isNot(variableMessage));
+      expect(fileMessage, contains('No se pudo leer el archivo .env'));
+      expect(variableMessage, contains('Falta la variable CURRENCY_BACK'));
+    });
+
+    test('still names the variable to define, and no value', () {
+      loadEnv('CURRENCY_BACK=https://private-deploy.internal');
+      Environment.debugSetEnvFileAvailable(false);
+
+      final message = Environment.validate()!.developerMessage;
+
+      expect(message, contains('CURRENCY_BACK'));
+      expect(message, contains('cp .env.example .env'));
+      expect(message, isNot(contains('private-deploy.internal')));
+    });
+
+    test('takes priority over the value left in memory', () {
+      // A previous load may have populated dotenv. If the file is gone now,
+      // that stale value must not make the app look configured.
+      loadEnv('CURRENCY_BACK=https://backend.example.com');
+      expect(Environment.validate(), isNull);
+
+      Environment.debugSetEnvFileAvailable(false);
+      expect(Environment.validate(), isNotNull);
+    });
+  });
 
   group('validate() rejects', () {
     test('a variable that is not defined at all', () {


### PR DESCRIPTION
# Descripción

Continuación de #70 (`fix/DTA-006`). Aquel PR daba por cubierto el crash de arranque con `.env` ausente usando `dotenv.load(isOptional: true)`, y **no lo estaba del todo**. Este PR cierra los dos criterios que añadió el comentario de auditoría (SEC-04) al issue #16 y que quedaron pendientes.

## El hueco

`isOptional: true` solo se traga `FileNotFoundError`. En `flutter_dotenv` 5.2.1:

```dart
// lib/src/dotenv.dart:163-174
Future<List<String>> _getEntriesFromFile(String filename) async {
  try {
    var envString = await rootBundle.loadString(filename);
    if (envString.isEmpty) {
      throw EmptyEnvFileError();      // ← no es un FlutterError
    }
    return envString.split('\n');
  } on FlutterError {
    throw FileNotFoundError();
  }
}
```

`EmptyEnvFileError` es un `Error` pelado (`lib/src/errors.dart`), no un `FlutterError`, así que no se convierte en `FileNotFoundError` — y `load()` solo captura ese último cuando `isOptional` está activo (`dotenv.dart:125`). Resultado: un `.env` **presente pero vacío** propagaba la excepción y **la app crasheaba antes del primer frame**, sin mensaje para el usuario ni log para quien la desarrolla. Un `touch .env`, o un `echo` que falló en CI y dejó el archivo a cero bytes, bastaban.

**Verificado empíricamente**, no solo leído del código fuente: con el bundle de assets simulado devolviendo un archivo vacío, `dotenv.load(fileName: '.env', isOptional: true)` lanza `EmptyEnvFileError`. Ese escenario es ahora un test de regresión permanente.

El segundo hueco es de diseño, y fue una decisión mía mal calibrada en #70: doblé "no se pudo leer el archivo" dentro de `EnvironmentIssue.missing`, razonando que para la app son la misma situación. Para quien levanta el proyecto **no lo son**: una se arregla copiando la plantilla y la otra editándola.

## Cambios

1. **`Environment.load()`** asume la carga y **nunca lanza**: captura cualquier fallo del bundle, no solo el que cubría el flag. `main()` pasa a llamarla en vez de a `dotenv.load` directamente, lo que además deja toda la interacción con `dotenv` dentro de `Environment`, como manda `environment-variables.md`.
2. **`EnvironmentIssue.envFileUnavailable`**, con su diagnóstico propio: nombra el archivo (`No se pudo leer el archivo .env… cp .env.example .env`) en lugar de la variable. La tabla de la auditoría queda cubierta.
3. **Lectura guardada** (`_read`): una carga fallida deja `dotenv` sin inicializar, y `dotenv.env` **lanza `NotInitializedError`** en ese estado. Sin esto, el problema reportado se convertía otra vez en un crash camino de la pantalla de error. Hay un test que lo fija.
4. **`debugSetEnvFileAvailable`** (`@visibleForTesting`) como única costura: el estado "archivo ilegible" solo es alcanzable a través del bundle, y no quería que los 13 tests existentes dependieran de simularlo.
5. **Tests**: 7 casos nuevos — el archivo ausente por la ruta real de `load()`, el archivo vacío contra un bundle simulado (en su propio archivo, porque el mock afecta a todas las claves), que el mensaje del archivo se distinga del de la variable, que el estado de archivo tenga prioridad sobre un valor viejo que quedara en memoria, y que `Environment.currency` siga siendo legible tras un fallo de carga.

### Lo que deliberadamente no cambia

**El mensaje de usuario sigue siendo uno solo.** La distinción que pide la auditoría es del diagnóstico de desarrollo: un usuario no puede actuar sobre la diferencia entre "falta el archivo" y "falta la variable", y ambas cosas significan lo mismo para él — la app no está configurada. Sigue sin exponerse la URL en ninguno de los dos casos.

Issue de GitHub relacionado: Closes #16

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad (cambio no-breaking que agrega funcionalidad)
- [x] 🛠️ Corrección de errores (cambio no-breaking que arregla un error)
- [ ] ❌ Cambio importante (arreglo o característica que haría que la funcionalidad existente no funcionara como se esperaba)
- [ ] 📝 Actualización de la documentación
- [ ] 🧹 Code refactoring (modificación de la estructura interna del código sin modificar las APIs)
- [ ] ✅ Build configuration change (modificación de los archivos para hacer deploy)
- [ ] 🗑️ Chore (actividades que no modifican la interacción con la app, por ejemplo, modificar el archivo de lints)

## ¿Cómo se ha probado esto?

- [x] `flutter test` — toda la suite en verde, con los 7 casos nuevos.
- [x] **Verificado que el bug existía**: con el bundle simulando un `.env` vacío, la llamada anterior (`dotenv.load(fileName: '.env', isOptional: true)`) lanza `EmptyEnvFileError`; `Environment.load()` completa y lo reporta.
- [x] `flutter analyze` — 8 issues, exactamente los mismos que en `development` (todos preexistentes). **0** en los archivos tocados.
- [x] Verificado que no se introdujo deriva de formato: lo único que `dart format` querría cambiar en `main.dart` es una línea preexistente (`Firebase.initializeApp`).
- [ ] **Pendiente de verificación manual** (requiere el reviewer, en dispositivo o emulador):
  - `touch .env` (archivo vacío) y arrancar → pantalla de configuración con el diagnóstico **del archivo**. Antes de este PR, crash silencioso.
  - Borrar el `.env` → misma pantalla, mismo diagnóstico.
  - `.env` con el archivo bien pero sin `CURRENCY_BACK` → pantalla con el diagnóstico **de la variable**, distinto del anterior.
  - Build de **release** con el `.env` vacío → mensaje de usuario, **sin** bloque de diagnóstico.

**Configuración de prueba**:

- Plataforma y versión de SO (Android / iOS): pendiente de la verificación manual.
- Dispositivo o emulador: pendiente.
- Tema (claro/oscuro) e idioma probados: la pantalla es la misma de #70 y no cambia; no hay copy nueva.

## Lista de Verificación

- [x] He agregado las nuevas dependencias (`pubspec.yaml`) en la descripción — no hay dependencias nuevas
- [x] He agregado las nuevas variables de entorno (solo los nombres) a la descripción — no hay variables nuevas
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código, particularmente en áreas difíciles de entender
- [x] He realizado los cambios correspondientes a la documentación
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente con mis cambios
- [ ] La app compila y el flujo afectado se probó en un dispositivo o emulador real — **pendiente**, ver arriba
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas (ver `i18n-convention.md`) — no aplica: el diagnóstico nuevo es solo de desarrollo (`kDebugMode`), no copy de usuario
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper de cálculo, incluí sus tests en este mismo PR (ver `test-coverage.md`)
- [x] No introduje modelos (`shared/data/model/`) en la UI ni en los controladores (ver `entities-vs-models.md`)
