### PR TITLE
[🧹 Refactor: DTA-016] - Introducir logging estructurado

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -32,12 +32,12 @@ Los enlaces son **relativos**, así que funcionan en cualquier clon. `.agents/sk
 
 ## Las reglas también se enlazan, pero con `paths:`
 
-`.claude/rules/*.md` se carga **en cada sesión**, y las 16 reglas suman 1.841 líneas (~27 mil tokens): cargarlas todas siempre inundaría el contexto, y la propia documentación advierte que eso *reduce* la adherencia.
+`.claude/rules/*.md` se carga **en cada sesión**, y las 17 reglas suman 1.905 líneas (~28 mil tokens): cargarlas todas siempre inundaría el contexto, y la propia documentación advierte que eso *reduce* la adherencia.
 
 La salida es el frontmatter `paths:`, que hace que una regla se cargue **solo al leer archivos que coincidan**. El reparto:
 
 - **4 sin `paths:` → siempre en contexto** (718 líneas, ~10 mil tokens): `issue-convention`, `branch-naming`, `commit-convention` y `pull-request`. Son procedimientos de git y GitHub: ningún archivo los dispara, así que no hay patrón que darles.
-- **12 con `paths:` → bajo demanda**: editar `lib/core/i18n/` trae la regla de i18n y nada más; tocar `pubspec.yaml` trae las tres de versionado.
+- **13 con `paths:` → bajo demanda**: editar `lib/core/i18n/` trae la regla de i18n y nada más; tocar `pubspec.yaml` trae las tres de versionado.
 
 El `paths:` vive en el frontmatter de `.agents/rules/*.md` junto al `description:`. Otros agentes lo ignoran sin problema; Claude Code lo usa para no cargar lo que no toca.
 
@@ -83,6 +83,7 @@ Reglas que el asistente debe respetar. Cada archivo lleva un `description` en el
 | [`environment-variables.md`](rules/environment-variables.md) | Sincroniza `Environment`, `.env.example`, README y `codemagic.yaml` al tocar variables de entorno |
 | [`test-coverage.md`](rules/test-coverage.md) | Toda fuente, endpoint, controlador o helper de cálculo nace con sus tests en el mismo PR |
 | [`documentation-convention.md`](rules/documentation-convention.md) | Todo lo público nace documentado con dartdoc, explicando el porqué y no el qué |
+| [`logging-convention.md`](rules/logging-convention.md) | Todo pasa por `AppLogger` con niveles; cada `catch` de un límite registra su causa; en release nada sensible ni URLs en crudo |
 
 ---
 

--- a/.agents/rules/logging-convention.md
+++ b/.agents/rules/logging-convention.md
@@ -1,0 +1,67 @@
+---
+description: Obliga a registrar a través del único logger del proyecto (AppLogger), con niveles, prohibiendo print/debugPrint/dart:developer suelto, y a que todo catch de un límite del sistema registre su causa antes de traducirla a estado de UI. En release no se registra información sensible ni URLs en crudo. Aplica al tocar la capa de red, los repositorios o un controlador que transforme un error en estado visible.
+paths:
+  - "lib/core/logging/**"
+  - "lib/core/network/**"
+  - "lib/shared/data/**"
+  - "lib/**/controller/**"
+---
+
+# Logging
+
+La app registra a través de **un único logger**: `AppLogger` (`lib/core/logging/app_logger.dart`). No hay `print`, no hay `debugPrint`, no hay `dart:developer log` suelto — todo pasa por ahí, con niveles.
+
+El riesgo que evita: los `catch` de los límites del sistema (red, parseo del contrato, refresco de datos) absorben la excepción y la convierten en estado de UI. Sin logging, el motivo real —el `message` y el `statusCode` que `ApiException` sí trae— se pierde en el momento en que se vuelve un texto de error en pantalla, y un fallo reportado por un usuario hay que diagnosticarlo a ciegas.
+
+## Regla
+
+1. **Un solo logger.** `AppLogger.debug/info/warning/error`. Nunca `print`, `debugPrint` ni `dart:developer log` directo. El lint `avoid_print` bloquea el primero; esta regla cubre el resto.
+2. **Todo `catch` de un límite del sistema registra la causa** antes de traducirla a estado de UI o de volver a lanzarla. "Límite del sistema" es: la capa de red (`HttpManager`, `DollarApiRest`), los repositorios (`DollarRepository`, `CurrencyRepository`) y cualquier controlador que transforme un error en estado visible. El log lleva el `error` y el `stackTrace`; la UI lleva el mensaje para el usuario. Son dos cosas distintas y van a sitios distintos.
+3. **El nivel expresa gravedad**, y se elige a conciencia:
+
+   | Nivel | Cuándo |
+   |---|---|
+   | `debug` | Trazas de desarrollo: una petición saliente, una transición de estado. Se silencian en release. |
+   | `info` | Hitos normales del ciclo de vida que ayudan a leer un log, sin ser un problema. |
+   | `warning` | Algo salió mal pero la app se recupera o degrada: un parseo que falla, un timeout, un valor inesperado del backend. |
+   | `error` | Un fallo que el usuario nota: el refresco de tasas que no completa, una excepción no recuperable. |
+
+4. **En release no se registra información sensible.** `AppLogger.minLevel` es `warning` en release, así que los `debug`/`info` —los que más probablemente llevan una URL o un payload— no llegan al build distribuido. Y **una URL nunca se registra en crudo**: pasa por `AppLogger.redactUri`, que quita el `user:pass@` y el query string donde viviría un token. Nada de credenciales, claves ni datos personales en el log, en ningún nivel.
+5. **El nivel es configuración, no decisión de cada llamada.** `AppLogger.minLevel` gobierna el umbral en un solo sitio; un call site no sube ni baja verbosidad por su cuenta.
+
+## Ejemplo
+
+**❌ Antes** — la causa se pierde:
+
+```dart
+try {
+  await _fetch();
+} catch (e) {
+  errorMessage.value = 'No se pudieron cargar las tasas';   // ← el porqué se evaporó
+}
+```
+
+**✅ Después** — el usuario ve un mensaje, el log guarda la causa:
+
+```dart
+try {
+  await _fetch();
+} catch (e, s) {
+  errorMessage.value = 'No se pudieron cargar las tasas';
+  AppLogger.error('Rate refresh failed', name: 'CurrencyRepository', error: e, stackTrace: s);
+}
+```
+
+## Fuera de alcance
+
+- **El envío remoto** de estos errores (Crashlytics) es #34, no esta regla. `AppLogger` es el punto único donde ese envío se enchufará el día que se haga: una razón más para que todo pase por él.
+
+## Verificación
+
+```bash
+# Nada debe registrar fuera del logger
+grep -rn "print(\|debugPrint(\|dart:developer" lib/ | grep -v "app_logger.dart"
+# → vacío (salvo el propio AppLogger, que envuelve dart:developer)
+
+flutter analyze   # avoid_print está activo y es fatal en CI
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ BCV Tracker is a Flutter mobile app that displays real-time Venezuelan Central B
 
 This file is the **map** of the codebase; `.agents/rules/` holds the **binding conventions**. When they disagree, the rules win — and the contradiction gets fixed in the same PR.
 
-`.agents/` is the single source. `.claude/rules/` and `.claude/skills/` are symlinks into it, so Claude Code discovers both natively and no file exists twice. **How each loads differs, and it matters:** four rules are always in context, twelve load only when you touch the files they govern, and skills load on demand from their description. If you are about to do something a path-scoped rule covers and it has not loaded, open it.
+`.agents/` is the single source. `.claude/rules/` and `.claude/skills/` are symlinks into it, so Claude Code discovers both natively and no file exists twice. **How each loads differs, and it matters:** four rules are always in context, thirteen load only when you touch the files they govern, and skills load on demand from their description. If you are about to do something a path-scoped rule covers and it has not loaded, open it.
 
 ### Always in context — the git and GitHub procedures
 
@@ -31,6 +31,7 @@ No file edit can trigger these, so they are unconditional. Shared verbatim with 
 |---|---|
 | `.agents/rules/entities-vs-models.md` | `shared/data/model/`, `shared/data/datasource/`, any `domain/entities/` |
 | `.agents/rules/dependency-injection.md` | `config/bindings/`, any `controller/`, `shared/data/repositories/`, `main.dart` |
+| `.agents/rules/logging-convention.md` | `core/logging/`, `core/network/`, `shared/data/`, any `controller/` |
 | `.agents/rules/navigation-convention.md` | `config/routes/`, any `page/` or `widget(s)/`, `navigation/` |
 | `.agents/rules/i18n-convention.md` | `core/i18n/`, any `page/` or `widget(s)/` |
 | `.agents/rules/constants-centralization.md` | `core/constants/`, `config/theme/`, any `page/` or `widget(s)/` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ BCV Tracker is a Flutter mobile app that displays real-time Venezuelan Central B
 
 This file is the **map** of the codebase; `.agents/rules/` holds the **binding conventions**. When they disagree, the rules win — and the contradiction gets fixed in the same PR.
 
-`.agents/` is the single source. `.claude/rules/` and `.claude/skills/` are symlinks into it, so Claude Code discovers both natively and no file exists twice. **How each loads differs, and it matters:** four rules are always in context, twelve load only when you touch the files they govern, and skills load on demand from their description. If you are about to do something a path-scoped rule covers and it has not loaded, open it.
+`.agents/` is the single source. `.claude/rules/` and `.claude/skills/` are symlinks into it, so Claude Code discovers both natively and no file exists twice. **How each loads differs, and it matters:** four rules are always in context, thirteen load only when you touch the files they govern, and skills load on demand from their description. If you are about to do something a path-scoped rule covers and it has not loaded, open it.
 
 ### Always in context — the git and GitHub procedures
 
@@ -31,6 +31,7 @@ No file edit can trigger these, so they are unconditional. Shared verbatim with 
 |---|---|
 | `.agents/rules/entities-vs-models.md` | `shared/data/model/`, `shared/data/datasource/`, any `domain/entities/` |
 | `.agents/rules/dependency-injection.md` | `config/bindings/`, any `controller/`, `shared/data/repositories/`, `main.dart` |
+| `.agents/rules/logging-convention.md` | `core/logging/`, `core/network/`, `shared/data/`, any `controller/` |
 | `.agents/rules/navigation-convention.md` | `config/routes/`, any `page/` or `widget(s)/`, `navigation/` |
 | `.agents/rules/i18n-convention.md` | `core/i18n/`, any `page/` or `widget(s)/` |
 | `.agents/rules/constants-centralization.md` | `core/constants/`, `config/theme/`, any `page/` or `widget(s)/` |

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Este repositorio versiona convenciones y capacidades para desarrollo asistido po
 
 ```
 .agents/
-├── rules/    # 16 convenciones obligatorias (issues, ramas, commits, PR, releases,
+├── rules/    # 17 convenciones obligatorias (issues, ramas, commits, PR, releases,
 │             #  versionado y las reglas técnicas de Flutter/Dart/GetX)
 └── skills/   # 24 skills, de 6 orígenes (ver .agents/ATTRIBUTION.md)
 ```

--- a/lib/core/logging/app_logger.dart
+++ b/lib/core/logging/app_logger.dart
@@ -1,0 +1,113 @@
+import 'dart:developer' as developer;
+
+import 'package:flutter/foundation.dart';
+
+/// Severity of a log record. The numeric value follows the `dart:developer`
+/// convention (higher is more severe), so it maps straight onto `log(level:)`
+/// and onto the IDE's log filtering.
+enum LogLevel {
+  debug(500),
+  info(800),
+  warning(900),
+  error(1000);
+
+  const LogLevel(this.value);
+
+  /// The `dart:developer` level int this severity emits at.
+  final int value;
+}
+
+/// The project's single logging entry point.
+///
+/// The app used to log almost nothing: the `catch` blocks at the system
+/// boundaries absorbed the exception and turned it into UI state, so the real
+/// cause — the `message` and `statusCode` an `ApiException` carries — vanished
+/// the moment it became an error string on screen. This routes those causes to
+/// one place, with levels, before the translation happens.
+///
+/// **This is the standard.** No `print`/`debugPrint` (the `avoid_print` lint
+/// enforces the first); every boundary `catch` logs its cause here. See
+/// `.agents/rules/logging-convention.md`.
+///
+/// **Release stays quiet and clean.** [minLevel] defaults to `warning` in
+/// release, so the verbose `debug`/`info` records — the ones most likely to
+/// carry a URL or a payload — never reach a shipped build. And a URL is logged
+/// through [redactUri], never raw, so no credentials in a query or userinfo
+/// component leak into a device log.
+class AppLogger {
+  AppLogger._();
+
+  /// Records below this level are dropped. `debug` and up in a debug build,
+  /// `warning` and up in release. Settable so a test can pin it and so a build
+  /// can raise or lower verbosity without touching call sites — the log level
+  /// is configuration, not something each caller decides.
+  static LogLevel minLevel = kReleaseMode ? LogLevel.warning : LogLevel.debug;
+
+  /// Whether a record at [level] would be emitted under the current [minLevel].
+  /// Exposed so the threshold is unit-testable without capturing developer log
+  /// output.
+  static bool shouldLog(LogLevel level) => level.value >= minLevel.value;
+
+  static void debug(String message, {String? name}) =>
+      _log(LogLevel.debug, message, name: name);
+
+  static void info(String message, {String? name}) =>
+      _log(LogLevel.info, message, name: name);
+
+  static void warning(
+    String message, {
+    String? name,
+    Object? error,
+    StackTrace? stackTrace,
+  }) => _log(
+    LogLevel.warning,
+    message,
+    name: name,
+    error: error,
+    stackTrace: stackTrace,
+  );
+
+  static void error(
+    String message, {
+    String? name,
+    Object? error,
+    StackTrace? stackTrace,
+  }) => _log(
+    LogLevel.error,
+    message,
+    name: name,
+    error: error,
+    stackTrace: stackTrace,
+  );
+
+  /// Strips the parts of a URL that must never reach a log: the `user:pass@`
+  /// userinfo and the query string, where a token or key would sit. Returns
+  /// `scheme://host[:port]/path`, or the input unchanged if it is not a URL
+  /// (better a harmless string than a thrown logger).
+  static String redactUri(String url) {
+    final uri = Uri.tryParse(url);
+    if (uri == null || !uri.hasScheme) return url;
+    final buffer = StringBuffer('${uri.scheme}://${uri.host}');
+    if (uri.hasPort) buffer.write(':${uri.port}');
+    buffer.write(uri.path);
+    if (uri.hasQuery) buffer.write('?…');
+    return buffer.toString();
+  }
+
+  static void _log(
+    LogLevel level,
+    String message, {
+    String? name,
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    if (!shouldLog(level)) return;
+    developer.log(
+      message,
+      level: level.value,
+      name: name ?? 'bcv_tracker',
+      error: error,
+      stackTrace: stackTrace,
+    );
+  }
+}

--- a/lib/core/network/http_manager.dart
+++ b/lib/core/network/http_manager.dart
@@ -4,10 +4,10 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:developer';
 
 import 'package:dio/dio.dart';
 
+import '../logging/app_logger.dart';
 import 'http_operation.dart';
 
 // Project imports:
@@ -65,6 +65,13 @@ class HttpManager {
 
     final data = json.encode(body ?? {});
 
+    // Endpoint redacted: the request is logged for tracing, but a query string
+    // never reaches the log (see AppLogger.redactUri).
+    AppLogger.debug(
+      '→ ${method.name.toUpperCase()} ${AppLogger.redactUri(endpoint)}',
+      name: _source,
+    );
+
     try {
       switch (method) {
         case HttpOperation.get:
@@ -108,8 +115,8 @@ class HttpManager {
 
       return response;
     } catch (e, s) {
-      log(
-        '❌ HTTP request failed',
+      AppLogger.error(
+        '❌ HTTP request failed for ${AppLogger.redactUri(endpoint)}',
         name: '$_source.request',
         error: e,
         stackTrace: s,

--- a/lib/shared/data/datasource/dollar_api/dollar_api_rest.dart
+++ b/lib/shared/data/datasource/dollar_api/dollar_api_rest.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:bcv_tracker_app/shared/data/datasource/datasource.dart';
 import 'package:dio/dio.dart';
 
+import '../../../../core/logging/app_logger.dart';
 import '../../../../core/network/api_exception.dart';
 import '../../../../core/network/http_manager.dart';
 import '../../model/model.dart';
@@ -15,6 +16,8 @@ class DollarApiRest implements IDollarApi {
 
   final String _apiUrl;
   final HttpManager _client;
+
+  static const String _source = 'DollarApiRest';
 
   @override
   Future<BcvCurrenciesModel> getCurrentBCVDollar() async {
@@ -28,7 +31,13 @@ class DollarApiRest implements IDollarApi {
 
     try {
       return BcvCurrenciesModel.fromJson(data);
-    } catch (e) {
+    } catch (e, s) {
+      AppLogger.warning(
+        'Contract parse failed for bcv/with-memory',
+        name: _source,
+        error: e,
+        stackTrace: s,
+      );
       throw ApiException.malformed(
         'No se pudo interpretar la respuesta de bcv/with-memory: $e',
       );
@@ -50,7 +59,13 @@ class DollarApiRest implements IDollarApi {
           .whereType<Map<String, dynamic>>()
           .map(CurrencyModel.fromJson)
           .toList();
-    } catch (e) {
+    } catch (e, s) {
+      AppLogger.warning(
+        'Contract parse failed for saved-currencies',
+        name: _source,
+        error: e,
+        stackTrace: s,
+      );
       throw ApiException.malformed(
         'No se pudo interpretar la respuesta de saved-currencies: $e',
       );
@@ -64,9 +79,15 @@ class DollarApiRest implements IDollarApi {
     final Response<dynamic> response;
     try {
       response = await _client.request(endpoint: _apiUrl + endpoint);
-    } on DioException catch (e) {
+    } on DioException catch (e, s) {
       // HttpManager accepts every status code, so Dio only throws when there is
       // no response at all (connectivity, DNS, timeout, TLS).
+      AppLogger.warning(
+        'Transport failure calling ${AppLogger.redactUri(_apiUrl + endpoint)}',
+        name: _source,
+        error: e,
+        stackTrace: s,
+      );
       final cause = e.error;
       if (cause is HandshakeException || cause is CertificateException) {
         // Raised when the certificate does not validate against the system
@@ -100,7 +121,13 @@ class DollarApiRest implements IDollarApi {
     final Object? envelope;
     try {
       envelope = json.decode(body);
-    } catch (e) {
+    } catch (e, s) {
+      AppLogger.warning(
+        'Backend responded with a non-JSON body',
+        name: _source,
+        error: e,
+        stackTrace: s,
+      );
       throw ApiException.malformed(
         'El backend respondió con un cuerpo no JSON: $e',
       );

--- a/lib/shared/data/repositories/currency_repository.dart
+++ b/lib/shared/data/repositories/currency_repository.dart
@@ -1,6 +1,5 @@
-import 'dart:developer';
-
 import 'package:get/get.dart';
+import '../../../core/logging/app_logger.dart';
 import '../../../core/network/api_exception.dart';
 import '../../domain/entities/entities.dart';
 import '../../domain/repositories/dollar_repositories.dart';
@@ -46,10 +45,13 @@ class CurrencyRepository extends GetxService {
       await Future.wait([getAveragedCurrencies(), getBCVCurrencies()]);
       errorMessage.value = null;
     } catch (e, s) {
+      // The cause is logged here, at the boundary where it becomes UI state:
+      // `errorMessage` gets the user-facing text, the log keeps the real
+      // exception and stack for diagnosis.
       errorMessage.value = _describe(e);
-      log(
+      AppLogger.error(
         'Error fetching data: $e',
-        name: 'CurrencyRepository.refreshData()',
+        name: 'CurrencyRepository.refreshData',
         error: e,
         stackTrace: s,
       );

--- a/lib/shared/data/repositories/dollar_repositories.dart
+++ b/lib/shared/data/repositories/dollar_repositories.dart
@@ -1,3 +1,4 @@
+import 'package:bcv_tracker_app/core/logging/app_logger.dart';
 import 'package:bcv_tracker_app/shared/data/datasource/dollar_api/dollar.dart';
 import 'package:bcv_tracker_app/shared/domain/entities/entities.dart';
 import 'package:bcv_tracker_app/shared/domain/repositories/repositories.dart';
@@ -7,13 +8,24 @@ class DollarRepository implements IDollarRepository {
 
   final IDollarApi _dollarApi;
 
+  static const String _source = 'DollarRepository';
+
   @override
   Future<BcvCurrencies> getCurrentBCVDollar() async {
     try {
       final data = await _dollarApi.getCurrentBCVDollar();
 
       return data.toEntity();
-    } catch (e) {
+    } catch (e, s) {
+      // A trace point at the repository boundary: the datasource has already
+      // logged the specific parse/transport cause, this records that the BCV
+      // fetch is the one that failed before the error propagates to the service.
+      AppLogger.warning(
+        'getCurrentBCVDollar failed',
+        name: _source,
+        error: e,
+        stackTrace: s,
+      );
       rethrow;
     }
   }
@@ -23,7 +35,13 @@ class DollarRepository implements IDollarRepository {
     try {
       final data = await _dollarApi.getCurrentDollar();
       return data.map((e) => e.toEntity()).toList();
-    } catch (e) {
+    } catch (e, s) {
+      AppLogger.warning(
+        'getCurrentDollar failed',
+        name: _source,
+        error: e,
+        stackTrace: s,
+      );
       rethrow;
     }
   }

--- a/test/core/logging/app_logger_test.dart
+++ b/test/core/logging/app_logger_test.dart
@@ -1,0 +1,82 @@
+import 'package:bcv_tracker_app/core/logging/app_logger.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // The threshold is global mutable state; restore it so one test cannot bleed
+  // into the next.
+  final LogLevel original = AppLogger.minLevel;
+  tearDown(() => AppLogger.minLevel = original);
+
+  group('shouldLog', () {
+    test('emits a record at or above the threshold', () {
+      AppLogger.minLevel = LogLevel.warning;
+
+      expect(AppLogger.shouldLog(LogLevel.warning), isTrue);
+      expect(AppLogger.shouldLog(LogLevel.error), isTrue);
+    });
+
+    test('drops a record below the threshold', () {
+      AppLogger.minLevel = LogLevel.warning;
+
+      expect(AppLogger.shouldLog(LogLevel.debug), isFalse);
+      expect(AppLogger.shouldLog(LogLevel.info), isFalse);
+    });
+
+    test('a debug threshold lets everything through', () {
+      AppLogger.minLevel = LogLevel.debug;
+
+      for (final level in LogLevel.values) {
+        expect(AppLogger.shouldLog(level), isTrue, reason: '$level');
+      }
+    });
+
+    test('an error threshold keeps only errors', () {
+      AppLogger.minLevel = LogLevel.error;
+
+      expect(AppLogger.shouldLog(LogLevel.error), isTrue);
+      expect(AppLogger.shouldLog(LogLevel.warning), isFalse);
+    });
+
+    test('level values are ordered by severity', () {
+      expect(LogLevel.debug.value, lessThan(LogLevel.info.value));
+      expect(LogLevel.info.value, lessThan(LogLevel.warning.value));
+      expect(LogLevel.warning.value, lessThan(LogLevel.error.value));
+    });
+  });
+
+  group('redactUri', () {
+    test('drops the query string, where a token would sit', () {
+      expect(
+        AppLogger.redactUri('https://api.example.com/v1/rates?token=secret'),
+        'https://api.example.com/v1/rates?…',
+      );
+    });
+
+    test('drops the user:pass userinfo', () {
+      expect(
+        AppLogger.redactUri('https://user:pass@api.example.com/v1/rates'),
+        'https://api.example.com/v1/rates',
+      );
+    });
+
+    test('keeps scheme, host, port and path intact', () {
+      expect(
+        AppLogger.redactUri('http://10.0.2.2:8000/api/v1/bcv'),
+        'http://10.0.2.2:8000/api/v1/bcv',
+      );
+    });
+
+    test('leaves a non-URL string untouched instead of throwing', () {
+      expect(AppLogger.redactUri('/api/v1/bcv'), '/api/v1/bcv');
+      expect(AppLogger.redactUri(''), '');
+    });
+
+    test('never leaks a query value it was given', () {
+      final redacted = AppLogger.redactUri(
+        'https://api.example.com/rates?apikey=DEADBEEF&user=me',
+      );
+      expect(redacted, isNot(contains('DEADBEEF')));
+      expect(redacted, isNot(contains('apikey')));
+    });
+  });
+}


### PR DESCRIPTION
# Descripción

La app **no registraba casi nada**: no había `print` ni `debugPrint`, pero tampoco un logger. Los `catch` de los límites del sistema (red, datasource, repositorios) absorbían la excepción y la convertían en estado de UI, de modo que el motivo real —el `message` y el `statusCode` que `ApiException` sí trae— se perdía en el momento en que se volvía un texto de error en pantalla. Un fallo reportado por un usuario había que diagnosticarlo a ciegas.

Cambios (rama `refactor/DTA-016`):

### El logger central
`AppLogger` (`lib/core/logging/app_logger.dart`):
- **Un solo punto de entrada**, cuatro niveles (`debug`/`info`/`warning`/`error`) mapeados a los ints de `dart:developer`.
- **Umbral según el build**: `minLevel` es `warning` en release, así que los `debug`/`info` —los que más probablemente llevan una URL o un payload— no llegan al build distribuido. `minLevel` es **configurable** (settable), no una decisión de cada call site.
- **`redactUri`**: una URL nunca se registra en crudo; se le quitan el `user:pass@` y el query string, donde viviría un token.

### Instrumentación de los límites
- **Red** (`HttpManager`): la petición se traza a `debug` con el endpoint **redactado**; el fallo, a `error`. Se retiró el `dart:developer log` suelto.
- **Datasource** (`DollarApiRest`): los fallos de parseo del contrato (`malformed`) y de transporte (`network`) se registran a `warning` antes de convertirse en `ApiException`.
- **Repositorios** (`DollarRepository`): los dos `catch` que solo hacían `rethrow` ahora registran qué fetch falló, dándoles un propósito. `CurrencyRepository.refreshData` registra la causa justo donde se vuelve estado de UI (se retiró su `dart:developer log`).
- Nada fuera de `AppLogger` toca `dart:developer`, `print` ni `debugPrint`.

### El guardrail
- Regla nueva `.agents/rules/logging-convention.md` (con frontmatter `paths:` para que Claude Code la cargue al tocar red/datos/controllers), registrada en `CLAUDE.md`/`AGENTS.md` (tabla path-scoped, contador 12→13) y en el índice de `.agents/README.md` (16→17 reglas, líneas recalculadas). El guardrail es esa regla **más** el lint `avoid_print`, ya activo desde #29.

### Tests
- `test/core/logging/app_logger_test.dart`: el predicado de umbral `shouldLog` (configurabilidad) y `redactUri` (que nunca filtra un valor de query, ni revienta con un no-URL).

## Fuera de alcance (como indicaba el issue)

El **envío remoto** de estos errores (Crashlytics) es **#34**. `AppLogger` es precisamente el punto único donde ese envío se enchufará el día que se haga.

Issue de GitHub relacionado: Closes #19

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad
- [ ] 🛠️ Corrección de errores
- [ ] ❌ Cambio importante
- [ ] 📝 Actualización de la documentación
- [x] 🧹 Code refactoring (modificación de la estructura interna del código sin modificar las APIs)
- [ ] ✅ Build configuration change
- [ ] 🗑️ Chore

## ¿Cómo se ha probado esto?

- [x] `flutter analyze` → **`No issues found!`** (config estricta de #29; `avoid_print` fatal).
- [x] `flutter test` — suite completa en verde, con los 10 casos nuevos del logger.
- [x] Verificado que nada fuera de `AppLogger` usa `dart:developer`/`print`/`debugPrint`: `grep -rn "print(\|debugPrint(\|dart:developer" lib/ | grep -v app_logger.dart` no devuelve nada real.
- [x] `diff CLAUDE.md AGENTS.md` sin diferencias; contadores de reglas recalculados (17 reglas, 13 path-scoped, 1.905 líneas).
- [ ] **Pendiente de verificación en dispositivo**: comprobar que en un fallo real (backend caído, `.env` a una URL inválida) el log muestra la causa con nivel `error`/`warning` y **sin** la URL en crudo, y que en un build de release los `debug` no aparecen. El comportamiento de la app no cambia (el logging es aditivo).

**Configuración de prueba**: el cambio no altera comportamiento visible; añade trazas. El caso a mirar a ojo es que el log de release no lleve `debug`/`info` ni URLs completas.

## Lista de Verificación

- [x] He agregado las nuevas dependencias a la descripción — ninguna (`dart:developer` es SDK)
- [x] He agregado las nuevas variables de entorno a la descripción — ninguna
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código — `AppLogger` documenta el porqué de cada decisión (umbral, redacción)
- [x] He realizado los cambios correspondientes a la documentación — regla nueva + índices + contadores
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente con mis cambios
- [ ] La app compila y el flujo afectado se probó en dispositivo real — **pendiente**, ver arriba
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas — no aplica
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper de cálculo, incluí sus tests — el logger lleva sus tests; el datasource/repos solo ganan trazas (sin cambio de lógica), y sus tests existentes siguen en verde
- [x] No introduje modelos en la UI ni en los controladores — no aplica
