### PR TITLE
[🧹 Refactor: DTA-013] - Cablear una sola historia de navegación

### DIFF
--- a/.agents/rules/navigation-convention.md
+++ b/.agents/rules/navigation-convention.md
@@ -60,12 +60,9 @@ GetPage(
 ),
 ```
 
-## Deuda conocida
+## Estado
 
-A la fecha de escribir esta regla hay tres desviaciones en el código; corrígelas cuando toques esos archivos (regla del boy-scout), sin desviar el objetivo del PR:
-
-- `lib/features/splash/presentation/page/splash_page.dart` — usa `Get.offAll(() => DashboardPage())` teniendo `AppRoutes.home` ya registrado.
-- `lib/shared/presentation/widgets/base_modal.dart` y `lib/features/converter/presentation/widget/converter_modals.dart` — cierran con `Navigator.pop(context)` en lugar de `Get.back()`.
+Sin desviaciones. Las rutas nombradas están cableadas en `GetMaterialApp` (`getPages: AppPages.routes`, `initialRoute: AppPages.initPage`), el splash navega con `Get.offAllNamed(AppRoutes.home)` y los modales cierran con `Get.back()`. La regla describe lo que el código hace, no un objetivo (resuelto en [#58](https://github.com/Teixeira49/bcv_tracker_app/issues/58)).
 
 ## Al agregar una pantalla
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,8 +129,7 @@ Tests live in `test/`, mirroring `lib/`. Any change to a data source, a market m
 Verified against the code. Fix on contact where the rule says so; do not treat as invisible:
 
 - **GetX workers are never disposed** — `HomeController` and `ConverterController` register `ever()` without `onClose()`. `get` 4.7.3 has no automatic disposal, and `CurrencyRepository` is `permanent`, so listeners accumulate on every `fenix` recreation. Tracked in [#45](https://github.com/Teixeira49/bcv_tracker_app/issues/45).
-- **`SettingsController` is registered twice** — `Get.put` in `main.dart:18` and `Get.lazyPut` in `initial_bindings.dart:30`.
-- **Navigation deviations** — `splash_page.dart:24` uses `Get.offAll(() => DashboardPage())`; `base_modal.dart:38` and `converter_modals.dart:69` close with `Navigator.pop`.
+- **`SettingsController` is registered twice** — `Get.put` in `main.dart` and `Get.lazyPut` in `initial_bindings.dart:30`.
 - **`WidthValues` is unused** — the 8pt grid is declared but the 21 `EdgeInsets` in the app carry bare numbers.
 - **Placeholder bundle identifiers** — `com.example.*` on both platforms blocks store publishing. Tracked in [#22](https://github.com/Teixeira49/bcv_tracker_app/issues/22).
 - **Invalid locale codes** — `SettingsController` offers `en_EN` and `ja_JA`; `AppTranslations` registers `en_US` and `ja_JP`. It works only because GetX falls back on the language code alone. Correcting them is now **safe**: the selector resolves an unknown stored code to `SettingsController.defaultLanguage` and `restoreLanguageCode` rewrites the preference, so an install carrying the old code no longer breaks the settings screen ([#54](https://github.com/Teixeira49/bcv_tracker_app/issues/54)).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,8 +129,7 @@ Tests live in `test/`, mirroring `lib/`. Any change to a data source, a market m
 Verified against the code. Fix on contact where the rule says so; do not treat as invisible:
 
 - **GetX workers are never disposed** — `HomeController` and `ConverterController` register `ever()` without `onClose()`. `get` 4.7.3 has no automatic disposal, and `CurrencyRepository` is `permanent`, so listeners accumulate on every `fenix` recreation. Tracked in [#45](https://github.com/Teixeira49/bcv_tracker_app/issues/45).
-- **`SettingsController` is registered twice** — `Get.put` in `main.dart:18` and `Get.lazyPut` in `initial_bindings.dart:30`.
-- **Navigation deviations** — `splash_page.dart:24` uses `Get.offAll(() => DashboardPage())`; `base_modal.dart:38` and `converter_modals.dart:69` close with `Navigator.pop`.
+- **`SettingsController` is registered twice** — `Get.put` in `main.dart` and `Get.lazyPut` in `initial_bindings.dart:30`.
 - **`WidthValues` is unused** — the 8pt grid is declared but the 21 `EdgeInsets` in the app carry bare numbers.
 - **Placeholder bundle identifiers** — `com.example.*` on both platforms blocks store publishing. Tracked in [#22](https://github.com/Teixeira49/bcv_tracker_app/issues/22).
 - **Invalid locale codes** — `SettingsController` offers `en_EN` and `ja_JA`; `AppTranslations` registers `en_US` and `ja_JP`. It works only because GetX falls back on the language code alone. Correcting them is now **safe**: the selector resolves an unknown stored code to `SettingsController.defaultLanguage` and `restoreLanguageCode` rewrites the preference, so an install carrying the old code no longer breaks the settings screen ([#54](https://github.com/Teixeira49/bcv_tracker_app/issues/54)).

--- a/lib/config/routes/pages.dart
+++ b/lib/config/routes/pages.dart
@@ -9,6 +9,13 @@ class AppPages {
 
   static final List<GetPage<dynamic>> routes = [
     GetPage(name: AppRoutes.splash, page: () => const SplashPage()),
-    GetPage(name: AppRoutes.home, page: () => DashboardPage()),
+    // The splash → home transition lives here, on the route, not at the call
+    // site: `Get.offAllNamed(AppRoutes.home)` from the splash inherits it.
+    GetPage(
+      name: AppRoutes.home,
+      page: () => DashboardPage(),
+      transition: Transition.fadeIn,
+      transitionDuration: const Duration(milliseconds: 500),
+    ),
   ];
 }

--- a/lib/features/converter/presentation/widget/converter_modals.dart
+++ b/lib/features/converter/presentation/widget/converter_modals.dart
@@ -66,6 +66,6 @@ class _CurrencySelectorDialogBody extends StatelessWidget {
     required bool isInput,
   }) {
     bool? validator = controller.selectCurrency(currency, isInput: isInput);
-    if (validator != null && validator) Navigator.pop(context);
+    if (validator != null && validator) Get.back<void>();
   }
 }

--- a/lib/features/splash/presentation/page/splash_page.dart
+++ b/lib/features/splash/presentation/page/splash_page.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:get/get.dart';
 
+import '../../../../config/routes/routes.dart';
 import '../../../../config/theme/colors/colors_values.dart';
 import '../../../../config/theme/icons/icons_constants.dart';
 import '../../../../core/constants/constants.dart';
-import '../../../dashboard/presentation/page/dashboard_page.dart';
 
 part '../widgets/splash_body.dart';
 
@@ -21,11 +21,9 @@ class _SplashPageState extends State<SplashPage> {
   void initState() {
     super.initState();
     Future.delayed(const Duration(seconds: Constants.splashDuration), () {
-      Get.offAll<void>(
-        () => DashboardPage(),
-        transition: Transition.fadeIn,
-        duration: const Duration(milliseconds: 500),
-      );
+      // Clears the stack and lands on home. The fadeIn transition lives on the
+      // home `GetPage` (see `AppPages`), not here.
+      Get.offAllNamed<void>(AppRoutes.home);
     });
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:bcv_tracker_app/config/theme/theme.dart';
-import 'package:bcv_tracker_app/features/splash/presentation/page/splash_page.dart';
 import 'package:bcv_tracker_app/shared/presentation/controller/settings_controller.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
@@ -7,6 +6,7 @@ import 'package:get/get.dart';
 
 import 'config/bindings/initial_bindings.dart';
 import 'config/enviroment/enviroment.dart';
+import 'config/routes/pages.dart';
 import 'core/constants/constants.dart';
 import 'core/i18n/app_translations.dart';
 import 'features/splash/presentation/page/configuration_error_page.dart';
@@ -68,7 +68,11 @@ class MyApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       title: Constants.appTitle,
       initialBinding: InitialBinding(),
-      home: SplashPage(),
+      // Named routes: the splash is the entry point and every screen resolves
+      // through `AppPages.routes`. `initialBinding` still runs — adding
+      // `getPages`/`initialRoute` does not displace it.
+      initialRoute: AppPages.initPage,
+      getPages: AppPages.routes,
       theme: AppTheme.lightTheme,
       darkTheme: AppTheme.darkTheme,
       themeMode: ThemeMode.system,

--- a/lib/shared/presentation/widgets/base_modal.dart
+++ b/lib/shared/presentation/widgets/base_modal.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 
 import '../../../config/theme/colors/colors_values.dart';
 
@@ -35,7 +36,7 @@ class BaseModal extends StatelessWidget {
           style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 22),
         ),
         IconButton(
-          onPressed: () => Navigator.of(context).pop(),
+          onPressed: () => Get.back<void>(),
           icon: const Icon(Icons.close),
         ),
       ],

--- a/test/config/routes/app_pages_test.dart
+++ b/test/config/routes/app_pages_test.dart
@@ -1,0 +1,58 @@
+import 'package:bcv_tracker_app/config/routes/pages.dart';
+import 'package:bcv_tracker_app/config/routes/routes.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Every route constant declared in [AppRoutes], read reflectively-by-hand.
+/// Kept next to the routes so adding a constant without listing it here is an
+/// obvious omission in the same file.
+const List<String> _declaredRoutes = [AppRoutes.splash, AppRoutes.home];
+
+void main() {
+  group('AppPages', () {
+    test('registers a GetPage for every declared route', () {
+      final registered = AppPages.routes.map((page) => page.name).toSet();
+
+      // The bug this guards against: a constant added to `AppRoutes` but never
+      // registered in `AppPages.routes`. With named routes wired into
+      // `GetMaterialApp`, `Get.toNamed` on an unregistered name fails at
+      // runtime, not at compile time — exactly what #58 set out to make
+      // impossible to ship silently.
+      for (final route in _declaredRoutes) {
+        expect(
+          registered,
+          contains(route),
+          reason: 'No GetPage registered for "$route" in AppPages.routes.',
+        );
+      }
+    });
+
+    test('does not register a route name twice', () {
+      final names = AppPages.routes.map((page) => page.name).toList();
+      expect(
+        names.length,
+        names.toSet().length,
+        reason: 'Duplicate route name in AppPages.routes.',
+      );
+    });
+
+    test('starts on the splash', () {
+      expect(AppPages.initPage, AppRoutes.splash);
+      expect(
+        AppPages.routes.map((page) => page.name),
+        contains(AppPages.initPage),
+      );
+    });
+
+    test('every registered page builds a widget', () {
+      // A `GetPage` whose `page` builder throws would only surface when the
+      // route is hit. Building each one here catches a broken builder up front.
+      for (final page in AppPages.routes) {
+        expect(
+          page.page(),
+          isNotNull,
+          reason: 'Route "${page.name}" builds null.',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
# Descripción

El proyecto tenía **dos historias de navegación**: una escrita (rutas nombradas en `routes.dart`/`pages.dart`) que no estaba conectada a nada, y la real —tres desviaciones—. `GetMaterialApp` se montaba con `home: SplashPage()` y **sin** `getPages`, así que cualquiera que siguiera la documentación (`CLAUDE.md` afirmaba rutas nombradas) y escribiera `Get.toNamed(AppRoutes.x)` obtenía un fallo **en tiempo de ejecución**.

## La decisión

Se eligió la **opción (A) del issue: cablear las rutas nombradas** — la recomendada, y la que el resto del proyecto ya asume (#37 pide ruta propia para ajustes). Se descarta (B) borrar el subsistema.

Cambios (rama `refactor/DTA-013`):

1. **`GetMaterialApp` (MyApp)** declara ahora `initialRoute: AppPages.initPage` y `getPages: AppPages.routes`, en vez de `home: SplashPage()`. Se conserva `initialBinding: InitialBinding()` — añadir `getPages` no lo desplaza (verificado: la app sigue registrando dependencias al arrancar).
2. **Splash** navega con `Get.offAllNamed(AppRoutes.home)`. Su transición `fadeIn` de 500 ms se movió al `GetPage` de home, fuera del sitio de la llamada (como manda la convención).
3. **Los dos modales** (`base_modal.dart`, `converter_modals.dart`) cierran con `Get.back()` en lugar de `Navigator.pop`.
4. **Documentación alineada con el código real**: se elimina el bullet de "Navigation deviations" de `CLAUDE.md`/`AGENTS.md` (sincronizados, byte-idénticos), y la sección "Deuda conocida" de `navigation-convention.md` pasa a un estado "sin desviaciones".
5. **Test estructural** (`test/config/routes/app_pages_test.dart`): cada constante de `AppRoutes` está registrada en `AppPages.routes`, sin duplicados, y cada página construye. Es justamente la clase de bug que el issue describe —una ruta declarada pero no registrada falla en runtime, no en compilación— convertida en un check de CI.

### Decisiones de detalle
- **`ConfigurationErrorApp` conserva `home:`**: es una pantalla terminal de error (config inválida) sin navegación, no una ruta de la app. Meterla en `AppPages` sería incorrecto.
- **El dashboard sigue montándose con `IndexedStack`**, así que el defecto del `dispose()` que menciona el issue (registrado en #37) **no** se activa: esta issue no cambia cómo se monta el dashboard, solo cómo se llega a él.

## Fuera de alcance (como indicaba el issue)

Pantallas nuevas ni rutas nuevas. Esta issue arregla la infraestructura y la documentación.

Issue de GitHub relacionado: Closes #58

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad
- [ ] 🛠️ Corrección de errores
- [ ] ❌ Cambio importante
- [ ] 📝 Actualización de la documentación
- [x] 🧹 Code refactoring (modificación de la estructura interna del código sin modificar las APIs)
- [ ] ✅ Build configuration change
- [ ] 🗑️ Chore

## ¿Cómo se ha probado esto?

- [x] `flutter analyze` → **`No issues found!`** (config estricta de #29, sin flags).
- [x] `flutter test` — suite en verde, incluidos los 4 casos nuevos de `AppPages`.
- [x] `grep` confirma que no queda ningún `Navigator.` ni `Get.offAll(`/`Get.to(` con widget en `lib/`: la navegación es 100% por nombre + `Get.back()`.
- [x] `diff CLAUDE.md AGENTS.md` sin diferencias.
- [ ] **Pendiente de verificación manual en dispositivo/emulador** (el issue la exige explícitamente para la opción A). Los cinco flujos a comprobar:
  1. **splash → dashboard**: arranca en el splash y transiciona (fadeIn) a home tras el delay.
  2. **cambio de pestaña**: home ↔ converter mueve `NavigationController.selectedIndex`, sin navegar la pila.
  3. **modal de ajustes**: abre y cierra con la X (`Get.back()`).
  4. **selector de moneda**: abre el modal y al elegir una divisa se cierra solo.
  5. **cierre de modales**: todos cierran con `Get.back()` sin dejar la pila en estado raro.

  El test estructural cubre que las rutas resuelven a nivel de registro; la resolución end-to-end con transición es lo que falta ver a ojo.

**Configuración de prueba**: Android/iOS pendiente. El cambio es de wiring de navegación; conviene el smoke test de los cinco flujos en al menos una plataforma.

## Lista de Verificación

- [x] He agregado las nuevas dependencias (`pubspec.yaml`) en la descripción — ninguna
- [x] He agregado las nuevas variables de entorno a la descripción — ninguna
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código — el porqué de la transición en el `GetPage` y del `home:` que conserva `ConfigurationErrorApp`
- [x] He realizado los cambios correspondientes a la documentación (`CLAUDE.md`, `AGENTS.md`, `navigation-convention.md`)
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente con mis cambios
- [ ] La app compila y el flujo afectado se probó en dispositivo real — **pendiente**, ver arriba
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas — no aplica
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper de cálculo, incluí sus tests — no aplica; aun así se añadió test estructural de rutas
- [x] No introduje modelos en la UI ni en los controladores — no aplica
