### PR TITLE
[✅ Build: DTA-015] - Eliminar dependencias declaradas sin usar

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,22 +81,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
-  connectivity_plus:
-    dependency: "direct main"
-    description:
-      name: connectivity_plus
-      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.5"
-  connectivity_plus_platform_interface:
-    dependency: transitive
-    description:
-      name: connectivity_plus_platform_interface
-      sha256: "42657c1715d48b167930d5f34d00222ac100475f73d10162ddf43e714932f204"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   crypto:
     dependency: transitive
     description:
@@ -105,30 +89,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
-  csslib:
-    dependency: transitive
-    description:
-      name: csslib
-      sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.2"
-  cupertino_icons:
-    dependency: "direct main"
-    description:
-      name: cupertino_icons
-      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.8"
-  dbus:
-    dependency: transitive
-    description:
-      name: dbus
-      sha256: "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.11"
   dio:
     dependency: "direct main"
     description:
@@ -256,14 +216,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.7.2"
-  html:
-    dependency: "direct main"
-    description:
-      name: html
-      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.15.6"
   http:
     dependency: transitive
     description:
@@ -368,14 +320,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  nm:
-    dependency: transitive
-    description:
-      name: nm
-      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.0"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,21 +31,16 @@ dependencies:
   flutter:
     sdk: flutter
 
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  connectivity_plus: ^6.1.0
   dio: ^5.7.0
   equatable: ^2.0.8
   flutter_dotenv: ^5.1.0
   flutter_svg: ^2.0.11
   get: ^4.6.6
   intl: ^0.18.1
-  html: ^0.15.6
 
   shared_preferences: ^2.2.3
   skeletonizer: ^2.0.0
 
-  cupertino_icons: ^1.0.8
   firebase_core: ^4.10.0
 
 dev_dependencies:


### PR DESCRIPTION
# Descripción

Tres dependencias directas estaban declaradas en `pubspec.yaml` y **no se importaban en ningún archivo** de `lib/`:

| Dependencia | Destino | Motivo |
|---|---|---|
| `html: ^0.15.6` | **Eliminada** | Sin uso; el parseo de HTML vive en el backend (BeautifulSoup), no en la app. Sin uso previsto. |
| `connectivity_plus: ^6.1.0` | **Eliminada** | Ni un `import` ni una llamada a `Connectivity()`. Arrastra código nativo y **permisos** en Android e iOS para cero uso actual. |
| `cupertino_icons: ^1.0.8` | **Eliminada** | Default de `flutter create`, pero `CupertinoIcons` no se referencia en ningún sitio. |

Tras la limpieza, **toda dependencia directa restante se usa** (verificado con grep de `package:<dep>/` en `lib/` + `test/`): `dio`, `equatable`, `flutter_dotenv`, `flutter_svg`, `get`, `intl`, `shared_preferences`, `skeletonizer`, `firebase_core`. Los `dev_dependencies` (`flutter_test`, `flutter_lints`, `change_app_package_name`, `flutter_launcher_icons`) son el framework de test, el linter y dos herramientas CLI que se ejecutan por comando, no por import.

## Las decisiones que el issue pedía

- **`html`**: sin uso previsto → fuera, definitivo.
- **`connectivity_plus`**: el issue permite conservarla "si se cablea" en #18/#17, pero **cablearla está fuera del alcance de #26** ("No incluir: ... cablearla"). La User Story pide "no cargar peso ni permisos que nadie necesita", y una dependencia con permisos nativos y cero uso es exactamente eso. **Decisión: eliminarla ahora; #18 la re-añade** cuando implemente la distinción sin-internet/servidor-caído. Re-declararla es una línea. Dejo constancia en #18.
- **`cupertino_icons`**: este va **más allá de los dos paquetes que nombraba el issue**, pero el alcance dice "revisar **todas** las dependencias ... eliminar las que no se usan", y ésta lo está. Lo señalo explícitamente por si se quería conservar el default del template; re-añadirla es trivial si algún día se usa un icono estilo iOS.

## Fuera de alcance (como indicaba el issue)

Actualizar versiones de las dependencias que sí se usan.

Issue de GitHub relacionado: Closes #26

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad
- [ ] 🛠️ Corrección de errores
- [ ] ❌ Cambio importante
- [ ] 📝 Actualización de la documentación
- [ ] 🧹 Code refactoring
- [x] ✅ Build configuration change (modificación de los archivos para hacer deploy) — `pubspec.yaml`
- [ ] 🗑️ Chore

## ¿Cómo se ha probado esto?

- [x] `flutter pub get` — resuelve sin error; `pubspec.lock` regenerado (los tres paquetes y sus transitivos ya no figuran como directos).
- [x] Verificado que ninguna de las tres se importa: `grep -rn "connectivity_plus\|package:html\|CupertinoIcons\|Connectivity(" lib/ test/` no devuelve nada.
- [x] Auditoría de las 9 deps directas restantes: todas con al menos un import real.
- [x] `flutter analyze` → **`No issues found!`** (config estricta de #29).
- [x] `flutter test` — toda la suite en verde.
- [ ] **Pendiente de verificación de build en dispositivo** (el criterio pide "compila en Android e iOS"): `flutter build apk` / `flutter build ios`. `pub get` + `analyze` + `test` pasan; el build completo lo corre Codemagic sobre `master`, y el workflow de PR (#27) corre analyze+test en esta PR. Como se **quitaron** deps (no se añadieron), el riesgo de romper el build es bajo — ninguna se referenciaba.

**Configuración de prueba**: cambio de `pubspec.yaml`; sin código. El único riesgo teórico sería que un paquete retirado se usara transitoriamente, descartado por el grep.

## Lista de Verificación

- [x] He agregado las nuevas dependencias (`pubspec.yaml`) en la descripción — no se añaden; se **eliminan** tres, listadas arriba
- [x] He agregado las nuevas variables de entorno a la descripción — ninguna
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código — no aplica
- [x] He realizado los cambios correspondientes a la documentación — el destino de cada dep queda documentado aquí y en #18
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente con mis cambios
- [ ] La app compila en Android e iOS — **pendiente** de build en dispositivo/CI, ver arriba
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas — no aplica
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper — no aplica
- [x] No introduje modelos en la UI ni en los controladores — no aplica
