### PR TITLE
[🧹 Refactor: DTA-011] - Importar GetX por su API pública

### DIFF
--- a/lib/config/routes/pages.dart
+++ b/lib/config/routes/pages.dart
@@ -1,5 +1,5 @@
 import 'package:bcv_tracker_app/config/routes/routes.dart';
-import 'package:get/get_navigation/src/routes/get_route.dart';
+import 'package:get/get.dart';
 
 import '../../features/dashboard/presentation/page/dashboard_page.dart';
 import '../../features/splash/presentation/page/splash_page.dart';

--- a/lib/core/i18n/app_messages.dart
+++ b/lib/core/i18n/app_messages.dart
@@ -1,4 +1,4 @@
-import 'package:get/get_utils/src/extensions/internacionalization.dart';
+import 'package:get/get.dart';
 
 class AppMessages {
   static String get homeView => 'homeView'.tr;

--- a/lib/features/converter/presentation/page/converter_page.dart
+++ b/lib/features/converter/presentation/page/converter_page.dart
@@ -2,7 +2,6 @@ import 'package:bcv_tracker_app/core/i18n/app_messages.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
-import 'package:get/get_state_manager/src/simple/get_state.dart';
 import 'dart:ui';
 
 import '../../../../config/theme/colors/colors_values.dart';

--- a/lib/features/home/presentation/page/home_page.dart
+++ b/lib/features/home/presentation/page/home_page.dart
@@ -2,9 +2,7 @@ import 'package:bcv_tracker_app/config/theme/colors/colors_values.dart';
 import 'package:bcv_tracker_app/shared/presentation/widgets/performance_indicator_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:get/get_core/src/get_main.dart';
-import 'package:get/get_instance/src/extension_instance.dart';
-import 'package:get/get_state_manager/src/simple/get_state.dart';
+import 'package:get/get.dart';
 
 import '../../../../core/helpers/currency_helpers.dart';
 import '../../../../core/i18n/app_messages.dart';

--- a/lib/shared/presentation/widgets/custom_bottom_navigator_bar.dart
+++ b/lib/shared/presentation/widgets/custom_bottom_navigator_bar.dart
@@ -1,7 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
-import 'package:get/get_state_manager/src/rx_flutter/rx_obx_widget.dart';
+import 'package:get/get.dart';
 
 import '../../../config/theme/colors/colors_values.dart';
 import '../../../navigation/navigation_controller.dart';


### PR DESCRIPTION
# Descripción

Había **7 imports en 5 archivos** que entraban a rutas `src/` internas del paquete `get` en vez de usar su fachada pública. `src/` no es API pública, así que un `flutter pub upgrade` que mueva o renombre cualquiera de esos archivos —algo permitido en una versión *patch*— rompería el build con un error de import que no menciona nada del cambio real.

Todo lo que esos archivos usan (`Get`, `GetBuilder`, `Obx`, `GetPage`, `.tr`) lo exporta el único import público `package:get/get.dart`.

Cambios (rama `refactor/DTA-011`):

| Archivo | Antes | Después |
|---|---|---|
| `core/i18n/app_messages.dart` | `get_utils/src/extensions/internacionalization.dart` | `package:get/get.dart` |
| `config/routes/pages.dart` | `get_navigation/src/routes/get_route.dart` | `package:get/get.dart` |
| `features/home/.../home_page.dart` | 3 imports internos (`get_main`, `extension_instance`, `get_state`) | un solo `package:get/get.dart` |
| `features/converter/.../converter_page.dart` | duplicado: ya tenía `get.dart` **y** `get_state.dart` interno | se borra el interno, queda la fachada |
| `shared/.../custom_bottom_navigator_bar.dart` | `get_state_manager/src/rx_flutter/rx_obx_widget.dart` | `package:get/get.dart` |

**El diff es imports y nada más.** Sin cambio de comportamiento — es exactamente lo que el issue pedía que el diff demostrara.

## Fuera de alcance (como indicaba el issue)

Cualquier otro cambio en esos archivos. En particular, `converter_page.dart` conserva su `import 'dart:ui'` innecesario (uno de los 8 hallazgos preexistentes del análisis): tocarlo aquí ensuciaría el diff. Ese y el resto de la limpieza son de **#29**, que además activará `implementation_imports` para que esta clase de import interno no vuelva a entrar.

Issue de GitHub relacionado: Closes #52

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad
- [ ] 🛠️ Corrección de errores
- [ ] ❌ Cambio importante
- [ ] 📝 Actualización de la documentación
- [x] 🧹 Code refactoring (modificación de la estructura interna del código sin modificar las APIs)
- [ ] ✅ Build configuration change
- [ ] 🗑️ Chore

## ¿Cómo se ha probado esto?

- [x] **Criterio del issue**: `grep -rn "package:get/get_" lib/` no devuelve **ningún** resultado (exit 1).
- [x] Los 5 archivos importan `package:get/get.dart` y nada más de `get`.
- [x] `flutter analyze` — 8 issues, **exactamente los mismos** que en `development` (el `unnecessary_import` de `dart:ui` solo se movió de línea al borrar el import duplicado). Ninguno nuevo.
- [x] `flutter test` — toda la suite en verde.
- [x] `git diff` confirma que el cambio es solo líneas de import.
- [x] `dart format` sin deriva introducida (la única marca en `pages.dart` es preexistente, sobre el formato de `GetPage`, no sobre imports).
- [x] Es un fix mecánico y verificable: si compila y los tests pasan, está bien. No hay comportamiento nuevo que probar en dispositivo (nota del propio issue).

**Configuración de prueba**: no aplica prueba en dispositivo; cambio sin efecto en el comportamiento.

## Lista de Verificación

- [x] He agregado las nuevas dependencias (`pubspec.yaml`) en la descripción — ninguna
- [x] He agregado las nuevas variables de entorno a la descripción — ninguna
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código — no aplica, cambio de imports
- [x] He realizado los cambios correspondientes a la documentación — no aplica
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente con mis cambios
- [x] La app compila; el cambio no tiene flujo que probar en dispositivo
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas — no aplica
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper de cálculo, incluí sus tests — no aplica: sin cambio funcional
- [x] No introduje modelos en la UI ni en los controladores — no aplica
