### PR TITLE
[🛠️ Fix: DTA-022] - Mensajes de error diferenciados por tipo

### DIFF
--- a/lib/core/i18n/app_messages.dart
+++ b/lib/core/i18n/app_messages.dart
@@ -102,4 +102,18 @@ class AppMessages {
   static String get configErrorTitle => 'configErrorTitle'.tr;
 
   static String get configErrorBody => 'configErrorBody'.tr;
+
+  static String get errorNoConnection => 'errorNoConnection'.tr;
+
+  static String get errorTimeout => 'errorTimeout'.tr;
+
+  static String get errorServiceUnavailable => 'errorServiceUnavailable'.tr;
+
+  static String get errorInvalidRequest => 'errorInvalidRequest'.tr;
+
+  static String get errorServerInternal => 'errorServerInternal'.tr;
+
+  static String get errorUnexpectedResponse => 'errorUnexpectedResponse'.tr;
+
+  static String get errorGeneric => 'errorGeneric'.tr;
 }

--- a/lib/core/i18n/languages/de_de.dart
+++ b/lib/core/i18n/languages/de_de.dart
@@ -51,4 +51,12 @@ const Map<String, String> deDe = {
   'configErrorTitle': 'Unvollständige Konfiguration',
   'configErrorBody':
       'Die App ist nicht korrekt konfiguriert und kann die Kurse nicht abrufen. Wenden Sie sich an die Person, die sie bereitstellt.',
+  'errorNoConnection': 'Keine Internetverbindung. Prüfe dein Netzwerk.',
+  'errorTimeout': 'Der Server hat zu lange gebraucht. Versuche es erneut.',
+  'errorServiceUnavailable': 'Der Dienst ist derzeit nicht verfügbar.',
+  'errorInvalidRequest': 'Die Anfrage ist ungültig.',
+  'errorServerInternal':
+      'Ein Serverfehler ist aufgetreten. Versuche es später.',
+  'errorUnexpectedResponse': 'Der Dienst hat unerwartet geantwortet.',
+  'errorGeneric': 'Daten konnten nicht geladen werden. Versuche es erneut.',
 };

--- a/lib/core/i18n/languages/en_us.dart
+++ b/lib/core/i18n/languages/en_us.dart
@@ -51,4 +51,11 @@ const Map<String, String> enUs = {
   'configErrorTitle': 'Incomplete configuration',
   'configErrorBody':
       'The app is not configured correctly and cannot fetch the rates. Contact whoever distributes it.',
+  'errorNoConnection': 'No internet connection. Check your network.',
+  'errorTimeout': 'The server took too long to respond. Try again.',
+  'errorServiceUnavailable': 'The service is unavailable right now.',
+  'errorInvalidRequest': 'The request is not valid.',
+  'errorServerInternal': 'A server error occurred. Try again later.',
+  'errorUnexpectedResponse': 'The service responded unexpectedly.',
+  'errorGeneric': 'Could not load the data. Try again.',
 };

--- a/lib/core/i18n/languages/es_es.dart
+++ b/lib/core/i18n/languages/es_es.dart
@@ -51,4 +51,11 @@ const Map<String, String> esEs = {
   'configErrorTitle': 'Configuración incompleta',
   'configErrorBody':
       'La app no se ha configurado correctamente y no puede consultar las tasas. Contacta con quien la distribuye.',
+  'errorNoConnection': 'Sin conexión a internet. Revisa tu red.',
+  'errorTimeout': 'El servidor tardó demasiado en responder. Intenta de nuevo.',
+  'errorServiceUnavailable': 'El servicio no está disponible en este momento.',
+  'errorInvalidRequest': 'La solicitud no es válida.',
+  'errorServerInternal': 'Ocurrió un error en el servidor. Intenta más tarde.',
+  'errorUnexpectedResponse': 'El servicio respondió de forma inesperada.',
+  'errorGeneric': 'No se pudieron cargar los datos. Intenta de nuevo.',
 };

--- a/lib/core/i18n/languages/fr_fr.dart
+++ b/lib/core/i18n/languages/fr_fr.dart
@@ -51,4 +51,12 @@ const Map<String, String> frFr = {
   'configErrorTitle': 'Configuration incomplète',
   'configErrorBody':
       'L\'application n\'est pas correctement configurée et ne peut pas récupérer les taux. Contactez la personne qui la distribue.',
+  'errorNoConnection': 'Pas de connexion internet. Vérifiez votre réseau.',
+  'errorTimeout': 'Le serveur a mis trop de temps à répondre. Réessayez.',
+  'errorServiceUnavailable': 'Le service est indisponible pour le moment.',
+  'errorInvalidRequest': 'La requête n\'est pas valide.',
+  'errorServerInternal':
+      'Une erreur serveur s\'est produite. Réessayez plus tard.',
+  'errorUnexpectedResponse': 'Le service a répondu de façon inattendue.',
+  'errorGeneric': 'Impossible de charger les données. Réessayez.',
 };

--- a/lib/core/i18n/languages/it_it.dart
+++ b/lib/core/i18n/languages/it_it.dart
@@ -51,4 +51,12 @@ const Map<String, String> itIt = {
   'configErrorTitle': 'Configurazione incompleta',
   'configErrorBody':
       'L\'app non è configurata correttamente e non può recuperare i tassi. Contatta chi la distribuisce.',
+  'errorNoConnection': 'Nessuna connessione a internet. Controlla la rete.',
+  'errorTimeout': 'Il server ha impiegato troppo tempo. Riprova.',
+  'errorServiceUnavailable': 'Il servizio non è disponibile al momento.',
+  'errorInvalidRequest': 'La richiesta non è valida.',
+  'errorServerInternal':
+      'Si è verificato un errore del server. Riprova più tardi.',
+  'errorUnexpectedResponse': 'Il servizio ha risposto in modo inaspettato.',
+  'errorGeneric': 'Impossibile caricare i dati. Riprova.',
 };

--- a/lib/core/i18n/languages/ja_jp.dart
+++ b/lib/core/i18n/languages/ja_jp.dart
@@ -52,4 +52,11 @@ const Map<String, String> jaJp = {
   'conversionUnavailable': 'この換算に利用できるレートがありません',
   'configErrorTitle': '設定が不完全です',
   'configErrorBody': 'アプリが正しく設定されておらず、レートを取得できません。配布元にお問い合わせください。',
+  'errorNoConnection': 'インターネット接続がありません。ネットワークを確認してください。',
+  'errorTimeout': 'サーバーの応答に時間がかかりすぎました。もう一度お試しください。',
+  'errorServiceUnavailable': '現在サービスを利用できません。',
+  'errorInvalidRequest': 'リクエストが無効です。',
+  'errorServerInternal': 'サーバーエラーが発生しました。後でもう一度お試しください。',
+  'errorUnexpectedResponse': 'サービスが予期しない応答を返しました。',
+  'errorGeneric': 'データを読み込めませんでした。もう一度お試しください。',
 };

--- a/lib/core/i18n/languages/ko_kr.dart
+++ b/lib/core/i18n/languages/ko_kr.dart
@@ -52,4 +52,11 @@ const Map<String, String> koKr = {
   'conversionUnavailable': '이 환전에 사용할 수 있는 환율이 없습니다',
   'configErrorTitle': '설정이 완료되지 않았습니다',
   'configErrorBody': '앱이 올바르게 설정되지 않아 환율을 가져올 수 없습니다. 배포자에게 문의하세요.',
+  'errorNoConnection': '인터넷 연결이 없습니다. 네트워크를 확인하세요.',
+  'errorTimeout': '서버 응답이 너무 오래 걸렸습니다. 다시 시도하세요.',
+  'errorServiceUnavailable': '현재 서비스를 사용할 수 없습니다.',
+  'errorInvalidRequest': '요청이 유효하지 않습니다.',
+  'errorServerInternal': '서버 오류가 발생했습니다. 나중에 다시 시도하세요.',
+  'errorUnexpectedResponse': '서비스가 예기치 않게 응답했습니다.',
+  'errorGeneric': '데이터를 불러올 수 없습니다. 다시 시도하세요.',
 };

--- a/lib/core/i18n/languages/pt_pt.dart
+++ b/lib/core/i18n/languages/pt_pt.dart
@@ -51,4 +51,11 @@ const Map<String, String> ptPt = {
   'configErrorTitle': 'Configuração incompleta',
   'configErrorBody':
       'A aplicação não está configurada corretamente e não consegue obter as taxas. Contacte quem a distribui.',
+  'errorNoConnection': 'Sem ligação à internet. Verifica a tua rede.',
+  'errorTimeout': 'O servidor demorou demasiado a responder. Tenta de novo.',
+  'errorServiceUnavailable': 'O serviço não está disponível neste momento.',
+  'errorInvalidRequest': 'O pedido não é válido.',
+  'errorServerInternal': 'Ocorreu um erro no servidor. Tenta mais tarde.',
+  'errorUnexpectedResponse': 'O serviço respondeu de forma inesperada.',
+  'errorGeneric': 'Não foi possível carregar os dados. Tenta de novo.',
 };

--- a/lib/core/i18n/languages/ru_ru.dart
+++ b/lib/core/i18n/languages/ru_ru.dart
@@ -51,4 +51,11 @@ const Map<String, String> ruRu = {
   'configErrorTitle': 'Неполная конфигурация',
   'configErrorBody':
       'Приложение настроено неверно и не может получить курсы. Свяжитесь с тем, кто его распространяет.',
+  'errorNoConnection': 'Нет подключения к интернету. Проверьте сеть.',
+  'errorTimeout': 'Сервер слишком долго отвечал. Повторите попытку.',
+  'errorServiceUnavailable': 'Сервис сейчас недоступен.',
+  'errorInvalidRequest': 'Запрос недействителен.',
+  'errorServerInternal': 'Произошла ошибка сервера. Повторите позже.',
+  'errorUnexpectedResponse': 'Сервис ответил неожиданно.',
+  'errorGeneric': 'Не удалось загрузить данные. Повторите попытку.',
 };

--- a/lib/core/i18n/languages/zh_cn.dart
+++ b/lib/core/i18n/languages/zh_cn.dart
@@ -50,4 +50,11 @@ const Map<String, String> zhCn = {
   'conversionUnavailable': '此换算暂无可用汇率',
   'configErrorTitle': '配置不完整',
   'configErrorBody': '应用未正确配置，无法获取汇率。请联系分发方。',
+  'errorNoConnection': '无网络连接。请检查你的网络。',
+  'errorTimeout': '服务器响应超时。请重试。',
+  'errorServiceUnavailable': '服务当前不可用。',
+  'errorInvalidRequest': '请求无效。',
+  'errorServerInternal': '服务器发生错误。请稍后重试。',
+  'errorUnexpectedResponse': '服务返回了意外的响应。',
+  'errorGeneric': '无法加载数据。请重试。',
 };

--- a/lib/core/network/api_error_messages.dart
+++ b/lib/core/network/api_error_messages.dart
@@ -1,0 +1,28 @@
+import '../i18n/app_messages.dart';
+import 'api_exception.dart';
+
+/// Translates an [ApiException] into the message the **user** should read.
+///
+/// The backend's own `message` is written for developers (and goes to the log,
+/// #19); the user needs to know whether the problem is theirs (no connection)
+/// or the service's, and what to do about it. The mapping is by [kind] first —
+/// so "no connection" is never confused with "the server failed" — and then by
+/// the HTTP code the backend assigns meaning to (408 slow source, 502 source
+/// down, 422 mode not allowed, 500 internal). Anything else falls to a
+/// controlled generic message rather than leaking a raw status.
+String apiErrorMessage(ApiException e) {
+  switch (e.kind) {
+    case ApiExceptionKind.network:
+      return AppMessages.errorNoConnection;
+    case ApiExceptionKind.malformed:
+      return AppMessages.errorUnexpectedResponse;
+    case ApiExceptionKind.response:
+      return switch (e.statusCode) {
+        408 => AppMessages.errorTimeout,
+        422 => AppMessages.errorInvalidRequest,
+        502 => AppMessages.errorServiceUnavailable,
+        500 => AppMessages.errorServerInternal,
+        _ => AppMessages.errorGeneric,
+      };
+  }
+}

--- a/lib/core/network/api_exception.dart
+++ b/lib/core/network/api_exception.dart
@@ -1,14 +1,32 @@
 import 'dart:convert';
 
+/// What kind of failure an [ApiException] represents, independent of the HTTP
+/// code. Lets the UI tell "you have no connection" apart from "the service
+/// answered with an error" — see `apiErrorMessage` in `api_error_messages.dart`.
+enum ApiExceptionKind {
+  /// The request never produced a response (no connectivity, DNS, timeout, TLS).
+  network,
+
+  /// A response arrived but its shape is not the expected contract.
+  malformed,
+
+  /// The backend answered with an error status and (usually) a message.
+  response,
+}
+
 /// Failure while talking to the currency backend.
 ///
 /// The backend answers every error with the same envelope
 /// (`{"status": "Error", "message": "..."}`) and a meaningful status code —
 /// 404 wrong route, 408 source timeout, 502 source unavailable, 500 internal.
-/// This exception keeps both so the UI can tell the user what happened instead
-/// of failing silently.
+/// This exception keeps both — plus a [kind] — so the UI can tell the user what
+/// happened instead of failing silently.
 class ApiException implements Exception {
-  const ApiException({required this.message, this.statusCode});
+  const ApiException({
+    required this.message,
+    this.statusCode,
+    this.kind = ApiExceptionKind.response,
+  });
 
   /// Builds the exception from an error response, reusing the `message` of the
   /// backend envelope when the body carries one.
@@ -16,19 +34,27 @@ class ApiException implements Exception {
     return ApiException(
       message: _messageFromBody(body) ?? 'HTTP $statusCode',
       statusCode: statusCode,
+      kind: ApiExceptionKind.response,
     );
   }
 
   /// The request never produced a response (no connectivity, DNS, timeout).
-  const ApiException.network(this.message) : statusCode = null;
+  const ApiException.network(this.message)
+    : statusCode = null,
+      kind = ApiExceptionKind.network;
 
   /// A response arrived but its shape is not the expected contract.
-  const ApiException.malformed(this.message) : statusCode = null;
+  const ApiException.malformed(this.message)
+    : statusCode = null,
+      kind = ApiExceptionKind.malformed;
 
   final String message;
 
   /// HTTP status code, or `null` when the request never reached the backend.
   final int? statusCode;
+
+  /// The category of failure, used to pick a user-facing message.
+  final ApiExceptionKind kind;
 
   static String? _messageFromBody(Object? body) {
     if (body is! String || body.isEmpty) return null;

--- a/lib/shared/data/repositories/currency_repository.dart
+++ b/lib/shared/data/repositories/currency_repository.dart
@@ -1,5 +1,7 @@
 import 'package:get/get.dart';
+import '../../../core/i18n/app_messages.dart';
 import '../../../core/logging/app_logger.dart';
+import '../../../core/network/api_error_messages.dart';
 import '../../../core/network/api_exception.dart';
 import '../../domain/entities/entities.dart';
 import '../../domain/repositories/dollar_repositories.dart';
@@ -78,8 +80,11 @@ class CurrencyRepository extends GetxService {
     hasBcvData.value = true;
   }
 
-  /// User-facing detail of a failure: [ApiException] already carries the
-  /// `message` of the backend error envelope.
+  /// User-facing message for a failure. An [ApiException] is mapped by its kind
+  /// and HTTP code to a translated app message (`apiErrorMessage`); the
+  /// backend's own developer-oriented text stays in the log (#19). Anything
+  /// unexpected degrades to a controlled generic message, never a raw
+  /// `toString()`.
   String _describe(Object error) =>
-      error is ApiException ? error.message : error.toString();
+      error is ApiException ? apiErrorMessage(error) : AppMessages.errorGeneric;
 }

--- a/test/core/network/api_error_messages_test.dart
+++ b/test/core/network/api_error_messages_test.dart
@@ -1,0 +1,71 @@
+import 'package:bcv_tracker_app/core/i18n/app_messages.dart';
+import 'package:bcv_tracker_app/core/network/api_error_messages.dart';
+import 'package:bcv_tracker_app/core/network/api_exception.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // The mapper returns AppMessages getters. Without GetX translations loaded,
+  // `.tr` returns the raw key, so both the actual and the expected evaluate to
+  // the same key — the assertions test the *mapping*, not the translation.
+  group('apiErrorMessage by kind', () {
+    test('a network failure is "no connection", not a server error', () {
+      expect(
+        apiErrorMessage(const ApiException.network('Connection refused')),
+        AppMessages.errorNoConnection,
+      );
+    });
+
+    test('a malformed response maps to "unexpected response"', () {
+      expect(
+        apiErrorMessage(const ApiException.malformed('bad contract')),
+        AppMessages.errorUnexpectedResponse,
+      );
+    });
+  });
+
+  group('apiErrorMessage by status code', () {
+    final cases = <int, String>{
+      408: AppMessages.errorTimeout,
+      422: AppMessages.errorInvalidRequest,
+      502: AppMessages.errorServiceUnavailable,
+      500: AppMessages.errorServerInternal,
+    };
+
+    cases.forEach((code, expected) {
+      test('$code maps to its own message', () {
+        expect(
+          apiErrorMessage(ApiException.fromResponse(statusCode: code)),
+          expected,
+        );
+      });
+    });
+
+    test('any other code falls to the controlled generic message', () {
+      for (final code in [404, 401, 400, 503, 418]) {
+        expect(
+          apiErrorMessage(ApiException.fromResponse(statusCode: code)),
+          AppMessages.errorGeneric,
+          reason: 'code $code',
+        );
+      }
+    });
+  });
+
+  test('connectivity is distinguished from a server failure', () {
+    final network = apiErrorMessage(const ApiException.network('x'));
+    final server = apiErrorMessage(ApiException.fromResponse(statusCode: 502));
+    expect(network, isNot(server));
+  });
+
+  test('the backend developer message never becomes the user message', () {
+    // fromResponse keeps the backend text in `.message`; the user sees the
+    // mapped app message instead.
+    final e = ApiException.fromResponse(
+      statusCode: 500,
+      body:
+          '{"status":"Error","message":"Traceback: NoneType has no attribute"}',
+    );
+    expect(apiErrorMessage(e), AppMessages.errorServerInternal);
+    expect(apiErrorMessage(e), isNot(contains('Traceback')));
+  });
+}

--- a/test/features/home/home_page_test.dart
+++ b/test/features/home/home_page_test.dart
@@ -70,14 +70,17 @@ Future<void> _pumpHome(WidgetTester tester, {String? error}) async {
 void main() {
   tearDown(() => Get.reset());
 
-  testWidgets('renders the error card when the refresh failed', (tester) async {
-    await _pumpHome(tester, error: 'El portal del BCV no responde');
+  testWidgets('renders the error card with the mapped message', (tester) async {
+    // A network failure: the repository maps it to a user message (#18), not
+    // the backend's raw text. The card shows the "could not load" headline and
+    // the "no connection" detail. In the error state showCurrencies is false,
+    // so no rate cards (and no network images) are built.
+    await _pumpHome(tester, error: 'Connection refused');
 
-    // The backend detail is passed through verbatim, so it is the reliable
-    // signal that the error card rendered. In the error state showCurrencies is
-    // false, so no rate cards (and no network images) are built.
-    expect(find.textContaining('El portal del BCV no responde'), findsWidgets);
     expect(find.text(AppMessages.loadingError), findsWidgets);
+    expect(find.text(AppMessages.errorNoConnection), findsWidgets);
+    // The developer-oriented backend text never reaches the screen.
+    expect(find.textContaining('Connection refused'), findsNothing);
   });
 
   testWidgets('shows no error card on a successful refresh', (tester) async {

--- a/test/shared/data/currency_repository_test.dart
+++ b/test/shared/data/currency_repository_test.dart
@@ -1,3 +1,4 @@
+import 'package:bcv_tracker_app/core/i18n/app_messages.dart';
 import 'package:bcv_tracker_app/core/network/api_exception.dart';
 import 'package:bcv_tracker_app/shared/data/repositories/currency_repository.dart';
 import 'package:bcv_tracker_app/shared/domain/entities/bcv_currencies.dart';
@@ -76,22 +77,25 @@ void main() {
   });
 
   group('refreshData() error paths', () {
-    test('an ApiException surfaces as errorMessage, loading resets', () async {
-      final repo = _repositoryWith(
-        _FakeDollarRepository(
-          bcvThrows: const ApiException.network(
-            'El portal del BCV no responde',
+    test(
+      'an ApiException surfaces as a mapped user message, loading resets',
+      () async {
+        final repo = _repositoryWith(
+          _FakeDollarRepository(
+            // The backend's own text is developer-oriented; the repo maps the
+            // exception kind/code to a user message (#18) instead of echoing it.
+            bcvThrows: const ApiException.network('Connection refused'),
+            saved: const [],
           ),
-          saved: const [],
-        ),
-      );
+        );
 
-      await repo.refreshData();
+        await repo.refreshData();
 
-      // ApiException carries the backend message; the repo hands that to the UI.
-      expect(repo.errorMessage.value, 'El portal del BCV no responde');
-      expect(repo.isLoading.value, isFalse);
-    });
+        expect(repo.errorMessage.value, AppMessages.errorNoConnection);
+        expect(repo.errorMessage.value, isNot('Connection refused'));
+        expect(repo.isLoading.value, isFalse);
+      },
+    );
 
     test('a partial failure still lands the side that succeeded', () async {
       // eagerError is off: the BCV fetch fails but the average fetch completes,
@@ -119,7 +123,9 @@ void main() {
 
       await repo.refreshData();
 
-      expect(repo.errorMessage.value, contains('unexpected'));
+      // Not an ApiException → the controlled generic message, never toString().
+      expect(repo.errorMessage.value, AppMessages.errorGeneric);
+      expect(repo.errorMessage.value, isNot(contains('unexpected')));
       expect(repo.isLoading.value, isFalse);
     });
   });


### PR DESCRIPTION
# Descripción

La capa de red ya distinguía las causas —`ApiException` separa **sin respuesta** (`network`), **contrato inesperado** (`malformed`) y **error del backend** (`fromResponse`, con su `statusCode`)— pero la UI colapsaba todo a un texto genérico, ignorando el tipo y los códigos HTTP a los que el backend da significado (408 fuente lenta, 502 fuente caída, 422 modo no permitido, 500 interno).

Cambios (rama `fix/DTA-022`):

- **`ApiExceptionKind`** (`network`/`malformed`/`response`) añadido a `ApiException`, para poder distinguir "sin conexión" de "el servidor falló".
- **`apiErrorMessage(ApiException)`** (`lib/core/network/api_error_messages.dart`): mapea primero por **tipo**, luego por **código HTTP** (408/422/502/500); cualquier otro código cae en un **mensaje genérico controlado** — nunca un código crudo ni el texto de desarrollador del backend, que se queda en el log (#19).
- **7 claves traducidas** en los 10 idiomas, expuestas por `AppMessages`: `errorNoConnection`, `errorTimeout`, `errorServiceUnavailable`, `errorInvalidRequest`, `errorServerInternal`, `errorUnexpectedResponse`, `errorGeneric`.
- **`CurrencyRepository._describe`** devuelve ahora el mensaje de usuario mapeado en vez del `message` del backend.

El mapeo:

| Caso | Mensaje |
|---|---|
| `kind == network` | Sin conexión (se distingue del fallo del servidor) |
| `kind == malformed` | Respuesta inesperada del servicio |
| `408` | El servidor tardó demasiado |
| `422` | Solicitud no válida |
| `502` | Servicio no disponible |
| `500` | Error del servidor |
| cualquier otro código | Genérico controlado |

## Criterios

- ✅ Cada tipo de `ApiException` produce un mensaje distinto y comprensible.
- ✅ 408, 422, 502 y 500 se traducen a mensajes propios; cualquier otro cae en el genérico controlado.
- ✅ La falta de conectividad (`network`) se distingue de un fallo del servidor (`response`) — hay un test explícito de ello.
- ✅ Los mensajes usan claves de `AppMessages` traducidas en los **10 idiomas** (paridad de 58 claves verificada; `AppMessages` expone exactamente ese conjunto).
- ✅ Tests del mapeo excepción→mensaje para **cada** caso.

## Fuera de alcance (como indicaba el issue)

El **rediseño visual** de los estados de error — eso es **#11**. Este PR define solo **qué dicen**; el otro, cómo se ven. El texto del backend, orientado a desarrolladores, se deja para el log (#19).

Issue de GitHub relacionado: Closes #18

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad
- [x] 🛠️ Corrección de errores
- [ ] ❌ Cambio importante
- [ ] 📝 Actualización de la documentación
- [ ] 🧹 Code refactoring
- [ ] ✅ Build configuration change
- [ ] 🗑️ Chore

## ¿Cómo se ha probado esto?

- [x] `flutter test` — **146 tests** en verde, incluidos los del mapper (cada rama) y la integración en el widget de Home (el mensaje mapeado se renderiza y el texto del backend **no** llega a pantalla).
- [x] `flutter analyze` → `No issues found!`.
- [x] Paridad i18n verificada: 58 claves en los 10 idiomas; `AppMessages` expone exactamente esas.
- [x] Actualizados los tests cuyo contrato cambió (`currency_repository_test`, `home_page_test`): `errorMessage` es ahora el mensaje de usuario, no el del backend.
- [ ] **Pendiente de verificación en dispositivo**: forzar cada caso (sin internet, 408/422/502/500, respuesta malformada) y ver el mensaje correcto en pantalla — la presentación de estos estados la rediseña #11, así que la verificación visual fina va con esa.

**Configuración de prueba**: la lógica de mapeo está cubierta por tests unitarios; el flujo end-to-end por el widget test de Home. La verificación en dispositivo por causa real queda para #11.

## Lista de Verificación

- [x] He agregado las nuevas dependencias a la descripción — ninguna
- [x] He agregado las nuevas variables de entorno a la descripción — ninguna
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código — el mapper documenta el criterio (tipo primero, luego código)
- [x] He realizado los cambios correspondientes a la documentación — no aplica (sin cambio de arquitectura)
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente con mis cambios
- [x] La app compila; los widget tests montan el árbol con el nuevo flujo
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas — sí, las 7 claves nuevas
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper de cálculo, incluí sus tests — el mapper y el cambio en `CurrencyRepository` llevan sus tests
- [x] No introduje modelos en la UI ni en los controladores — no aplica
