### PR TITLE
[📝 Doc: DTA-014] - Registrar la decisión de mantener ever→update

### DIFF
--- a/.agents/skills/getx-architecture/SKILL.md
+++ b/.agents/skills/getx-architecture/SKILL.md
@@ -86,7 +86,7 @@ The cost is that rebuilds are explicit: **if you add reactive state to a service
   }
   ```
 
-  `HomeController` and `ConverterController` currently register workers without disposing them. Fix it when you touch either file.
+  `HomeController` and `ConverterController` currently register workers without disposing them ([#45](https://github.com/Teixeira49/bcv_tracker_app/issues/45)) — fix it when you touch either file. But this is not only a debt to clear once: because the `ever → update()` pattern was **kept** over `Obx`-granular (#60), disposing every worker in `onClose()` is a standing requirement of the convention. Every new controller that registers a worker owns its disposal, forever.
 
 * **Dependencies are registered only in `initial_bindings.dart`.** `main.dart` currently also does `Get.put(SettingsController())`, duplicating the `Get.lazyPut<SettingsController>` in the binding. Do not copy that pattern; see `.agents/rules/dependency-injection.md`.
 
@@ -99,3 +99,5 @@ The cost is that rebuilds are explicit: **if you add reactive state to a service
 * **Navigate with named routes.** `Get.toNamed` / `Get.offAllNamed`, never `Navigator` and never by passing a widget — see `.agents/rules/navigation-convention.md`.
 
 * **GetX is a settled decision, not an open comparison.** Generic Flutter material — including `flutter-expert` in this same directory — will suggest BLoC or Riverpod, and rate GetX as fit for "rapid prototyping". Do not propose a migration as part of an unrelated task. If you think the stack should change, that is its own issue with its own discussion.
+
+* **The `ever(...) => update()` bridge is a settled decision too.** Replacing it with granular `Obx` was proposed by the audit and declined in [#60](https://github.com/Teixeira49/bcv_tracker_app/issues/60): the view↔service boundary it buys was judged worth the coarser rebuilds. See `references/reactivity.md`. The trade-off is that disposing every worker (below) is a **permanent** requirement, not optional — do not treat #45 as a bug that, once fixed, ends the discipline.

--- a/.agents/skills/getx-architecture/references/reactivity.md
+++ b/.agents/skills/getx-architecture/references/reactivity.md
@@ -37,6 +37,19 @@ Widget build(BuildContext context) => GetBuilder<HomeController>(
 - `custom_bottom_navigator_bar.dart` and `dashboard_page.dart` → `NavigationController.selectedIndex`, an `RxInt` owned by that controller.
 - `settings_widgets.dart` (×2) → `SettingsController` observables, inside a `GetBuilder` that supplies the controller.
 
+## Decision: `ever → update()` stays (#60)
+
+The 2026-08-03 audit (findings ARQ-07 / EFF-02) proposed replacing the
+`ever(...) => update()` bridge with granular `Obx` reading the repository's
+observables directly. It was **considered and declined** in [#60](https://github.com/Teixeira49/bcv_tracker_app/issues/60). The reasoning, so it is not relitigated on every screen:
+
+- **The bridge is a real boundary, not inertia.** With plain getters the view never names `CurrencyRepository`'s `Rx` types; a view doing `Obx(() => ...repository.x.value)` would weld the service's reactive shape into the widget's contract. Keeping that boundary was judged worth more than the granular-rebuild win — the same argument as `entities-vs-models.md`.
+- **`update()`'s coarseness is a known, bounded cost.** A whole-controller rebuild on a rate refresh is acceptable on the screens this app has; if a specific screen ever shows measurable jank, scope it with `update(['id'])` + `GetBuilder(id: 'id')` rather than switching the whole app to `Obx`.
+
+**The consequence you must honour:** keeping the pattern makes worker disposal a **permanent** requirement, not a one-time cleanup. Every `ever`/`debounce`/`interval` in a controller needs its `onClose()` — see `lifecycle-and-di.md` and [#45](https://github.com/Teixeira49/bcv_tracker_app/issues/45). That discipline is the price of this decision; it does not expire.
+
+Migrating to `Obx`-granular is not off the table forever, but it is its own issue with its own device-verification pass across every screen in light and dark — not a change to fold into unrelated work.
+
 ## Which one to use
 
 Use **`GetBuilder`** when the data comes from `CurrencyRepository` through a feature controller. It matches the surrounding code and keeps the service's `Rx` types out of the widget.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ flutter build ios --release          # iOS release build
 
 ## Architecture
 
-**State management**: GetX. Reactive `Rx` state lives in a **service**, not in feature controllers: `CurrencyRepository` (a `GetxService`, `permanent`) owns the observables; feature controllers expose plain unwrapped getters and bridge changes with `ever(...) => update()`; views use `GetBuilder` (17 uses) far more than `Obx` (4). If you add reactive state to a service and forget the `ever`, the screen silently stops refreshing. See `.agents/skills/getx-architecture`.
+**State management**: GetX. Reactive `Rx` state lives in a **service**, not in feature controllers: `CurrencyRepository` (a `GetxService`, `permanent`) owns the observables; feature controllers expose plain unwrapped getters and bridge changes with `ever(...) => update()`; views use `GetBuilder` (17 uses) far more than `Obx` (4). This `ever → update()` bridge is a **deliberate, retained decision** — the audit proposed migrating to granular `Obx` and it was declined in [#60](https://github.com/Teixeira49/bcv_tracker_app/issues/60), to keep the view↔service boundary (views never name the repository's `Rx` types). Its price is that disposing every worker is a permanent requirement (see below). If you add reactive state to a service and forget the `ever`, the screen silently stops refreshing. See `.agents/skills/getx-architecture`.
 
 **Dependency injection**: declared in `lib/config/bindings/initial_bindings.dart` with `Get.lazyPut` / `Get.put`. This is the single place to register controllers, repositories and services — resolve with `Get.find()`, never instantiate a controller inside a widget.
 
@@ -128,7 +128,7 @@ Tests live in `test/`, mirroring `lib/`. Any change to a data source, a market m
 
 Verified against the code. Fix on contact where the rule says so; do not treat as invisible:
 
-- **GetX workers are never disposed** — `HomeController` and `ConverterController` register `ever()` without `onClose()`. `get` 4.7.3 has no automatic disposal, and `CurrencyRepository` is `permanent`, so listeners accumulate on every `fenix` recreation. Tracked in [#45](https://github.com/Teixeira49/bcv_tracker_app/issues/45).
+- **GetX workers are never disposed** — `HomeController` and `ConverterController` register `ever()` without `onClose()`. `get` 4.7.3 has no automatic disposal, and `CurrencyRepository` is `permanent`, so listeners accumulate on every `fenix` recreation. Tracked in [#45](https://github.com/Teixeira49/bcv_tracker_app/issues/45). Because the `ever → update()` pattern was kept over `Obx`-granular ([#60](https://github.com/Teixeira49/bcv_tracker_app/issues/60)), this is a **permanent convention requirement**, not a one-time fix: every controller with a worker owns its `onClose()`, always.
 - **`SettingsController` is registered twice** — `Get.put` in `main.dart` and `Get.lazyPut` in `initial_bindings.dart:30`.
 - **`WidthValues` is unused** — the 8pt grid is declared but the 21 `EdgeInsets` in the app carry bare numbers.
 - **Placeholder bundle identifiers** — `com.example.*` on both platforms blocks store publishing. Tracked in [#22](https://github.com/Teixeira49/bcv_tracker_app/issues/22).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ flutter build ios --release          # iOS release build
 
 ## Architecture
 
-**State management**: GetX. Reactive `Rx` state lives in a **service**, not in feature controllers: `CurrencyRepository` (a `GetxService`, `permanent`) owns the observables; feature controllers expose plain unwrapped getters and bridge changes with `ever(...) => update()`; views use `GetBuilder` (17 uses) far more than `Obx` (4). If you add reactive state to a service and forget the `ever`, the screen silently stops refreshing. See `.agents/skills/getx-architecture`.
+**State management**: GetX. Reactive `Rx` state lives in a **service**, not in feature controllers: `CurrencyRepository` (a `GetxService`, `permanent`) owns the observables; feature controllers expose plain unwrapped getters and bridge changes with `ever(...) => update()`; views use `GetBuilder` (17 uses) far more than `Obx` (4). This `ever → update()` bridge is a **deliberate, retained decision** — the audit proposed migrating to granular `Obx` and it was declined in [#60](https://github.com/Teixeira49/bcv_tracker_app/issues/60), to keep the view↔service boundary (views never name the repository's `Rx` types). Its price is that disposing every worker is a permanent requirement (see below). If you add reactive state to a service and forget the `ever`, the screen silently stops refreshing. See `.agents/skills/getx-architecture`.
 
 **Dependency injection**: declared in `lib/config/bindings/initial_bindings.dart` with `Get.lazyPut` / `Get.put`. This is the single place to register controllers, repositories and services — resolve with `Get.find()`, never instantiate a controller inside a widget.
 
@@ -128,7 +128,7 @@ Tests live in `test/`, mirroring `lib/`. Any change to a data source, a market m
 
 Verified against the code. Fix on contact where the rule says so; do not treat as invisible:
 
-- **GetX workers are never disposed** — `HomeController` and `ConverterController` register `ever()` without `onClose()`. `get` 4.7.3 has no automatic disposal, and `CurrencyRepository` is `permanent`, so listeners accumulate on every `fenix` recreation. Tracked in [#45](https://github.com/Teixeira49/bcv_tracker_app/issues/45).
+- **GetX workers are never disposed** — `HomeController` and `ConverterController` register `ever()` without `onClose()`. `get` 4.7.3 has no automatic disposal, and `CurrencyRepository` is `permanent`, so listeners accumulate on every `fenix` recreation. Tracked in [#45](https://github.com/Teixeira49/bcv_tracker_app/issues/45). Because the `ever → update()` pattern was kept over `Obx`-granular ([#60](https://github.com/Teixeira49/bcv_tracker_app/issues/60)), this is a **permanent convention requirement**, not a one-time fix: every controller with a worker owns its `onClose()`, always.
 - **`SettingsController` is registered twice** — `Get.put` in `main.dart` and `Get.lazyPut` in `initial_bindings.dart:30`.
 - **`WidthValues` is unused** — the 8pt grid is declared but the 21 `EdgeInsets` in the app carry bare numbers.
 - **Placeholder bundle identifiers** — `com.example.*` on both platforms blocks store publishing. Tracked in [#22](https://github.com/Teixeira49/bcv_tracker_app/issues/22).


### PR DESCRIPTION
# Descripción

#60 **arranca con una decisión, no con una migración**: la auditoría (ARQ-07 / EFF-02) propuso sustituir el puente `ever(...) => update()` por `Obx` granular leyendo los observables del repositorio. El propio issue lo dice: "lo primero es decidir si se cambia. Si la respuesta es no, esta issue se cierra … y la auditoría queda respondida."

**Decisión (consultada y confirmada con el mantenedor): mantener el patrón `ever → update()`.** No se migra.

## El motivo (escrito, para no relitigar por pantalla)

- **El puente es una frontera real, no inercia.** Con getters planos la vista nunca nombra los tipos `Rx` de `CurrencyRepository`; una vista con `Obx(() => ...repository.x.value)` soldaría la forma reactiva del servicio al contrato del widget. Ese desacoplamiento vista↔servicio se juzgó más valioso que la ganancia de reconstrucción granular — el mismo argumento de `entities-vs-models.md`.
- **La grosería de `update()` es un coste conocido y acotado.** Un redibujado de todo el controlador en un refresco de tasas es aceptable en las pantallas que esta app tiene; si alguna mostrara jank medible, se acota con `update(['id'])` + `GetBuilder(id: 'id')`, no cambiando toda la app a `Obx`.
- **El coste de mantener el patrón:** disponer cada worker pasa a ser un requisito **permanente**, no una limpieza puntual. Cada `ever`/`debounce`/`interval` en un controlador necesita su `onClose()`. #45 deja de ser "un bug que, una vez arreglado, cierra el tema" y se vuelve disciplina permanente de la convención.

## Qué se documentó (sin cambio de código)

| Archivo | Cambio |
|---|---|
| `.agents/skills/getx-architecture/references/reactivity.md` | Sección "Decision" nueva: el razonamiento y el coste acotado de `update()`. |
| `.agents/skills/getx-architecture/SKILL.md` | El puente `ever → update()` marcado como decisión asentada, junto a la de GetX-vs-BLoC; y el constraint de workers elevado a requisito permanente. |
| `CLAUDE.md` / `AGENTS.md` (sincronizados) | La nota de state management nombra la decisión (#60); el bullet de #45 en *Known debt* se reencuadra como requisito permanente de la convención. |

Ningún cambio en `lib/` ni en `test/`: mantener el patrón significa que no había nada que reescribir.

## Fuera de alcance (como indicaba el issue)

Cambiar quién es dueño del estado — `CurrencyRepository` sigue siendo el propietario de los observables. Y la migración a `Obx` no queda descartada para siempre: sería su propia issue, con su pase de verificación en dispositivo (claro y oscuro) en cada pantalla, no un cambio para colar en trabajo ajeno.

Issue de GitHub relacionado: Closes #60

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad
- [ ] 🛠️ Corrección de errores
- [ ] ❌ Cambio importante
- [x] 📝 Actualización de la documentación
- [ ] 🧹 Code refactoring
- [ ] ✅ Build configuration change
- [ ] 🗑️ Chore

## ¿Cómo se ha probado esto?

- [x] `flutter analyze` → `No issues found!` (sin cambio de código, se mantiene).
- [x] `flutter test` — suite en verde (sin cambio de código).
- [x] `diff CLAUDE.md AGENTS.md` sin diferencias.
- [x] Los recuentos citados en la doc se verificaron contra el código: 17 `GetBuilder`, 4 `Obx`, 7 `ever`, 9 `update()`.
- [x] No aplica prueba en dispositivo: es documentación de una decisión; el código no cambia.

**Configuración de prueba**: no aplica — cambio documental.

## Lista de Verificación

- [x] He agregado las nuevas dependencias a la descripción — ninguna
- [x] He agregado las nuevas variables de entorno a la descripción — ninguna
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código — no aplica, documentación
- [x] He realizado los cambios correspondientes a la documentación — **es** el cambio
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente
- [x] La app compila y el flujo afectado se probó — no aplica: sin cambio de código
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas — no aplica
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper — no aplica: sin cambio de código
- [x] No introduje modelos en la UI ni en los controladores — no aplica
