### PR TITLE
[🧪 Test: DTA-017] - Verificar paridad de claves en los 10 idiomas

### DIFF
--- a/test/core/i18n/translation_parity_test.dart
+++ b/test/core/i18n/translation_parity_test.dart
@@ -1,0 +1,122 @@
+import 'dart:io';
+
+import 'package:bcv_tracker_app/core/i18n/app_translations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The ten language maps, keyed by locale, exactly as `AppTranslations`
+/// registers them for GetX. Using the registration itself means this test also
+/// fails if a language map stops being wired in.
+final Map<String, Map<String, String>> _languages = AppTranslations().keys;
+
+/// The keys `AppMessages` actually asks GetX to translate.
+///
+/// Dart has no runtime reflection here, so the keys are read from the source:
+/// every `'<key>'.tr` in `app_messages.dart`. `flutter test` runs with the
+/// package root as the working directory, so the relative path resolves.
+Set<String> _appMessagesKeys() {
+  final content = File('lib/core/i18n/app_messages.dart').readAsStringSync();
+  return RegExp(
+    r"'([A-Za-z0-9_]+)'\.tr",
+  ).allMatches(content).map((m) => m.group(1)!).toSet();
+}
+
+void main() {
+  group('i18n key parity', () {
+    test('the ten expected languages are registered', () {
+      expect(
+        _languages.keys.toSet(),
+        {
+          'en_US',
+          'es_ES',
+          'pt_PT',
+          'zh_CN',
+          'fr_FR',
+          'de_DE',
+          'it_IT',
+          'ja_JP',
+          'ko_KR',
+          'ru_RU',
+        },
+        reason: 'AppTranslations must register exactly these ten locales.',
+      );
+    });
+
+    test('every language has the same set of keys', () {
+      // The union is the reference: a key present in one language but absent in
+      // another shows up as the others "missing" it. That catches divergence in
+      // either direction and names the language and the exact keys — not a bare
+      // `expected true`, which is the whole point of #36.
+      final Set<String> union = {
+        for (final map in _languages.values) ...map.keys,
+      };
+
+      final problems = <String>[];
+      _languages.forEach((locale, map) {
+        final missing = union.difference(map.keys.toSet());
+        if (missing.isNotEmpty) {
+          final sorted = missing.toList()..sort();
+          problems.add('$locale is missing ${sorted.length} key(s): $sorted');
+        }
+      });
+
+      expect(
+        problems,
+        isEmpty,
+        reason:
+            'The ten languages must share one key set. A key added to only some '
+            'renders as the raw key on screen for the rest:\n${problems.join('\n')}',
+      );
+    });
+
+    test('every key AppMessages exposes exists in all ten languages', () {
+      final keys = _appMessagesKeys();
+      expect(
+        keys,
+        isNotEmpty,
+        reason: 'No `.tr` keys found in app_messages.dart — regex or path off?',
+      );
+
+      final problems = <String>[];
+      for (final key in keys) {
+        final absentIn = _languages.entries
+            .where((e) => !e.value.containsKey(key))
+            .map((e) => e.key)
+            .toList();
+        if (absentIn.isNotEmpty) {
+          problems.add(
+            '"$key" is used by AppMessages but missing in: $absentIn',
+          );
+        }
+      }
+
+      expect(
+        problems,
+        isEmpty,
+        reason:
+            'Every AppMessages getter must resolve in all ten languages:\n'
+            '${problems.join('\n')}',
+      );
+    });
+
+    test('no translation value is empty or equal to its key', () {
+      final problems = <String>[];
+      _languages.forEach((locale, map) {
+        map.forEach((key, value) {
+          if (value.trim().isEmpty) {
+            problems.add('$locale["$key"] is empty');
+          } else if (value == key) {
+            problems.add('$locale["$key"] equals its key (left untranslated)');
+          }
+        });
+      });
+
+      expect(
+        problems,
+        isEmpty,
+        reason:
+            'A value equal to its key or empty renders as the raw key or blank:\n'
+            '${problems.join('\n')}',
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Descripción

La i18n se apoya en tres piezas que nada mantenía sincronizadas: `AppMessages` (los getters `'key'.tr`), los diez mapas `core/i18n/languages/*.dart`, y `AppTranslations` (el registro). Si una clave se añade a `AppMessages` y a un solo idioma, GetX **no falla**: `'clave'.tr` devuelve la propia clave, así que el usuario ve `moneyValue` en pantalla en los otros nueve idiomas. Con diez archivos y copy que cambia seguido, es una regresión silenciosa casi garantizada.

Cambios (rama `test/DTA-017`):

`test/core/i18n/translation_parity_test.dart` — parte de `AppTranslations().keys` (el registro real, así que el test también falla si un idioma deja de estar cableado) y verifica:

1. **Los diez locales esperados están registrados** (`en_US`, `es_ES`, … `ru_RU`).
2. **Los diez idiomas comparten un único conjunto de claves**: compara cada idioma contra la unión y, si diverge, nombra **el idioma y las claves concretas** que faltan.
3. **Cada clave que `AppMessages` expone existe en los diez idiomas**: las claves se extraen leyendo `app_messages.dart` (Dart no tiene reflexión aquí, así que se leen los `'<key>'.tr` de la fuente; `flutter test` corre con la raíz del paquete como CWD).
4. **Ningún valor está vacío ni es igual a su clave** (ambos renderizan la clave cruda o un hueco).

Los mensajes de fallo nombran el idioma y las claves, no un `expected true` pelado — que es justo lo que pedía el issue.

## Verificado que atrapa el bug

Inyectando una clave presente solo en `en_US` y un valor vacío, el test **falla** con `is missing` e `is empty`; al restaurar, vuelve a verde. No es un test que pase de vacío.

## Coordinación

- **Con #27**: es un test normal, así que corre en el check de PR de GitHub Actions — convierte "añadir la clave a los 10 idiomas" en una condición verificable, no un recordatorio.
- **Con #57**: aquel corrige traducciones **contaminadas** (idioma equivocado), que este test **no** detecta (la clave existe y el valor no está vacío ni es igual a la clave). Son independientes: #57 no rompe este test y este no cubre la calidad del idioma.
- **Con #28**: el inventario `docs/lista_de_tests.md` lo actualiza #28 (que amplía la suite); este PR no lo toca, para no solaparse.

## Fuera de alcance (como indicaba el issue)

Juzgar la calidad de la traducción, y detectar claves declaradas y no usadas por la UI (anotado como paso siguiente).

Issue de GitHub relacionado: Closes #36

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad
- [ ] 🛠️ Corrección de errores
- [ ] ❌ Cambio importante
- [ ] 📝 Actualización de la documentación
- [ ] 🧹 Code refactoring
- [ ] ✅ Build configuration change
- [x] 🧪 Test — nuevo test de paridad (marco el tipo real; el checklist de abajo usa la plantilla del repo)

## ¿Cómo se ha probado esto?

- [x] `flutter test` — los 4 casos nuevos en verde, y la suite completa.
- [x] **Verificado que falla ante una divergencia real**: clave solo en `en_US` → `is missing`; valor vacío → `is empty`. Restaurado → verde.
- [x] `flutter analyze` → `No issues found!`.
- [x] No toca `lib/`: es puramente aditivo (un archivo de test).

**Configuración de prueba**: no aplica dispositivo; es un test de datos estáticos.

## Lista de Verificación

- [x] He agregado las nuevas dependencias a la descripción — ninguna (`dart:io` es SDK)
- [x] He agregado las nuevas variables de entorno a la descripción — ninguna
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código — el test documenta por qué lee la fuente y por qué la unión es la referencia
- [x] He realizado los cambios correspondientes a la documentación — no aplica (el inventario lo lleva #28)
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente con mis cambios
- [x] La app compila — no aplica: solo añade un test
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas — no aplica; este test **es** el que lo vigila
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper — no aplica
- [x] No introduje modelos en la UI ni en los controladores — no aplica
