### PR TITLE
[📝 Doc: DTA-020] - Adoptar DESIGN.md como fuente del diseño

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -32,12 +32,12 @@ Los enlaces son **relativos**, así que funcionan en cualquier clon. `.agents/sk
 
 ## Las reglas también se enlazan, pero con `paths:`
 
-`.claude/rules/*.md` se carga **en cada sesión**, y las 17 reglas suman 1.905 líneas (~28 mil tokens): cargarlas todas siempre inundaría el contexto, y la propia documentación advierte que eso *reduce* la adherencia.
+`.claude/rules/*.md` se carga **en cada sesión**, y las 18 reglas suman 1.944 líneas (~29 mil tokens): cargarlas todas siempre inundaría el contexto, y la propia documentación advierte que eso *reduce* la adherencia.
 
 La salida es el frontmatter `paths:`, que hace que una regla se cargue **solo al leer archivos que coincidan**. El reparto:
 
 - **4 sin `paths:` → siempre en contexto** (718 líneas, ~10 mil tokens): `issue-convention`, `branch-naming`, `commit-convention` y `pull-request`. Son procedimientos de git y GitHub: ningún archivo los dispara, así que no hay patrón que darles.
-- **13 con `paths:` → bajo demanda**: editar `lib/core/i18n/` trae la regla de i18n y nada más; tocar `pubspec.yaml` trae las tres de versionado.
+- **14 con `paths:` → bajo demanda**: editar `lib/core/i18n/` trae la regla de i18n y nada más; tocar `pubspec.yaml` trae las tres de versionado.
 
 El `paths:` vive en el frontmatter de `.agents/rules/*.md` junto al `description:`. Otros agentes lo ignoran sin problema; Claude Code lo usa para no cargar lo que no toca.
 
@@ -84,6 +84,7 @@ Reglas que el asistente debe respetar. Cada archivo lleva un `description` en el
 | [`test-coverage.md`](rules/test-coverage.md) | Toda fuente, endpoint, controlador o helper de cálculo nace con sus tests en el mismo PR |
 | [`documentation-convention.md`](rules/documentation-convention.md) | Todo lo público nace documentado con dartdoc, explicando el porqué y no el qué |
 | [`logging-convention.md`](rules/logging-convention.md) | Todo pasa por `AppLogger` con niveles; cada `catch` de un límite registra su causa; en release nada sensible ni URLs en crudo |
+| [`design-system.md`](rules/design-system.md) | `DESIGN.md` es la fuente de verdad visual; un token nuevo se declara ahí primero y luego en `config/theme/`; verificar en claro y oscuro |
 
 ---
 

--- a/.agents/rules/design-system.md
+++ b/.agents/rules/design-system.md
@@ -1,0 +1,39 @@
+---
+description: Obliga a consultar DESIGN.md (la fuente de verdad del sistema de diseño) antes de construir o reformar UI, y a declarar un token nuevo primero en DESIGN.md y después en lib/config/theme/. Aplica al tocar cualquier page/widget, el tema o los tokens de diseño.
+paths:
+  - "DESIGN.md"
+  - "lib/config/theme/**"
+  - "lib/**/page/**"
+  - "lib/**/{widget,widgets}/**"
+---
+
+# Sistema de Diseño
+
+La identidad visual de la app vive en **[`DESIGN.md`](../../DESIGN.md)** (raíz): tokens legibles por máquina (color, tipografía, espaciado, radios, componentes) en el front matter YAML, y el razonamiento en prosa. Es la **fuente de verdad**; `lib/config/theme/` es su implementación.
+
+El riesgo que evita: cada pantalla nueva —y el backlog está lleno de superficie nueva (#11, #37, #38, #40, #42)— vuelve a decidir tamaños, espaciados y radios desde cero, y la identidad se diluye en 23 `fontSize` a mano y `EdgeInsets` con números sueltos. `DESIGN.md` es el sitio donde esa decisión se toma una vez.
+
+## Regla
+
+1. **Antes de construir o reformar UI, lee `DESIGN.md`.** No inventes un tamaño, un color o un radio "parecido" a uno que ya existe: búscalo ahí.
+2. **Un token nuevo se declara primero en `DESIGN.md`, luego en Dart.** El orden importa: el diseño se decide en el documento, no en un widget. Si un color, un nivel tipográfico o un radio no está en `DESIGN.md`, se agrega ahí —con su razonamiento en la prosa— y en el mismo PR se implementa en `lib/config/theme/`.
+3. **`config/theme/` se mantiene a mano, con `DESIGN.md` como checklist.** No se genera desde los tokens (no hay export oficial a Flutter, y la capa semántica de cuatro modos de `colors_values.dart` es más rica que el mapa plano de `colors`). Al cambiar un token en `DESIGN.md`, actualiza su equivalente en `config/theme/` en el mismo PR, y viceversa: los dos no pueden divergir.
+4. **Los cuatro modos de color** (`light`, `dark`, `onBrandLight`, `onBrandDark`) viven en `colors_values.dart`; `DESIGN.md` declara la **paleta de marca** normativa y documenta el mapeo por modo en prosa. No dupliques las cuatro variantes en el front matter.
+5. **Verifica en claro y oscuro.** El modo oscuro no es un detalle: es la mitad del producto. Y en texto que puede alargarse (alemán, ruso), usa `Flexible`/`overflow`.
+
+## Relación con otras reglas
+
+- **`constants-centralization.md`** es el "cómo" en Dart (constantes en `core/constants/` y `config/theme/`, cero valores mágicos); `DESIGN.md` es el "qué y por qué" del diseño. Se complementan: un token vive declarado en `DESIGN.md` e implementado como constante en `config/theme/`.
+- **`i18n-convention.md`**: el texto de la UI pasa por `AppMessages`; su **tamaño y peso** los fija la escala tipográfica de `DESIGN.md`.
+
+## Verificación
+
+```bash
+# Valida estructura y contraste WCAG de los tokens
+npx @google/design.md lint DESIGN.md      # debe salir con 0 errores
+
+# Compara cambios de token entre versiones
+npx @google/design.md diff <viejo> DESIGN.md
+```
+
+El spec está en **alpha**; `version: alpha` está fijado en el front matter y no se construyen automatismos frágiles encima todavía.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ BCV Tracker is a Flutter mobile app that displays real-time Venezuelan Central B
 
 This file is the **map** of the codebase; `.agents/rules/` holds the **binding conventions**. When they disagree, the rules win — and the contradiction gets fixed in the same PR.
 
-`.agents/` is the single source. `.claude/rules/` and `.claude/skills/` are symlinks into it, so Claude Code discovers both natively and no file exists twice. **How each loads differs, and it matters:** four rules are always in context, thirteen load only when you touch the files they govern, and skills load on demand from their description. If you are about to do something a path-scoped rule covers and it has not loaded, open it.
+`.agents/` is the single source. `.claude/rules/` and `.claude/skills/` are symlinks into it, so Claude Code discovers both natively and no file exists twice. **How each loads differs, and it matters:** four rules are always in context, fourteen load only when you touch the files they govern, and skills load on demand from their description. If you are about to do something a path-scoped rule covers and it has not loaded, open it.
 
 ### Always in context — the git and GitHub procedures
 
@@ -35,6 +35,7 @@ No file edit can trigger these, so they are unconditional. Shared verbatim with 
 | `.agents/rules/navigation-convention.md` | `config/routes/`, any `page/` or `widget(s)/`, `navigation/` |
 | `.agents/rules/i18n-convention.md` | `core/i18n/`, any `page/` or `widget(s)/` |
 | `.agents/rules/constants-centralization.md` | `core/constants/`, `config/theme/`, any `page/` or `widget(s)/` |
+| `.agents/rules/design-system.md` | `DESIGN.md`, `config/theme/`, any `page/` or `widget(s)/` |
 | `.agents/rules/environment-variables.md` | `config/enviroment/`, `.env.example`, `codemagic.yaml`, `README.md` |
 | `.agents/rules/test-coverage.md` | `test/`, `shared/data/`, any `controller/`, `core/helpers/` |
 | `.agents/rules/documentation-convention.md` | any `.dart` under `lib/` |
@@ -114,6 +115,8 @@ Entities live in `shared/domain/entities/` and `features/*/domain/entities/`. JS
 Named routes in `lib/config/routes/` — constants in `routes.dart` (`AppRoutes`), `GetPage` entries in `pages.dart` (`AppPages`). Navigate with `Get.toNamed()` / `Get.offAllNamed()` — never Flutter's `Navigator`, and never by passing a widget. Close dialogs and modals with `Get.back()`. Transitions belong on the `GetPage`, not the call site. Tabs are not routes: switching tabs changes `NavigationController.selectedIndex`.
 
 ## Theming
+
+The **source of truth for visual decisions is [`DESIGN.md`](DESIGN.md)** (root): a design-system document with machine-readable tokens (color, typography, spacing, radii, components) in the front matter and the rationale in prose. `lib/config/theme/` is its **implementation** — it must match what `DESIGN.md` declares, and a new token is declared there **first**. Before building UI, read `DESIGN.md`; see `.agents/rules/design-system.md`.
 
 Light/dark/system themes in `lib/config/theme/`. Colors (`AppColors`), icons and the 8pt spacing grid (`WidthValues`) are centralized there — no `Color(0xFF...)` in widgets. `SettingsController.favBrightness` drives the active theme. The app is still **Material 2**; migration to Material 3 is decided and tracked in [#44](https://github.com/Teixeira49/bcv_tracker_app/issues/44).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ BCV Tracker is a Flutter mobile app that displays real-time Venezuelan Central B
 
 This file is the **map** of the codebase; `.agents/rules/` holds the **binding conventions**. When they disagree, the rules win — and the contradiction gets fixed in the same PR.
 
-`.agents/` is the single source. `.claude/rules/` and `.claude/skills/` are symlinks into it, so Claude Code discovers both natively and no file exists twice. **How each loads differs, and it matters:** four rules are always in context, thirteen load only when you touch the files they govern, and skills load on demand from their description. If you are about to do something a path-scoped rule covers and it has not loaded, open it.
+`.agents/` is the single source. `.claude/rules/` and `.claude/skills/` are symlinks into it, so Claude Code discovers both natively and no file exists twice. **How each loads differs, and it matters:** four rules are always in context, fourteen load only when you touch the files they govern, and skills load on demand from their description. If you are about to do something a path-scoped rule covers and it has not loaded, open it.
 
 ### Always in context — the git and GitHub procedures
 
@@ -35,6 +35,7 @@ No file edit can trigger these, so they are unconditional. Shared verbatim with 
 | `.agents/rules/navigation-convention.md` | `config/routes/`, any `page/` or `widget(s)/`, `navigation/` |
 | `.agents/rules/i18n-convention.md` | `core/i18n/`, any `page/` or `widget(s)/` |
 | `.agents/rules/constants-centralization.md` | `core/constants/`, `config/theme/`, any `page/` or `widget(s)/` |
+| `.agents/rules/design-system.md` | `DESIGN.md`, `config/theme/`, any `page/` or `widget(s)/` |
 | `.agents/rules/environment-variables.md` | `config/enviroment/`, `.env.example`, `codemagic.yaml`, `README.md` |
 | `.agents/rules/test-coverage.md` | `test/`, `shared/data/`, any `controller/`, `core/helpers/` |
 | `.agents/rules/documentation-convention.md` | any `.dart` under `lib/` |
@@ -114,6 +115,8 @@ Entities live in `shared/domain/entities/` and `features/*/domain/entities/`. JS
 Named routes in `lib/config/routes/` — constants in `routes.dart` (`AppRoutes`), `GetPage` entries in `pages.dart` (`AppPages`). Navigate with `Get.toNamed()` / `Get.offAllNamed()` — never Flutter's `Navigator`, and never by passing a widget. Close dialogs and modals with `Get.back()`. Transitions belong on the `GetPage`, not the call site. Tabs are not routes: switching tabs changes `NavigationController.selectedIndex`.
 
 ## Theming
+
+The **source of truth for visual decisions is [`DESIGN.md`](DESIGN.md)** (root): a design-system document with machine-readable tokens (color, typography, spacing, radii, components) in the front matter and the rationale in prose. `lib/config/theme/` is its **implementation** — it must match what `DESIGN.md` declares, and a new token is declared there **first**. Before building UI, read `DESIGN.md`; see `.agents/rules/design-system.md`.
 
 Light/dark/system themes in `lib/config/theme/`. Colors (`AppColors`), icons and the 8pt spacing grid (`WidthValues`) are centralized there — no `Color(0xFF...)` in widgets. `SettingsController.favBrightness` drives the active theme. The app is still **Material 2**; migration to Material 3 is decided and tracked in [#44](https://github.com/Teixeira49/bcv_tracker_app/issues/44).
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,221 @@
+---
+version: alpha
+name: BCV Tracker
+description: >-
+  Sistema de diseño de una app financiera de consulta de tasas de cambio del
+  BCV. Identidad seria y de confianza: azul profundo institucional, un acento
+  ámbar para la acción, y un modo oscuro "midnight" de primera. Denso pero
+  legible: el número —la tasa— es el protagonista de cada pantalla.
+colors:
+  primary: "#02466D"
+  secondary: "#064469"
+  accent: "#FFA726"
+  neutral: "#808080"
+  midnight: "#070E15"
+  success: "#39E079"
+  error: "#F44336"
+  warning: "#FF9800"
+  info: "#1187CE"
+typography:
+  displayLarge:
+    fontFamily: Roboto
+    fontSize: 40px
+    fontWeight: 700
+    lineHeight: 1.1
+  headlineMedium:
+    fontFamily: Roboto
+    fontSize: 28px
+    fontWeight: 700
+    lineHeight: 1.2
+  headlineSmall:
+    fontFamily: Roboto
+    fontSize: 24px
+    fontWeight: 700
+    lineHeight: 1.2
+  titleLarge:
+    fontFamily: Roboto
+    fontSize: 22px
+    fontWeight: 700
+    lineHeight: 1.25
+  titleMedium:
+    fontFamily: Roboto
+    fontSize: 20px
+    fontWeight: 600
+    lineHeight: 1.3
+  bodyLarge:
+    fontFamily: Roboto
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.4
+  bodyMedium:
+    fontFamily: Roboto
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 1.4
+  labelMedium:
+    fontFamily: Roboto
+    fontSize: 12px
+    fontWeight: 500
+    lineHeight: 1.3
+  labelSmall:
+    fontFamily: Roboto
+    fontSize: 10px
+    fontWeight: 500
+    lineHeight: 1.3
+rounded:
+  none: 0px
+  xs: 8px
+  sm: 12px
+  md: 16px
+  lg: 20px
+  xl: 24px
+  full: 9999px
+spacing:
+  xs: 8px
+  sm: 12px
+  md: 16px
+  lg: 24px
+  xl: 32px
+components:
+  card:
+    backgroundColor: "{colors.neutral}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.md}"
+  primaryButton:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.accent}"
+    rounded: "{rounded.md}"
+  bottomNav:
+    backgroundColor: "{colors.midnight}"
+    textColor: "{colors.accent}"
+    rounded: "{rounded.md}"
+  errorState:
+    textColor: "{colors.error}"
+    rounded: "{rounded.sm}"
+  emptyState:
+    textColor: "{colors.warning}"
+    rounded: "{rounded.sm}"
+---
+
+# BCV Tracker — Sistema de Diseño
+
+> **Fuente de verdad de las decisiones visuales.** Los tokens del front matter son normativos; la implementación en Flutter vive en `lib/config/theme/` y debe coincidir con lo declarado aquí. Antes de construir UI nueva, lee este archivo; ver `.agents/rules/design-system.md`.
+
+## Overview
+
+BCV Tracker es una app de consulta financiera: alguien la abre para decidir cuánto cobra o cuánto paga. El diseño existe para que ese número —la tasa— se lea de un vistazo, con confianza y sin ruido.
+
+- **Personalidad:** seria, institucional, precisa. Más cerca de una app bancaria que de una de consumo. Nada juguetón; nada que reste credibilidad al dato.
+- **Audiencia:** venezolanos que siguen el dólar a diario, en condiciones de red variables. El diseño asume que el dato puede fallar o tardar, y trata los estados de error y vacío como parte del producto, no como una excepción fea.
+- **Respuesta emocional:** calma y control. El azul profundo transmite estabilidad; el ámbar marca la acción sin gritar; el modo oscuro "midnight" hace la lectura nocturna cómoda.
+- **Densidad:** media-alta. Se muestran varias tasas por pantalla, así que la jerarquía tipográfica y el espaciado del grid de 8 pt hacen el trabajo de separar sin encerrar cada dato en una caja.
+
+## Colors
+
+La paleta se ancla en un **azul profundo** de marca, un **acento ámbar** para la acción, y una base neutra gris para el modo claro y "midnight" para el oscuro. Los estados semánticos (éxito/error/aviso/info) completan el conjunto.
+
+- **Primary (#02466D):** azul BCV profundo. Marca, texto de encabezado sobre claro, y fondo de acción.
+- **Secondary (#064469):** azul complementario, un grado más apagado; superficies y bordes de marca.
+- **Accent (#FFA726):** ámbar. El **único** color de acción destacada — icono activo del bottom bar, etiqueta del botón primario, aviso de estado vacío. Se usa con moderación; si todo es acento, nada lo es.
+- **Neutral (#808080):** gris. Base de las superficies del modo claro, texto secundario, bordes y metadatos.
+- **Midnight (#070E15):** casi negro azulado. Base de las superficies del modo oscuro.
+- **Success (#39E079) / Error (#F44336) / Warning (#FF9800) / Info (#1187CE):** estados. `info` tiñe también los bordes y sombras sutiles de las tarjetas.
+
+### Los cuatro modos — decisión
+
+El schema de `colors` es un mapa plano *token → color*, pero esta app asigna hasta **cuatro variantes por token semántico**: `light`, `dark`, `onBrandLight`, `onBrandDark` (ver `_ColorScheme` en `lib/config/theme/colors/colors_values.dart`).
+
+**Decisión:** el front matter declara la **paleta de marca** —los nueve colores fuente de arriba, agnósticos de modo, tomados literalmente de `lib/config/theme/colors/colors_constants.dart`—. La **asignación semántica por modo** (qué tono de la paleta pinta el fondo, el texto o el borde en claro vs. oscuro) es responsabilidad de `colors_values.dart` y se documenta aquí en prosa, **no** se duplica en el front matter. Por qué:
+
+- El modo oscuro **no es una derivación** del claro: sus tonos están escogidos a mano (base `midnight`, no un `primary` oscurecido). Un esquema "claro normativo + derivación" mentiría sobre cómo se construye el oscuro.
+- Sufijar cada token (`bgPrimaryLight`/`bgPrimaryDark`/…) multiplicaría por cuatro un inventario de ~50 tokens semánticos y volvería el archivo ilegible para lo que aporta.
+- Con la paleta como normativa, el linter comprueba el contraste WCAG de los colores fuente, que es donde vive la identidad; la fidelidad de cada superficie se verifica contra `colors_values.dart` y, a futuro, con los golden tests de #35.
+
+**Mapeo semántico (resumen; el detalle exacto está en `colors_values.dart`):**
+
+| Rol | Modo claro | Modo oscuro |
+|---|---|---|
+| Fondo de página | `neutral` claro (grey.50/100) | `midnight` (700/800) |
+| Superficie de tarjeta | blanco/grey muy claro | `midnight` un grado más claro |
+| Texto primario | `primary` / casi negro | blanco / grey muy claro |
+| Texto secundario | `neutral` (grey.600) | grey claro |
+| Acción / marca (fg) | `primary` / `secondary` | tonos claros de `primary` |
+| Bordes sutiles | `info` con alpha | `info` con alpha |
+
+## Typography
+
+No hay fuente propia: se usa la **de plataforma** (Roboto en Android, San Francisco en iOS vía el fallback de Material). Los tokens fijan **Roboto** como referencia de la escala; el peso y el tamaño son lo normativo, no la familia.
+
+La escala se derivó de los tamaños que hoy están dispersos por los widgets (nueve valores distintos, de 10 a 40 px). Roles:
+
+- **displayLarge (40/700):** el monto del conversor. Es el número más grande de la app, y su tamaño es deliberado: el resultado de la conversión es el producto.
+- **headlineMedium (28/700) / headlineSmall (24/700):** títulos de pantalla y de sección. `headlineSmall` es el título de `BaseLayout`.
+- **titleLarge (22/700):** título de modal (`BaseModal`).
+- **titleMedium (20/600):** subtítulos y encabezados de tarjeta.
+- **bodyLarge (16/400) / bodyMedium (14/400):** el cuerpo. `bodyMedium` es el tamaño de trabajo de la mayoría de las etiquetas y valores.
+- **labelMedium (12/500) / labelSmall (10/500):** metadatos, fechas, pies de tarjeta.
+
+> Estos tokens **aún no se consumen** desde el código (hay 25 `fontSize:` a mano). Adoptarlos —crear un `textTheme` y migrar los widgets— es trabajo de #44, no de esta issue.
+
+## Layout
+
+El proyecto usa un **grid de 8 pt** (`_WidthConstants._gridSystem = 8`): todo espaciado es múltiplo de 8. La escala de `spacing` declara el subconjunto de uso común; la escala completa (hasta 480 px) vive en `lib/config/theme/width/`.
+
+- **xs (8) / sm (12) / md (16):** gaps entre elementos y padding interno. `md` (16) es el padding de tarjeta por defecto.
+- **lg (24) / xl (32):** separación entre bloques y padding de contenedores amplios.
+
+Regla: si un valor de espaciado no está en la escala, la pregunta es si el diseño debería usar uno que sí. `WidthValues` ya declara la escala; los `EdgeInsets` con números sueltos son deuda que #44 migra.
+
+## Elevation & Depth
+
+La app es **plana con profundidad sutil**, no material pesado. La jerarquía se logra con color y borde antes que con sombra.
+
+- **Tarjetas:** borde de 1–1.25 px teñido con `info` a baja opacidad, más una sombra muy suave del mismo tono. La separación viene del borde, no de una sombra marcada.
+- **Modales y diálogos:** se elevan sobre un fondo difuminado (`BackdropFilter`) en vez de una sombra dura — el foco se logra desenfocando lo de atrás.
+- **Bottom bar:** flota sobre el contenido con `BackdropFilter` y un borde `info`, no con una barra opaca anclada.
+
+No hay una escala numérica de elevación (`z-1`…`z-5`): la profundidad es cualitativa y se describe por componente.
+
+## Shapes
+
+Esquinas redondeadas, coherentes con la escala `rounded` (grid de 8 pt):
+
+- **md (16):** el radio por defecto. Tarjetas, botones grandes, el contenedor del tab bar y la mayoría de las superficies usan `BorderRadius.circular(16)`.
+- **sm (12) / xs (8):** elementos más pequeños y avisos de estado.
+- **lg (20) / xl (24):** superficies amplias cuando se busca un gesto más suave.
+- **full (9999):** elementos circulares — avatares de divisa, indicadores.
+
+Nada de esquinas vivas (`none`/0) salvo divisores. La redondez es parte del tono "cuidado" de la app.
+
+## Components
+
+Los tokens de `components` fijan las relaciones color→rol de los componentes recurrentes; el layout exacto vive en el widget.
+
+- **card:** fondo neutro, acento `info` en el borde, radio `md`. Es la unidad base: cada tasa, cada sección, es una tarjeta.
+- **primaryButton:** fondo `primary`, etiqueta `accent`. La acción principal.
+- **bottomNav:** tinte `info`, icono activo `accent`. Es un componente **propio** (`CustomBottomNavigatorBar`), no un `BottomNavigationBar`/`NavigationBar` de Material — decisión que #44 debe confirmar al migrar a M3.
+- **errorState / emptyState:** acento `error` vs. `warning`, radio `sm`. Hoy son tarjetas mínimas (`_ErrorAdvisorCard`); #11 los rediseña como componentes compartidos con branding, e #18 define qué dice cada uno según la causa.
+
+## Do's and Don'ts
+
+**Do**
+
+- Declara un token **aquí primero**, luego impleméntalo en `lib/config/theme/`. El orden importa: el diseño se decide en este archivo, no en un widget.
+- Usa la escala de 8 pt para todo espaciado y radio. Si necesitas un valor fuera de la escala, revisa el diseño antes que la escala.
+- Reserva `accent` (ámbar) para la acción. Un solo acento por pantalla.
+- Verifica cada pantalla en **claro y oscuro**; el modo oscuro no es un detalle, es la mitad del producto.
+- En texto que puede alargarse (alemán, ruso), usa `Flexible`/`overflow` — el ancho del español no es el peor caso.
+
+**Don't**
+
+- No escribas un `Color(0xFF…)`, un `fontSize:` ni un `EdgeInsets` con número suelto en un widget. Va contra `constants-centralization.md` y contra este documento.
+- No inventes un tono nuevo "parecido" a uno existente. Si falta, se declara aquí.
+- No uses `accent` para texto largo ni fondos grandes: es un acento, no un color de superficie.
+- No trates los estados de error/vacío como una excepción fea: son parte del diseño (#11).
+
+---
+
+## Mantenimiento
+
+- **Dirección del flujo:** `lib/config/theme/` se mantiene **a mano**, con este documento como checklist de revisión. **No** se genera desde los tokens. Motivo: no hay un export oficial de design.md a Flutter (`export` emite Tailwind/DTCG/CSS, no `ThemeData`), y la capa semántica de cuatro modos de `colors_values.dart` es más rica que el mapa plano de `colors`; un generador perdería esa fidelidad. Al cambiar un token aquí, actualiza su equivalente en `config/theme/` en el mismo PR.
+- **Verificación:** `npx @google/design.md lint DESIGN.md` valida la estructura (incluido contraste WCAG). `npx @google/design.md diff` compara versiones. El spec está en **alpha** y cambiará; por eso `version: alpha` está fijado y no se construyen automatismos frágiles encima todavía.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Esta aplicación depende directamente de su servicio backend para obtener los da
 
 ## 🤝 Contribuir
 
-Antes de abrir un PR, lee la [**Guía de Contribución**](CONTRIBUTING.md): arquitectura, reglas de implementación y el flujo `issue → rama → commits → PR → release`.
+Antes de abrir un PR, lee la [**Guía de Contribución**](CONTRIBUTING.md): arquitectura, reglas de implementación y el flujo `issue → rama → commits → PR → release`. El sistema de diseño de la app (tokens de color, tipografía, espaciado y su razonamiento) vive en [**`DESIGN.md`**](DESIGN.md), la fuente de verdad visual.
 
 Cada PR hacia `development` o `master` corre `flutter analyze` y `flutter test` en GitHub Actions antes de poder fusionarse; la construcción y distribución siguen en Codemagic sobre `master`. Detalle en [CONTRIBUTING.md → Integración Continua](CONTRIBUTING.md#-integración-continua-ci).
 
@@ -97,7 +97,7 @@ Este repositorio versiona convenciones y capacidades para desarrollo asistido po
 
 ```
 .agents/
-├── rules/    # 17 convenciones obligatorias (issues, ramas, commits, PR, releases,
+├── rules/    # 18 convenciones obligatorias (issues, ramas, commits, PR, releases,
 │             #  versionado y las reglas técnicas de Flutter/Dart/GetX)
 └── skills/   # 24 skills, de 6 orígenes (ver .agents/ATTRIBUTION.md)
 ```


### PR DESCRIPTION
# Descripción

El sistema de diseño vivía a medias: color y anchos centralizados en `config/theme/`, pero **tipografía como 25 `fontSize:` a mano** por los widgets, y espaciado/radios/componentes como números sueltos. Nada declaraba la identidad visual ni su porqué, así que cada pantalla nueva volvía a decidir tamaños.

Cambios (rama `docs/DTA-020`):

### `DESIGN.md` (raíz) — la fuente de verdad
Formato [google-labs-code/design.md](https://github.com/google-labs-code/design.md):
- **Front matter (tokens normativos):** 9 colores de marca, una **escala tipográfica de 9 niveles derivada de los tamaños dispersos** (10→40 px), el espaciado y los radios del **grid de 8 pt**, y 5 componentes.
- **Cuerpo:** las **ocho secciones canónicas** (Overview, Colors, Typography, Layout, Elevation & Depth, Shapes, Components, Do's and Don'ts) con el razonamiento de cada decisión.
- **Los tokens coinciden con `config/theme` exactamente** — los 9 colores son los valores base de los swatches `AppColors`; la escala y el espaciado salen del grid de 8 pt de `WidthValues`. **Ningún valor inventado.**

### Las dos decisiones que el issue pedía tomar

1. **Los cuatro modos de color** (`light`/`dark`/`onBrandLight`/`onBrandDark`): se quedan en `colors_values.dart`. El front matter declara la **paleta de marca agnóstica de modo** y documenta el mapeo por modo en prosa. Motivo: el oscuro está **escogido a mano** (base `midnight`), no derivado del claro, así que "claro normativo + derivación" mentiría, y sufijar cada token cuadruplicaría ~50 tokens semánticos.
2. **`config/theme/` se mantiene a mano**, con `DESIGN.md` como checklist. No se genera: no hay export oficial de design.md a Flutter (emite Tailwind/DTCG/CSS, no `ThemeData`), y la capa semántica de 4 modos es más rica que el mapa plano.

### Wiring (la otra mitad del valor)
- **`CLAUDE.md`** (Theming): apunta a `DESIGN.md` como fuente de verdad, `config/theme/` como implementación.
- **Regla nueva `.agents/rules/design-system.md`** (con `paths:`): leer `DESIGN.md` antes de construir UI; un token nuevo se declara ahí primero. Registrada en la tabla de CLAUDE.md/AGENTS.md y en el índice de `.agents/README.md` (17→18 reglas, 13→14 path-scoped, líneas recalculadas).
- **`README.md`**: menciona `DESIGN.md` entre los documentos del proyecto (18 convenciones).

### Salida del linter (criterio: registrarla en la PR)

`npx @google/design.md lint DESIGN.md` (v0.4.0):

```json
{
  "findings": [
    { "severity": "warning", "path": "colors.success", "message": "'success' is defined but never referenced by any component.", "rule": "orphaned-tokens" },
    { "severity": "warning", "path": "colors.info", "message": "'info' is defined but never referenced by any component.", "rule": "orphaned-tokens" },
    { "severity": "info", "message": "Design system defines 9 colors, 9 typography scales, 7 rounding levels, 5 spacing tokens, 5 components.", "rule": "token-summary" }
  ],
  "summary": { "errors": 0, "warnings": 2, "infos": 1 }
}
```

**0 errores.** Las 2 advertencias son `success`/`info` sin componente que las referencie — colores semánticos legítimos (estados, tinte de tarjeta) documentados en prosa; forzar una referencia falsa sería menos honesto. Una advertencia de contraste temprana (ámbar sobre azul info, 2.01:1 en el bottom bar) se resolvió corrigiendo el token para que sea **veraz**: el fondo del bottom bar es la superficie oscura (`midnight`), e `info` es el borde — no un fondo sólido.

## Fuera de alcance (como indicaba el issue)

Refactorizar los widgets para consumir los tokens (los 25 `fontSize` a mano, los `EdgeInsets` sueltos). Esto establece la fuente de verdad; la migración es **#44**.

Issue de GitHub relacionado: Closes #46

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad
- [ ] 🛠️ Corrección de errores
- [ ] ❌ Cambio importante
- [x] 📝 Actualización de la documentación
- [ ] 🧹 Code refactoring
- [ ] ✅ Build configuration change
- [ ] 🗑️ Chore

## ¿Cómo se ha probado esto?

- [x] `npx @google/design.md lint DESIGN.md` → **0 errores** (salida arriba).
- [x] `flutter analyze` → `No issues found!`; `flutter test` en verde (sin cambio de código).
- [x] `diff CLAUDE.md AGENTS.md` sin diferencias.
- [x] Verificado que los 9 colores del front matter coinciden con `colors_constants.dart` y que el espaciado/radios salen del grid de 8 pt de `WidthValues`.
- [x] No aplica dispositivo: es documentación; no cambia el código de la app.

**Configuración de prueba**: cambio documental + convención; sin efecto en el binario.

## Lista de Verificación

- [x] He agregado las nuevas dependencias a la descripción — ninguna (el linter se corre con `npx`, no es dependencia del proyecto)
- [x] He agregado las nuevas variables de entorno a la descripción — ninguna
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código — el `DESIGN.md` es todo razonamiento
- [x] He realizado los cambios correspondientes a la documentación — es **el** cambio (+ wiring en CLAUDE/AGENTS/README/.agents)
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente
- [x] La app compila — no aplica: sin cambio de código
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas — no aplica
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper — no aplica
- [x] No introduje modelos en la UI ni en los controladores — no aplica
