### PR TITLE
[💚 CI: DTA-010] - Validar analyze y tests en cada PR

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,60 @@
+# Validación de Pull Requests
+#
+# Corre el análisis estático y los tests en cada PR, ANTES de fusionar, para no
+# descubrir en `master` que algo se rompió (issue #27).
+#
+# Este pipeline NO construye ni distribuye: eso sigue en `codemagic.yaml`, que
+# se dispara con el push a `master`. Aquí solo se valida.
+name: PR Validation
+
+# El workflow de trabajo de este repo mergea a `development` y solo promociona
+# `development → master` en el release. Validar solo los PR a `master` dejaría
+# sin check todo el trabajo diario, así que se cubren ambas ramas destino.
+on:
+  pull_request:
+    branches:
+      - master
+      - development
+
+# Un push nuevo a la misma PR cancela la validación en curso: no tiene sentido
+# gastar minutos en un commit que ya quedó atrás.
+concurrency:
+  group: pr-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze-and-test:
+    name: flutter analyze + flutter test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          # Mismo canal que el pipeline de distribución (codemagic.yaml), para
+          # que lo que valida la PR sea lo mismo que luego construye el release.
+          channel: stable
+          cache: true
+
+      - name: Crear .env de validación
+        # La app solo necesita que la variable exista y tenga forma de URL para
+        # arrancar; en validación no se distribuye nada, así que un valor
+        # ficticio basta. Nunca un backend real: esto queda en los logs de la PR.
+        run: echo "CURRENCY_BACK=https://ci.example.com" > .env
+
+      - name: Instalar dependencias
+        run: flutter pub get
+
+      - name: Analizar código
+        # Severidad alineada con codemagic.yaml por ahora: los errores SIEMPRE
+        # rompen el build (nunca dejan de ser fatales), así que una PR con
+        # errores de análisis no se puede fusionar. Los warnings/infos se
+        # endurecen en #29, que retira estos flags aquí y en codemagic a la vez.
+        run: flutter analyze --no-fatal-infos --no-fatal-warnings
+
+      - name: Ejecutar tests
+        run: flutter test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,25 @@ fix/DTA-00Y  ─┼──▶ development ──(release)──▶ master ──�
 
 ---
 
+## ✅ Integración Continua (CI)
+
+Hay dos pipelines, con responsabilidades separadas:
+
+| Pipeline | Cuándo corre | Qué hace |
+|---|---|---|
+| **Validación de PR** — [`.github/workflows/pr-validation.yml`](.github/workflows/pr-validation.yml) (GitHub Actions) | En cada pull request hacia `development` o `master` | `flutter pub get` → `flutter analyze` → `flutter test`. **No** construye ni distribuye. |
+| **Distribución** — [`codemagic.yaml`](codemagic.yaml) (Codemagic) | En el push a `master` | Analiza, testea, **construye** el APK/IPA y lo **distribuye** a Firebase App Distribution. |
+
+**Por qué GitHub Actions para la validación y no Codemagic:** el check aparece de forma nativa en la PR de GitHub, no consume minutos de build de Codemagic para una tarea que no construye nada, y separa limpiamente "validar" (en cada PR) de "distribuir" (solo en `master`). Codemagic sigue siendo el único que construye y firma.
+
+**Por qué se validan los PR a `development` y no solo a `master`:** el trabajo diario se mergea a `development` y solo el release promociona a `master`. Validar solo los PR a `master` dejaría sin check todo el trabajo del día a día, que es justo lo que este pipeline existe para atrapar.
+
+Una PR **no se puede fusionar** si `flutter analyze` reporta **errores** o si `flutter test` falla. Hoy el análisis corre con `--no-fatal-infos --no-fatal-warnings` (igual que `codemagic.yaml`), así que los warnings todavía no bloquean; endurecer esa severidad es trabajo de [#29](https://github.com/Teixeira49/bcv_tracker_app/issues/29), que retira esos flags en ambos pipelines a la vez.
+
+> El workflow crea un `.env` ficticio (`CURRENCY_BACK=https://ci.example.com`) solo para que la app resuelva su configuración durante la validación. Nunca un backend real: quedaría en los logs públicos de la PR.
+
+---
+
 ## 🏷️ Versionado y Changelog
 
 El proyecto sigue **[Semantic Versioning](https://semver.org/lang/es/)** (`MAJOR.MINOR.PATCH`, con tags `vX.Y.Z`) y mantiene un historial formal en `CHANGELOG.md` con el formato **[Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/)**.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Esta aplicación depende directamente de su servicio backend para obtener los da
 
 Antes de abrir un PR, lee la [**Guía de Contribución**](CONTRIBUTING.md): arquitectura, reglas de implementación y el flujo `issue → rama → commits → PR → release`.
 
+Cada PR hacia `development` o `master` corre `flutter analyze` y `flutter test` en GitHub Actions antes de poder fusionarse; la construcción y distribución siguen en Codemagic sobre `master`. Detalle en [CONTRIBUTING.md → Integración Continua](CONTRIBUTING.md#-integración-continua-ci).
+
 ### 🤖 Tooling agéntico
 
 Este repositorio versiona convenciones y capacidades para desarrollo asistido por IA en [`.agents/`](.agents/), más la config compartida en `.claude/pr-config.json` y el lockfile `skills-lock.json`. Al clonar, todo el equipo dispone de las mismas reglas sin configuración extra.


### PR DESCRIPTION
# Descripción

La verificación existía pero llegaba tarde: `codemagic.yaml` solo corría `flutter analyze` y `flutter test` en el push a `master` (**después** de fusionar), y sus otros dos workflows eran manuales (`events: []`). Una PR no mostraba ningún check, así que un fallo se descubría en `master`.

Cambios (rama `ci/DTA-010`):

1. **Nuevo workflow de GitHub Actions** ([`.github/workflows/pr-validation.yml`](.github/workflows/pr-validation.yml)) que corre en cada PR: `flutter pub get` → `flutter analyze` → `flutter test`. **No** construye ni distribuye — eso sigue siendo responsabilidad exclusiva de `codemagic.yaml` sobre `master`.
2. **Documentación** en `CONTRIBUTING.md` (sección nueva "Integración Continua") con la tabla de los dos pipelines y el porqué de cada decisión, más un puntero desde el `README.md`.

## Decisiones (las que el issue pedía tomar)

- **GitHub Actions, no un workflow de PR en Codemagic.** El check aparece nativo en la PR de GitHub, no gasta minutos de build de Codemagic en una tarea que no construye nada, y separa limpiamente "validar" (cada PR) de "distribuir" (solo `master`).
- **Se validan los PR a `development` además de a `master`.** El criterio del issue dice "hacia `master`", pero en este repo el trabajo diario se mergea a `development` y solo el release promociona a `master`. Validar solo `master` dejaría sin check todo el trabajo del día a día — justo lo que este pipeline existe para atrapar. Cubrir ambas ramas cumple el criterio literal (master incluido) y la intención de la User Story ("cada pull request antes de fusionar").
- **Severidad alineada con `codemagic.yaml` por ahora** (`--no-fatal-infos --no-fatal-warnings`). Los **errores** de análisis siempre son fatales (los flags no los afectan), así que una PR con errores de análisis **no se puede fusionar** — que es el criterio de aceptación. Endurecer warnings/infos es trabajo de **#29**, que retira estos flags en GitHub Actions **y** en Codemagic a la vez. Esta es la coordinación que el propio issue anticipaba.

## Fuera de alcance (como indicaba el issue)

Construir o distribuir artefactos en las PR. Eso sigue en `codemagic.yaml` sobre `master`, sin duplicar builds por PR.

Issue de GitHub relacionado: Closes #27

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad (cambio no-breaking que agrega funcionalidad)
- [ ] 🛠️ Corrección de errores (cambio no-breaking que arregla un error)
- [ ] ❌ Cambio importante
- [ ] 📝 Actualización de la documentación
- [ ] 🧹 Code refactoring
- [x] ✅ Build configuration change (modificación de los archivos para hacer deploy) — pipeline de CI
- [ ] 🗑️ Chore

## ¿Cómo se ha probado esto?

- [x] `flutter analyze --no-fatal-infos --no-fatal-warnings` — **exit 0** en el árbol actual (8 issues preexistentes, ninguno error). Verificado que `flutter analyze` a secas da **exit 1**: esa es exactamente la severidad que #29 hará bloqueante.
- [x] `flutter test` — toda la suite en verde localmente, que es lo que correrá el paso de tests.
- [x] YAML validado con un parser (`yaml.safe_load`), sin errores de sintaxis.
- [ ] **Pendiente de verificación en GitHub** (solo observable al abrir esta PR): que el check `PR Validation / flutter analyze + flutter test` aparezca y quede en verde. Es el propio acto de abrir la PR el que lo dispara.
- [ ] **Acción de repo pendiente para el reviewer** (fuera del código, en la config de GitHub): marcar el check como **required** en la protección de rama de `development` y `master` para que el criterio "no se puede fusionar en rojo" se aplique de verdad. El workflow lo habilita; la regla de protección lo exige.

**Configuración de prueba**:

- El workflow corre en `ubuntu-latest` con `subosito/flutter-action@v2`, canal `stable` (el mismo que `codemagic.yaml`).
- No aplica prueba en dispositivo: el cambio es de infraestructura de CI, no toca código de la app.

## Lista de Verificación

- [x] He agregado las nuevas dependencias (`pubspec.yaml`) en la descripción — no hay dependencias nuevas
- [x] He agregado las nuevas variables de entorno (solo los nombres) a la descripción — no hay variables nuevas; el workflow crea un `.env` ficticio (`CURRENCY_BACK` con un valor de ejemplo, nunca un backend real)
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código, particularmente en áreas difíciles de entender — el YAML lleva comentarios explicando cada decisión
- [x] He realizado los cambios correspondientes a la documentación (`CONTRIBUTING.md` + `README.md`)
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente con mis cambios
- [x] La app compila y el flujo afectado se probó — no aplica: cambio de CI, no de app; los pasos se probaron localmente
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas — no aplica
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper de cálculo, incluí sus tests — no aplica
- [x] No introduje modelos (`shared/data/model/`) en la UI ni en los controladores — no aplica
