### PR TITLE
[🧪 Test: DTA-019] - Ampliar la suite y exigirla por regla

### DIFF
--- a/.agents/rules/test-coverage.md
+++ b/.agents/rules/test-coverage.md
@@ -54,7 +54,7 @@ No se exige un widget test por cada cambio de UI, pero **sí** cuando el widget 
 
 - **La suite debe quedar en verde**: `flutter test` sin fallos, localmente y en CI.
 - **El análisis estático también**: `flutter analyze` sin nuevos errores.
-- **CI obligatorio**: los workflows de `codemagic.yaml` corren `flutter analyze` y `flutter test` antes de compilar. Un build con tests en rojo no distribuye.
+- **CI obligatorio, en dos puntos**: el workflow de validación de PR (`.github/workflows/pr-validation.yml`, GitHub Actions, #27) corre `flutter analyze` y `flutter test` en **cada PR** hacia `development`/`master` — una PR con tests en rojo no se puede fusionar; y `codemagic.yaml` los vuelve a correr antes de construir, así que un build con tests en rojo tampoco distribuye. El inventario de lo cubierto vive en [`docs/lista_de_tests.md`](../../docs/lista_de_tests.md).
 - No reduzcas la cobertura existente: no borres ni marques con `skip` tests para que pase el build.
 
 ```bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
-# Documentación interna (NO se versiona): planes de migración, listados de
-# trabajo y borradores de PR (el PR canónico vive en GitHub).
-# SÍ se versionan las notas de release, que acompañan a cada tag.
+# Documentación interna (NO se versiona): planes de migración y borradores de
+# PR (el PR canónico vive en GitHub).
+# SÍ se versionan: las notas de release (acompañan a cada tag) y el inventario
+# de tests (`docs/lista_de_tests.md`, mantenido por la suite — ver #28).
 docs/*
 !docs/release/
+!docs/lista_de_tests.md
 
 # Miscellaneous
 *.env

--- a/docs/lista_de_tests.md
+++ b/docs/lista_de_tests.md
@@ -1,0 +1,209 @@
+# Lista de Tests — BCV Tracker
+
+Este documento es el **inventario de la suite**: primero lo que ya está cubierto, después lo que queda por hacer (roadmap). Mantenlo al día al agregar tests — la regla [`test-coverage.md`](../.agents/rules/test-coverage.md) exige que toda fuente, endpoint, controlador o helper de cálculo nuevo nazca con sus tests, y el check de PR de #27 (`flutter test` en GitHub Actions) lo hace cumplir en cada PR.
+
+## Cobertura actual (19 archivos, 123 tests)
+
+| Área | Archivo | Qué cubre |
+|---|---|---|
+| **Helpers** | `test/core/helpers/backend_date_test.dart` | Parseo y formateo de fechas del backend |
+| | `test/core/helpers/currency_helpers_average_test.dart` | Cálculo de promedios y mapeo de códigos |
+| | `test/core/helpers/currency_helpers_parse_date_test.dart` | Formato de fechas para la UI |
+| **Datos / mapeo** | `test/shared/data/currency_normalizer_test.dart` | Normalización del promedio (dedup, merge buy/sell) |
+| | `test/shared/data/bcv_currencies_model_test.dart` | `toEntity()` convierte la lista, no filtra modelos |
+| | `test/shared/data/dollar_api_rest_test.dart` | Datasource: contrato saliente y `ApiException` (mock de `HttpManager`) |
+| **Repositorios** | `test/shared/data/dollar_repository_test.dart` | **(#28)** Devuelve entidades; propaga `ApiException` |
+| | `test/shared/data/currency_repository_test.dart` | **(#28)** `refreshData` éxito, error, fallo parcial, `isLoading` |
+| **Controllers** | `test/features/converter/converter_controller_calculator_test.dart` | Cálculo pivote, división por cero, swap, selectCurrency |
+| | `test/features/home/home_controller_test.dart` | **(#28)** Getters puente y `refreshHomeData` (éxito/error) |
+| | `test/navigation/navigation_controller_test.dart` | **(#28)** `changeIndex`, observabilidad del índice |
+| | `test/shared/presentation/settings_controller_language_test.dart` | Idioma: `orElse`, normalización de código guardado |
+| | `test/shared/presentation/settings_controller_test.dart` | **(#28)** Tema y mercado favorito: persistencia y no-op |
+| **Widgets** | `test/features/home/home_page_test.dart` | **(#28)** Home: estado de error, sin-error, frame |
+| | `test/features/converter/converter_page_test.dart` | **(#28)** Cuerpo del conversor: render e input |
+| **Config / i18n** | `test/config/enviroment/environment_test.dart` + `environment_empty_env_test.dart` | Validación de `CURRENCY_BACK`, `.env` ausente/vacío |
+| | `test/core/i18n/translation_parity_test.dart` | **(#36)** Paridad de claves en los 10 idiomas |
+| | `test/config/routes/app_pages_test.dart` | Registro de rutas nombradas |
+| | `test/config/theme/colors_constants_test.dart` | Opacidad de la paleta (alpha de 8 dígitos) |
+
+> Todos los tests **mockean la red**: ninguno llama al backend real (fakes de `HttpManager` / `IDollarApi` / `IDollarRepository`). Las imágenes de red en los widget tests se evitan vaciando los placeholders del skeleton.
+
+---
+
+## Roadmap — lo que queda por cubrir
+
+> Los tests de `ConverterController.calculator()` ya están implementados en
+> `test/features/converter/converter_controller_calculator_test.dart`.
+
+---
+
+## Unit Tests — `CurrencyHelpers`
+
+> Archivo sugerido: `test/core/helpers/currency_helpers_test.dart`
+
+| # | Test | Descripción |
+|---|------|-------------|
+| 1 | `castCurrencySymbolText` símbolo correcto por código | Verifica que `USD`→`$`, `EUR`→`€`, `VES`→`Bs.S`, `TRY`→`₺`, `CNY`→`¥`, `RUB`→`₽`, `BTC`→`₿`, `USDT`→`₮`, `USDC`→`¢` |
+| 2 | `castCurrencySymbolText` código desconocido | Retorna `''` para un código no reconocido |
+| 3 | `castCurrencySymbolIcon` path correcto por código | Cada código retorna el asset correcto (`flagVenezuelaIcon`, `cryptoBTCIcon`, etc.) |
+| 4 | `castCurrencySymbolIcon` código desconocido | Retorna `''` |
+| 5 | `castCurrencyCountry` mapeo completo | Verifica `countryName`, `currencyCode`, `currencySymbol` para `USD`, `EUR`, `TRY`, `CNY`, `RUB` |
+| 6 | `castCurrencyCountry` código desconocido | Retorna país con `countryName: 'Desconocido'` y `currencyCode: '-'` |
+| 7 | `getAverageValue` calcula promedio correctamente | Lista con múltiples currencies del mismo `keyName`, verifica `sum / count` |
+| 8 | `getAverageValue` lista vacía retorna `0.0` | Sin lanzar excepción |
+| 9 | `getAverageValue` sin coincidencias retorna `0.0` | Ningún elemento tiene el `currencyCode` buscado; división por 0 |
+| 10 | `completeCurrencyExchange` concatena el par | `'USD'` → `'USD/VES'` |
+| 11 | `parseDate` formatea fecha ISO válida | Fecha conocida produce el string esperado |
+| 12 | `parseDate` con `addDayName: false` omite el nombre del día | El resultado no contiene el prefijo del día |
+| 13 | `getDayName` retorna nombre correcto del 1 al 7 | Lunes=1 ... Domingo=7 |
+| 14 | `getDayName` fuera de rango retorna `''` | Valores `0`, `8`, `-1` |
+
+---
+
+## Unit Tests — Modelos
+
+> Archivo sugerido: `test/shared/data/model/currency_model_test.dart`
+
+| # | Test | Descripción |
+|---|------|-------------|
+| 15 | `CurrencyModel.fromJson` JSON completo | Todos los campos mapeados correctamente |
+| 16 | `CurrencyModel.fromJson` campo faltante lanza excepción | Omitir `'name'`, `'code'`, `'value'`, etc. |
+| 17 | `CurrencyModel.toEntity` retorna `Currency` con valores idénticos | Compara campo a campo |
+| 18 | `BcvCurrenciesModel.fromJson` deserializa lista anidada | `currencies` es lista de `CurrencyModel` |
+| 19 | `BcvCurrenciesModel.toEntity` retorna `BcvCurrencies` con fecha y lista correctas | |
+
+---
+
+## Unit Tests — `ConvertibleCurrency`
+
+> Archivo sugerido: `test/features/converter/domain/convertible_currency_test.dart`
+
+| # | Test | Descripción |
+|---|------|-------------|
+| 20 | `originalValue` delega a `currency.value` | Verifica que es la misma referencia |
+| 21 | `copyWith` conserva campos no modificados | Solo cambia `convertedValue`, `currency` queda igual |
+| 22 | Equatable: mismas props → iguales | Dos instancias con misma `currency` y `convertedValue` |
+| 23 | Equatable: distinta `convertedValue` → distintos | |
+
+---
+
+## Unit Tests — `ConverterController` (resto de métodos)
+
+> Archivo sugerido: `test/features/converter/converter_controller_test.dart`
+
+### `selectCurrency()`
+
+| # | Test | Descripción |
+|---|------|-------------|
+| 24 | Seleccionar la misma moneda retorna `null` | Sin cambios en estado |
+| 25 | Seleccionar la moneda del otro lado ejecuta swap y retorna `true` | `fromCurrency` y `toCurrency` se intercambian |
+| 26 | Dos no-VES con `isInput: true` fuerza VES como `toCurrency` | Pivot rule |
+| 27 | Dos no-VES con `isInput: false` fuerza VES como `fromCurrency` | Pivot rule |
+| 28 | `isInput: true` setea `fromCurrency` y recalcula | `toCurrency.convertedValue` cambia |
+| 29 | `isInput: false` setea `toCurrency` con cálculo inverso | `fromAmount = (1.0 * toRate) / fromRate` |
+
+### `swapCurrencies()`
+
+| # | Test | Descripción |
+|---|------|-------------|
+| 30 | Después del swap, `from` y `to` están intercambiados | |
+| 31 | Se recalcula automáticamente tras el swap | `toCurrency.convertedValue` refleja el nuevo cálculo |
+
+### `_updateCurrenciesAndInit()`
+
+| # | Test | Descripción |
+|---|------|-------------|
+| 32 | No añade duplicados si `averageCurrencies` y `bcvCurrencies` comparten composite key | Lista `currencies` no tiene entradas repetidas |
+| 33 | Selección inicial usa VES como `fromCurrency` | `pivotCurrency.keyName == 'VES'` |
+| 34 | Selección inicial usa la primera no-VES como `toCurrency` | |
+| 35 | No reinicializa si `fromCurrency.keyName` ya es válido | Estado previo se conserva |
+
+### `getRoundedCurrency()`
+
+| # | Test | Descripción |
+|---|------|-------------|
+| 36 | Formato correcto `"X ≈ Y"` | Verifica el separador `≈` y los valores de `originalValue` |
+
+---
+
+## Unit Tests — `SettingsController`
+
+> Archivo sugerido: `test/shared/presentation/controller/settings_controller_test.dart`
+> Requiere mock de `SharedPreferences` (`SharedPreferences.setMockInitialValues`).
+
+| # | Test | Descripción |
+|---|------|-------------|
+| 37 | `setFavMarket` no persiste si el índice ya es el activo | `SharedPreferences` no debe recibir `setInt` |
+| 38 | `setFavMarket` persiste el nuevo índice | Valor en prefs == índice nuevo |
+| 39 | `setFavLanguage` no cambia locale si ya es el código activo | |
+| 40 | `setFavLanguage` actualiza `favLanguageCode` y llama `Get.updateLocale` | |
+| 41 | `setFavTheme` no escribe en prefs si el tema no cambió | |
+| 42 | `setFavTheme` persiste el nombre del nuevo `ThemeMode` | |
+| 43 | `_loadPreferences` carga valores previos de prefs al inicio | Simular prefs pre-pobladas |
+| 44 | `_loadPreferences` usa `ThemeMode.system` si no hay valor guardado | |
+
+---
+
+## Integration Tests — `CurrencyRepository`
+
+> Archivo sugerido: `test/shared/data/repositories/currency_repository_test.dart`
+
+| # | Test | Descripción |
+|---|------|-------------|
+| 45 | `refreshData` pone `isLoading` en `true` antes de las llamadas | Observable cambia antes del `await` |
+| 46 | `refreshData` pone `isLoading` en `false` al finalizar (éxito) | |
+| 47 | `refreshData` pone `isLoading` en `false` al finalizar (error) | No queda en `true` si el datasource falla |
+| 48 | `getAveragedCurrencies` asigna correctamente la lista de `averageCurrencies` | |
+| 49 | `getAveragedCurrencies` no lanza excepción si el datasource falla | Silencia el error |
+| 50 | `getBCVCurrencies` asigna `bcvCurrencies` y `bcvCurrentDate` | |
+| 51 | `getBCVCurrencies` no lanza excepción si el datasource falla | |
+
+---
+
+## Widget Tests
+
+> Archivo sugerido: `test/features/home/home_page_test.dart`
+
+| # | Test | Descripción |
+|---|------|-------------|
+| 52 | Muestra skeleton cuando `isLoading == true` | `CustomSkeletonizer` visible |
+| 53 | Muestra datos reales cuando `isLoading == false` y datos disponibles | |
+| 54 | `GetBuilder` se reconstruye cuando `averageCurrencies` cambia | |
+
+> Archivo sugerido: `test/features/converter/converter_page_test.dart`
+
+| # | Test | Descripción |
+|---|------|-------------|
+| 55 | El campo de texto dispara `calculator` con el valor ingresado | |
+| 56 | El botón de swap intercambia los labels de las monedas | |
+| 57 | El modal de selección llama a `selectCurrency` con el parámetro correcto | |
+
+---
+
+## Golden Tests (snapshot)
+
+> Archivo sugerido: `test/shared/presentation/widgets/golden_test.dart`
+
+| # | Test | Widget | Descripción |
+|---|------|---------|-------------|
+| 58 | `PerformanceIndicatorWidget` tendencia positiva | `tendency > 0` | Flecha e color verde |
+| 59 | `PerformanceIndicatorWidget` tendencia negativa | `tendency < 0` | Flecha e color rojo |
+| 60 | `PerformanceIndicatorWidget` tendencia neutral | `tendency == 0` | Sin flecha o color neutro |
+| 61 | `CustomSkeletonizer` activo | `enabled: true` | Efecto shimmer visible |
+| 62 | `CustomSkeletonizer` inactivo | `enabled: false` | Contenido real visible |
+
+---
+
+## Notas de Setup
+
+```dart
+// Para tests de controllers con GetX:
+setUp(() => Get.testMode = true);
+tearDown(() => Get.reset());
+
+// Para tests de SettingsController:
+SharedPreferences.setMockInitialValues({});
+
+// Para tests que requieren mocktail (agregar a dev_dependencies):
+// mocktail: ^0.3.0
+```

--- a/test/features/converter/converter_page_test.dart
+++ b/test/features/converter/converter_page_test.dart
@@ -1,0 +1,68 @@
+import 'package:bcv_tracker_app/core/i18n/app_messages.dart';
+import 'package:bcv_tracker_app/core/i18n/app_translations.dart';
+import 'package:bcv_tracker_app/features/converter/presentation/controller/converter_controller.dart';
+import 'package:bcv_tracker_app/features/converter/presentation/page/converter_page.dart';
+import 'package:bcv_tracker_app/shared/data/repositories/currency_repository.dart';
+import 'package:bcv_tracker_app/shared/domain/entities/bcv_currencies.dart';
+import 'package:bcv_tracker_app/shared/domain/entities/currency.dart';
+import 'package:bcv_tracker_app/shared/domain/repositories/dollar_repositories.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+
+class _FakeDollarRepository implements IDollarRepository {
+  @override
+  Future<BcvCurrencies> getCurrentBCVDollar() async =>
+      BcvCurrencies(date: null, currencies: const []);
+
+  @override
+  Future<List<Currency>> getCurrentDollar() async => const [];
+}
+
+Future<void> _pumpConverter(WidgetTester tester) async {
+  Get.testMode = true;
+  Get.put<IDollarRepository>(_FakeDollarRepository());
+  final repo = Get.put(CurrencyRepository());
+  Get.put(ConverterController());
+
+  // The default pivot/skeleton currencies fall back to initials for their icon,
+  // so no network image loads; clearing the placeholder lists keeps it that way.
+  repo.averageCurrencies.clear();
+  repo.bcvCurrencies.clear();
+
+  await tester.pumpWidget(
+    GetMaterialApp(
+      translations: AppTranslations(),
+      locale: const Locale('es', 'ES'),
+      fallbackLocale: const Locale('en', 'US'),
+      home: const Scaffold(body: ConverterPage()),
+    ),
+  );
+  await tester.pump(const Duration(milliseconds: 50));
+  await tester.pump(const Duration(milliseconds: 50));
+}
+
+void main() {
+  tearDown(() => Get.reset());
+
+  testWidgets('renders the converter body with a title and an input', (
+    tester,
+  ) async {
+    await _pumpConverter(tester);
+
+    // The frame and the body are up: the title, and the amount input of the
+    // "from" card.
+    expect(find.text(AppMessages.converterView), findsWidgets);
+    expect(find.byType(TextFormField), findsWidgets);
+  });
+
+  testWidgets('typing an amount does not throw', (tester) async {
+    await _pumpConverter(tester);
+
+    await tester.enterText(find.byType(TextFormField).first, '100');
+    await tester.pump();
+
+    // The controller ran calculator() without error; the field holds the input.
+    expect(find.text('100'), findsWidgets);
+  });
+}

--- a/test/features/home/home_controller_test.dart
+++ b/test/features/home/home_controller_test.dart
@@ -1,0 +1,98 @@
+import 'package:bcv_tracker_app/features/home/presentation/controller/home_controller.dart';
+import 'package:bcv_tracker_app/shared/data/repositories/currency_repository.dart';
+import 'package:bcv_tracker_app/shared/domain/entities/bcv_currencies.dart';
+import 'package:bcv_tracker_app/shared/domain/entities/currency.dart';
+import 'package:bcv_tracker_app/shared/domain/repositories/dollar_repositories.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+
+class _FakeDollarRepository implements IDollarRepository {
+  _FakeDollarRepository({this.bcvThrows});
+
+  final Object? bcvThrows;
+
+  @override
+  Future<BcvCurrencies> getCurrentBCVDollar() async {
+    if (bcvThrows != null) throw bcvThrows!;
+    return BcvCurrencies(date: '2026-07-23', currencies: const [_usd]);
+  }
+
+  @override
+  Future<List<Currency>> getCurrentDollar() async => const [];
+}
+
+const _usd = Currency(
+  name: 'Dolar',
+  keyName: 'USD',
+  platform: 'Banco Central de Venezuela',
+  value: 737.88,
+);
+
+void main() {
+  late CurrencyRepository repository;
+  late HomeController controller;
+
+  setUp(() {
+    Get.testMode = true;
+    Get.put<IDollarRepository>(_FakeDollarRepository());
+    repository = Get.put(CurrencyRepository());
+    controller = Get.put(HomeController());
+  });
+
+  tearDown(() => Get.reset());
+
+  group('HomeController delegation', () {
+    test('unwrapped getters read straight from the repository', () {
+      repository.isLoading.value = true;
+      repository.errorMessage.value = 'boom';
+      repository.bcvCurrentDate.value = '2026-07-23';
+      repository.hasAverageData.value = true;
+      repository.hasBcvData.value = false;
+
+      expect(controller.isLoading, isTrue);
+      expect(controller.errorMessage, 'boom');
+      expect(controller.bcvCurrentDate, '2026-07-23');
+      expect(controller.hasAverageData, isTrue);
+      expect(controller.hasBcvData, isFalse);
+    });
+
+    test('currency getters expose the repository lists', () {
+      repository.bcvCurrencies.assignAll(const [_usd]);
+      expect(controller.bcvCurrencies, contains(_usd));
+    });
+
+    test('errorMessage is null when the last refresh succeeded', () {
+      repository.errorMessage.value = null;
+      expect(controller.errorMessage, isNull);
+    });
+  });
+
+  group('refreshHomeData()', () {
+    test('drives a repository refresh and lands its data', () async {
+      await controller.refreshHomeData();
+
+      expect(controller.hasBcvData, isTrue);
+      expect(controller.bcvCurrentDate, '2026-07-23');
+      expect(controller.isLoading, isFalse);
+      expect(controller.errorMessage, isNull);
+    });
+
+    test(
+      'a failing refresh surfaces the error through the controller',
+      () async {
+        Get.reset();
+        Get.testMode = true;
+        Get.put<IDollarRepository>(
+          _FakeDollarRepository(bcvThrows: StateError('down')),
+        );
+        Get.put(CurrencyRepository());
+        final failing = Get.put(HomeController());
+
+        await failing.refreshHomeData();
+
+        expect(failing.errorMessage, isNotNull);
+        expect(failing.isLoading, isFalse);
+      },
+    );
+  });
+}

--- a/test/features/home/home_page_test.dart
+++ b/test/features/home/home_page_test.dart
@@ -1,0 +1,95 @@
+import 'package:bcv_tracker_app/core/i18n/app_messages.dart';
+import 'package:bcv_tracker_app/core/i18n/app_translations.dart';
+import 'package:bcv_tracker_app/core/network/api_exception.dart';
+import 'package:bcv_tracker_app/features/home/presentation/controller/home_controller.dart';
+import 'package:bcv_tracker_app/features/home/presentation/page/home_page.dart';
+import 'package:bcv_tracker_app/shared/data/repositories/currency_repository.dart';
+import 'package:bcv_tracker_app/shared/domain/entities/bcv_currencies.dart';
+import 'package:bcv_tracker_app/shared/domain/entities/currency.dart';
+import 'package:bcv_tracker_app/shared/domain/repositories/dollar_repositories.dart';
+import 'package:bcv_tracker_app/shared/presentation/controller/settings_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+
+/// Either returns empty rates or fails, no network. When [errorMessage] is set,
+/// both calls throw, which drives `CurrencyRepository.refreshData` down its
+/// error path and lands the home error state.
+class _FakeDollarRepository implements IDollarRepository {
+  _FakeDollarRepository({this.errorMessage});
+
+  final String? errorMessage;
+
+  @override
+  Future<BcvCurrencies> getCurrentBCVDollar() async {
+    if (errorMessage != null) throw ApiException.network(errorMessage!);
+    return BcvCurrencies(date: null, currencies: const []);
+  }
+
+  @override
+  Future<List<Currency>> getCurrentDollar() async {
+    if (errorMessage != null) throw ApiException.network(errorMessage!);
+    return const [];
+  }
+}
+
+/// Brings up HomePage over a fake repository. The repository's `onReady` fires
+/// the refresh that produces the state under test, so nothing has to be poked
+/// after the fact.
+Future<void> _pumpHome(WidgetTester tester, {String? error}) async {
+  Get.testMode = true;
+  Get.put<IDollarRepository>(_FakeDollarRepository(errorMessage: error));
+  final repo = Get.put(CurrencyRepository());
+  Get.put(SettingsController());
+  Get.put(HomeController());
+
+  // Drop the skeleton placeholders before the first frame: they carry a
+  // `placehold.co` image URL, and a real network fetch fails (and should) in a
+  // test. Empty lists render no image-bearing cards.
+  repo.averageCurrencies.clear();
+  repo.bcvCurrencies.clear();
+
+  await tester.pumpWidget(
+    GetMaterialApp(
+      translations: AppTranslations(),
+      locale: const Locale('es', 'ES'),
+      fallbackLocale: const Locale('en', 'US'),
+      // In the app HomePage is a tab inside DashboardPage's Scaffold; that
+      // Scaffold gives the inner TabBar its Material ancestor and the
+      // TabBarView its bounded height. Reproduce it.
+      home: const Scaffold(body: HomePage()),
+    ),
+  );
+
+  // Let onReady's refresh settle. Explicit pumps, not pumpAndSettle, which
+  // would hang on the skeleton's shimmer animation.
+  await tester.pump(const Duration(milliseconds: 50));
+  await tester.pump(const Duration(milliseconds: 50));
+}
+
+void main() {
+  tearDown(() => Get.reset());
+
+  testWidgets('renders the error card when the refresh failed', (tester) async {
+    await _pumpHome(tester, error: 'El portal del BCV no responde');
+
+    // The backend detail is passed through verbatim, so it is the reliable
+    // signal that the error card rendered. In the error state showCurrencies is
+    // false, so no rate cards (and no network images) are built.
+    expect(find.textContaining('El portal del BCV no responde'), findsWidgets);
+    expect(find.text(AppMessages.loadingError), findsWidgets);
+  });
+
+  testWidgets('shows no error card on a successful refresh', (tester) async {
+    await _pumpHome(tester);
+
+    expect(find.text(AppMessages.loadingError), findsNothing);
+  });
+
+  testWidgets('the home frame renders (title + scaffold)', (tester) async {
+    await _pumpHome(tester, error: 'x');
+
+    expect(find.text(AppMessages.homeView), findsWidgets);
+    expect(find.byType(Scaffold), findsWidgets);
+  });
+}

--- a/test/navigation/navigation_controller_test.dart
+++ b/test/navigation/navigation_controller_test.dart
@@ -1,0 +1,37 @@
+import 'package:bcv_tracker_app/navigation/navigation_controller.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+
+void main() {
+  late NavigationController controller;
+
+  setUp(() {
+    Get.testMode = true;
+    controller = NavigationController();
+  });
+
+  tearDown(() => Get.reset());
+
+  test('starts on the first tab', () {
+    expect(controller.selectedIndex.value, 0);
+  });
+
+  test('changeIndex moves the selected tab', () {
+    controller.changeIndex(1);
+    expect(controller.selectedIndex.value, 1);
+
+    controller.changeIndex(0);
+    expect(controller.selectedIndex.value, 0);
+  });
+
+  test('the selected index is observable', () {
+    final seen = <int>[];
+    // A tab switch must notify, or the dashboard's IndexedStack never moves.
+    controller.selectedIndex.listen(seen.add);
+
+    controller.changeIndex(1);
+    controller.changeIndex(1); // same value: RxInt does not re-notify
+
+    expect(seen, [1]);
+  });
+}

--- a/test/shared/data/currency_repository_test.dart
+++ b/test/shared/data/currency_repository_test.dart
@@ -1,0 +1,126 @@
+import 'package:bcv_tracker_app/core/network/api_exception.dart';
+import 'package:bcv_tracker_app/shared/data/repositories/currency_repository.dart';
+import 'package:bcv_tracker_app/shared/domain/entities/bcv_currencies.dart';
+import 'package:bcv_tracker_app/shared/domain/entities/currency.dart';
+import 'package:bcv_tracker_app/shared/domain/repositories/dollar_repositories.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+
+/// A repository fake: returns entities or throws, no network.
+class _FakeDollarRepository implements IDollarRepository {
+  _FakeDollarRepository({this.bcv, this.saved, this.bcvThrows});
+
+  final BcvCurrencies? bcv;
+  final List<Currency>? saved;
+  final Object? bcvThrows;
+
+  @override
+  Future<BcvCurrencies> getCurrentBCVDollar() async {
+    if (bcvThrows != null) throw bcvThrows!;
+    return bcv ?? BcvCurrencies(date: null, currencies: const []);
+  }
+
+  @override
+  Future<List<Currency>> getCurrentDollar() async {
+    return saved ?? const [];
+  }
+}
+
+const _bcvUsd = Currency(
+  name: 'Dolar',
+  keyName: 'USD',
+  platform: 'Banco Central de Venezuela',
+  value: 737.88,
+);
+
+CurrencyRepository _repositoryWith(_FakeDollarRepository fake) {
+  Get.put<IDollarRepository>(fake);
+  return Get.put(CurrencyRepository());
+}
+
+void main() {
+  setUp(() => Get.testMode = true);
+  tearDown(() => Get.reset());
+
+  group('refreshData() success', () {
+    test('populates BCV data and clears the error', () async {
+      final repo = _repositoryWith(
+        _FakeDollarRepository(
+          bcv: BcvCurrencies(date: '2026-07-23', currencies: [_bcvUsd]),
+          saved: const [],
+        ),
+      );
+
+      await repo.refreshData();
+
+      expect(repo.bcvCurrencies, contains(_bcvUsd));
+      expect(repo.bcvCurrentDate.value, '2026-07-23');
+      expect(repo.hasBcvData.value, isTrue);
+      expect(repo.hasAverageData.value, isTrue);
+      expect(repo.errorMessage.value, isNull);
+      expect(repo.isLoading.value, isFalse);
+    });
+
+    test('a null BCV date becomes an empty string, not "null"', () async {
+      final repo = _repositoryWith(
+        _FakeDollarRepository(
+          bcv: BcvCurrencies(date: null, currencies: const []),
+          saved: const [],
+        ),
+      );
+
+      await repo.refreshData();
+
+      expect(repo.bcvCurrentDate.value, '');
+    });
+  });
+
+  group('refreshData() error paths', () {
+    test('an ApiException surfaces as errorMessage, loading resets', () async {
+      final repo = _repositoryWith(
+        _FakeDollarRepository(
+          bcvThrows: const ApiException.network(
+            'El portal del BCV no responde',
+          ),
+          saved: const [],
+        ),
+      );
+
+      await repo.refreshData();
+
+      // ApiException carries the backend message; the repo hands that to the UI.
+      expect(repo.errorMessage.value, 'El portal del BCV no responde');
+      expect(repo.isLoading.value, isFalse);
+    });
+
+    test('a partial failure still lands the side that succeeded', () async {
+      // eagerError is off: the BCV fetch fails but the average fetch completes,
+      // so its data is present even though an error is reported.
+      final repo = _repositoryWith(
+        _FakeDollarRepository(
+          bcvThrows: const ApiException.malformed('bad BCV contract'),
+          saved: const [],
+        ),
+      );
+
+      await repo.refreshData();
+
+      expect(repo.hasAverageData.value, isTrue);
+      expect(repo.errorMessage.value, isNotNull);
+    });
+
+    test('a non-ApiException degrades to its toString', () async {
+      final repo = _repositoryWith(
+        _FakeDollarRepository(
+          bcvThrows: StateError('unexpected'),
+          saved: const [],
+        ),
+      );
+
+      await repo.refreshData();
+
+      expect(repo.errorMessage.value, contains('unexpected'));
+      expect(repo.isLoading.value, isFalse);
+    });
+  });
+}

--- a/test/shared/data/dollar_repository_test.dart
+++ b/test/shared/data/dollar_repository_test.dart
@@ -1,0 +1,112 @@
+import 'package:bcv_tracker_app/core/network/api_exception.dart';
+import 'package:bcv_tracker_app/shared/data/datasource/dollar_api/dollar_api.dart';
+import 'package:bcv_tracker_app/shared/data/model/model.dart';
+import 'package:bcv_tracker_app/shared/data/repositories/dollar_repositories.dart';
+import 'package:bcv_tracker_app/shared/domain/entities/bcv_currencies.dart';
+import 'package:bcv_tracker_app/shared/domain/entities/currency.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A datasource fake: returns canned models or throws, never touches the
+/// network. What it was asked is recorded so the repository's contract can be
+/// asserted.
+class _FakeDollarApi implements IDollarApi {
+  _FakeDollarApi({this.bcv, this.saved, this.throwsOn});
+
+  final BcvCurrenciesModel? bcv;
+  final List<CurrencyModel>? saved;
+
+  /// If set, both calls throw this instead of returning.
+  final Object? throwsOn;
+
+  int bcvCalls = 0;
+  int savedCalls = 0;
+
+  @override
+  Future<BcvCurrenciesModel> getCurrentBCVDollar() async {
+    bcvCalls++;
+    if (throwsOn != null) throw throwsOn!;
+    return bcv!;
+  }
+
+  @override
+  Future<List<CurrencyModel>> getCurrentDollar() async {
+    savedCalls++;
+    if (throwsOn != null) throw throwsOn!;
+    return saved!;
+  }
+}
+
+CurrencyModel _model(String code) => CurrencyModel.fromJson({
+  'code': code,
+  'name': code,
+  'platform': 'Test',
+  'value': 1.0,
+  'change': 0,
+  'createDate': null,
+  'updateDate': null,
+  'platform_img': '',
+});
+
+void main() {
+  group('DollarRepository.getCurrentBCVDollar()', () {
+    test('returns a domain entity, converted from the model', () async {
+      final api = _FakeDollarApi(
+        bcv: BcvCurrenciesModel(
+          date: '2026-07-23',
+          currencies: [_model('USD')],
+        ),
+      );
+      final repo = DollarRepository(dollarApi: api);
+
+      final result = await repo.getCurrentBCVDollar();
+
+      expect(api.bcvCalls, 1);
+      expect(result.date, '2026-07-23');
+      // The boundary must hand over entities, not the models it deserialised.
+      expect(result.runtimeType, BcvCurrencies);
+      expect(result.currencies.first.runtimeType, Currency);
+    });
+
+    test('propagates an ApiException from the datasource', () async {
+      final repo = DollarRepository(
+        dollarApi: _FakeDollarApi(
+          throwsOn: const ApiException.network('backend down'),
+        ),
+      );
+
+      await expectLater(
+        repo.getCurrentBCVDollar(),
+        throwsA(
+          isA<ApiException>().having(
+            (e) => e.message,
+            'message',
+            'backend down',
+          ),
+        ),
+      );
+    });
+  });
+
+  group('DollarRepository.getCurrentDollar()', () {
+    test('maps every model to an entity', () async {
+      final api = _FakeDollarApi(saved: [_model('USD'), _model('EUR')]);
+      final repo = DollarRepository(dollarApi: api);
+
+      final result = await repo.getCurrentDollar();
+
+      expect(api.savedCalls, 1);
+      expect(result, hasLength(2));
+      expect(result.every((c) => c.runtimeType == Currency), isTrue);
+    });
+
+    test('propagates an ApiException from the datasource', () async {
+      final repo = DollarRepository(
+        dollarApi: _FakeDollarApi(
+          throwsOn: const ApiException.malformed('bad contract'),
+        ),
+      );
+
+      await expectLater(repo.getCurrentDollar(), throwsA(isA<ApiException>()));
+    });
+  });
+}

--- a/test/shared/presentation/settings_controller_test.dart
+++ b/test/shared/presentation/settings_controller_test.dart
@@ -1,0 +1,89 @@
+import 'package:bcv_tracker_app/shared/presentation/controller/settings_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _themeKey = 'theme_mode';
+const _favMarketKey = 'fav_market';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late SettingsController controller;
+
+  setUp(() {
+    Get.testMode = true;
+    controller = SettingsController();
+  });
+
+  tearDown(() => Get.reset());
+
+  group('setFavMarket()', () {
+    test('persists the chosen market and updates the observable', () async {
+      SharedPreferences.setMockInitialValues({});
+      controller.setFavMarket(1);
+
+      expect(controller.favMarketIndex.value, 1);
+      // The write is async; let it settle.
+      await Future<void>.delayed(Duration.zero);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getInt(_favMarketKey), 1);
+    });
+
+    test('does nothing when the market is already selected', () async {
+      SharedPreferences.setMockInitialValues({});
+      controller.favMarketIndex.value = 2;
+
+      controller.setFavMarket(2);
+      await Future<void>.delayed(Duration.zero);
+
+      // No write happened: the early return skipped SharedPreferences.
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getInt(_favMarketKey), isNull);
+    });
+  });
+
+  group('setFavTheme()', () {
+    // setFavTheme ends in Get.changeThemeMode, which reassembles the app, so it
+    // only works inside a mounted GetMaterialApp.
+    testWidgets('persists the theme and updates the observable', (
+      tester,
+    ) async {
+      await tester.pumpWidget(const GetMaterialApp(home: SizedBox()));
+      SharedPreferences.setMockInitialValues({});
+
+      controller.setFavTheme(ThemeMode.dark);
+      await tester.pump();
+
+      expect(controller.favBrightness.value, ThemeMode.dark);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString(_themeKey), 'dark');
+    });
+
+    testWidgets('does nothing when the theme is already selected', (
+      tester,
+    ) async {
+      await tester.pumpWidget(const GetMaterialApp(home: SizedBox()));
+      SharedPreferences.setMockInitialValues({});
+      controller.favBrightness.value = ThemeMode.light;
+
+      controller.setFavTheme(ThemeMode.light);
+      await tester.pump();
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString(_themeKey), isNull);
+    });
+  });
+
+  group('defaults', () {
+    test('starts on the default language, system theme and first market', () {
+      expect(
+        controller.favLanguageCode.value,
+        SettingsController.defaultLanguage.code,
+      );
+      expect(controller.favBrightness.value, ThemeMode.system);
+      expect(controller.favMarketIndex.value, 0);
+    });
+  });
+}


### PR DESCRIPTION
# Descripción

La suite existía pero era parcial: ocho archivos en helpers, mapeo de datos y el cálculo del conversor. Quedaban sin cubrir las piezas donde vive el comportamiento observable de la app. Este PR las cubre, **todo con fakes y sin red real**.

Cambios (rama `test/DTA-019`):

### Tests de controllers y repositorios (criterio 1)

| Test | Cubre |
|---|---|
| `test/shared/data/dollar_repository_test.dart` | Devuelve entidades (no modelos); propaga `ApiException` del datasource |
| `test/shared/data/currency_repository_test.dart` | `refreshData`: éxito, camino de error (`ApiException.message` a la UI), fallo parcial (una fuente cae, la otra aterriza), `isLoading` |
| `test/features/home/home_controller_test.dart` | Los getters-puente leen del repositorio; `refreshHomeData` en éxito y error |
| `test/navigation/navigation_controller_test.dart` | `changeIndex` mueve el índice; el índice es observable |
| `test/shared/presentation/settings_controller_test.dart` | Tema y mercado favorito: persistencia en `SharedPreferences` y no-op cuando no cambia |

> `SettingsController` de idioma ya tenía su test (`settings_controller_language_test.dart`); este añade tema y mercado.

### Tests de widget (criterio 2)

| Test | Cubre |
|---|---|
| `test/features/home/home_page_test.dart` | **Estado de error** (renderiza la tarjeta de error con el detalle del backend, y **no** las tarjetas de tasa), estado **sin error**, y el frame de la página |
| `test/features/converter/converter_page_test.dart` | El **cuerpo del conversor** renderiza (título + campo de monto) y acepta input sin lanzar |

**Cómo se montan sin red ni assets rotos:** las páginas se pumpean dentro de un `Scaffold` (que en la app real provee `DashboardPage`, y que da `Material` al `TabBar` y constraints al `TabBarView`). Los placeholders del skeleton —que llevan un `imgUrl` de red— se vacían antes del primer frame, así ninguna imagen de red se carga. El estado de error de la Home no renderiza tarjetas de tasa (SVG), lo que lo hace estable.

### El guardrail (criterio "existe una regla")

La regla escrita **ya existe**: [`test-coverage.md`](.agents/rules/test-coverage.md) exige que toda fuente, endpoint, controlador o helper nuevo nazca con sus tests. Se **reforzó su nota de CI** para nombrar el mecanismo que la hace cumplir: el check de PR de #27 (`flutter test` en GitHub Actions, bloqueante) además del de Codemagic.

### El inventario

`docs/lista_de_tests.md` estaba **gitignored** (`docs/*`) y sin rastrear — por eso nunca se versionó. Se **des-ignoró** (como ya se hace con `docs/release/`) y se convirtió en el **inventario de cobertura**: una tabla de los 19 archivos y qué cubre cada uno, marcando los añadidos aquí. El roadmap de pendientes queda debajo.

## Fuera de alcance (como indicaba el issue)

Tests de integración end-to-end contra el backend real y golden tests.

Issue de GitHub relacionado: Closes #28

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad
- [ ] 🛠️ Corrección de errores
- [ ] ❌ Cambio importante
- [ ] 📝 Actualización de la documentación
- [ ] 🧹 Code refactoring
- [ ] ✅ Build configuration change
- [x] 🧪 Test — ampliación de la suite + guardrail

## ¿Cómo se ha probado esto?

- [x] `flutter test` — **123 tests en verde** (de ~80 antes), 19 archivos.
- [x] `flutter analyze` → `No issues found!` (config estricta de #29).
- [x] Ningún test toca la red: fakes de `IDollarApi` / `IDollarRepository` / `HttpManager`; las imágenes de red en los widget tests se evitan por construcción.
- [x] Verificado que el CI de #27 correrá esta suite (es `flutter test`).
- [ ] **Nota de fragilidad**: los widget tests montan páginas con internos privados (`part of`); se estabilizaron (Scaffold + placeholders vacíos + pumps explícitos en vez de `pumpAndSettle` por el shimmer). Si en el futuro se extraen los widgets de estado (tarjeta de error, vacío) a unidades públicas, el widget-testing será más directo — anotado como mejora, no bloqueante.

**Configuración de prueba**: unit + widget tests, sin dispositivo.

## Lista de Verificación

- [x] He agregado las nuevas dependencias a la descripción — ninguna
- [x] He agregado las nuevas variables de entorno a la descripción — ninguna
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código — los tests documentan por qué se montan como se montan
- [x] He realizado los cambios correspondientes a la documentación — `docs/lista_de_tests.md` (inventario) + nota en `test-coverage.md`
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente con mis cambios
- [x] La app compila — no aplica: solo añade tests y docs
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas — no aplica
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper — no aplica: es la cobertura de las que ya existen
- [x] No introduje modelos en la UI ni en los controladores — no aplica
