### PR TITLE
[🧹 Refactor: DTA-023] - Unificar estados de error y vacío con branding

### DIFF
--- a/lib/core/constants/constants.dart
+++ b/lib/core/constants/constants.dart
@@ -8,4 +8,8 @@ class Constants {
   static const String bcvFormatDate = 'yyyy-MM-dd';
 
   static const String defaultFormatDate = 'yyyy-MM-dd HH:mm';
+
+  /// The app logo (foreground layer), used as the branded illustration of the
+  /// empty state. Declared as an asset in `pubspec.yaml`.
+  static const String appLogoAsset = 'assets/images/foreground_icon_app.png';
 }

--- a/lib/core/i18n/app_messages.dart
+++ b/lib/core/i18n/app_messages.dart
@@ -116,4 +116,8 @@ class AppMessages {
   static String get errorUnexpectedResponse => 'errorUnexpectedResponse'.tr;
 
   static String get errorGeneric => 'errorGeneric'.tr;
+
+  static String get emptyStateTitle => 'emptyStateTitle'.tr;
+
+  static String get emptyStateMessage => 'emptyStateMessage'.tr;
 }

--- a/lib/core/i18n/languages/de_de.dart
+++ b/lib/core/i18n/languages/de_de.dart
@@ -59,4 +59,6 @@ const Map<String, String> deDe = {
       'Ein Serverfehler ist aufgetreten. Versuche es später.',
   'errorUnexpectedResponse': 'Der Dienst hat unerwartet geantwortet.',
   'errorGeneric': 'Daten konnten nicht geladen werden. Versuche es erneut.',
+  'emptyStateTitle': 'Keine Daten',
+  'emptyStateMessage': 'Noch keine Kurse vorhanden. Zum Aktualisieren ziehen.',
 };

--- a/lib/core/i18n/languages/en_us.dart
+++ b/lib/core/i18n/languages/en_us.dart
@@ -58,4 +58,6 @@ const Map<String, String> enUs = {
   'errorServerInternal': 'A server error occurred. Try again later.',
   'errorUnexpectedResponse': 'The service responded unexpectedly.',
   'errorGeneric': 'Could not load the data. Try again.',
+  'emptyStateTitle': 'No data',
+  'emptyStateMessage': 'No rates to show yet. Pull to refresh.',
 };

--- a/lib/core/i18n/languages/es_es.dart
+++ b/lib/core/i18n/languages/es_es.dart
@@ -58,4 +58,7 @@ const Map<String, String> esEs = {
   'errorServerInternal': 'Ocurrió un error en el servidor. Intenta más tarde.',
   'errorUnexpectedResponse': 'El servicio respondió de forma inesperada.',
   'errorGeneric': 'No se pudieron cargar los datos. Intenta de nuevo.',
+  'emptyStateTitle': 'Sin datos',
+  'emptyStateMessage':
+      'Aún no hay tasas para mostrar. Desliza para actualizar.',
 };

--- a/lib/core/i18n/languages/fr_fr.dart
+++ b/lib/core/i18n/languages/fr_fr.dart
@@ -59,4 +59,7 @@ const Map<String, String> frFr = {
       'Une erreur serveur s\'est produite. Réessayez plus tard.',
   'errorUnexpectedResponse': 'Le service a répondu de façon inattendue.',
   'errorGeneric': 'Impossible de charger les données. Réessayez.',
+  'emptyStateTitle': 'Aucune donnée',
+  'emptyStateMessage':
+      'Aucun taux à afficher pour l\'instant. Tire pour actualiser.',
 };

--- a/lib/core/i18n/languages/it_it.dart
+++ b/lib/core/i18n/languages/it_it.dart
@@ -59,4 +59,7 @@ const Map<String, String> itIt = {
       'Si è verificato un errore del server. Riprova più tardi.',
   'errorUnexpectedResponse': 'Il servizio ha risposto in modo inaspettato.',
   'errorGeneric': 'Impossibile caricare i dati. Riprova.',
+  'emptyStateTitle': 'Nessun dato',
+  'emptyStateMessage':
+      'Ancora nessun tasso da mostrare. Trascina per aggiornare.',
 };

--- a/lib/core/i18n/languages/ja_jp.dart
+++ b/lib/core/i18n/languages/ja_jp.dart
@@ -59,4 +59,6 @@ const Map<String, String> jaJp = {
   'errorServerInternal': 'サーバーエラーが発生しました。後でもう一度お試しください。',
   'errorUnexpectedResponse': 'サービスが予期しない応答を返しました。',
   'errorGeneric': 'データを読み込めませんでした。もう一度お試しください。',
+  'emptyStateTitle': 'データがありません',
+  'emptyStateMessage': '表示できるレートはまだありません。引っ張って更新してください。',
 };

--- a/lib/core/i18n/languages/ko_kr.dart
+++ b/lib/core/i18n/languages/ko_kr.dart
@@ -59,4 +59,6 @@ const Map<String, String> koKr = {
   'errorServerInternal': '서버 오류가 발생했습니다. 나중에 다시 시도하세요.',
   'errorUnexpectedResponse': '서비스가 예기치 않게 응답했습니다.',
   'errorGeneric': '데이터를 불러올 수 없습니다. 다시 시도하세요.',
+  'emptyStateTitle': '데이터 없음',
+  'emptyStateMessage': '아직 표시할 환율이 없습니다. 당겨서 새로고침하세요.',
 };

--- a/lib/core/i18n/languages/pt_pt.dart
+++ b/lib/core/i18n/languages/pt_pt.dart
@@ -58,4 +58,6 @@ const Map<String, String> ptPt = {
   'errorServerInternal': 'Ocorreu um erro no servidor. Tenta mais tarde.',
   'errorUnexpectedResponse': 'O serviço respondeu de forma inesperada.',
   'errorGeneric': 'Não foi possível carregar os dados. Tenta de novo.',
+  'emptyStateTitle': 'Sem dados',
+  'emptyStateMessage': 'Ainda não há taxas para mostrar. Puxa para atualizar.',
 };

--- a/lib/core/i18n/languages/ru_ru.dart
+++ b/lib/core/i18n/languages/ru_ru.dart
@@ -58,4 +58,6 @@ const Map<String, String> ruRu = {
   'errorServerInternal': 'Произошла ошибка сервера. Повторите позже.',
   'errorUnexpectedResponse': 'Сервис ответил неожиданно.',
   'errorGeneric': 'Не удалось загрузить данные. Повторите попытку.',
+  'emptyStateTitle': 'Нет данных',
+  'emptyStateMessage': 'Пока нет курсов. Потяните, чтобы обновить.',
 };

--- a/lib/core/i18n/languages/zh_cn.dart
+++ b/lib/core/i18n/languages/zh_cn.dart
@@ -57,4 +57,6 @@ const Map<String, String> zhCn = {
   'errorServerInternal': '服务器发生错误。请稍后重试。',
   'errorUnexpectedResponse': '服务返回了意外的响应。',
   'errorGeneric': '无法加载数据。请重试。',
+  'emptyStateTitle': '暂无数据',
+  'emptyStateMessage': '暂无可显示的汇率。下拉刷新。',
 };

--- a/lib/features/converter/presentation/controller/converter_controller.dart
+++ b/lib/features/converter/presentation/controller/converter_controller.dart
@@ -8,6 +8,10 @@ class ConverterController extends GetxController {
 
   bool get isLoading => _repository.isLoading.value;
 
+  /// Detail of the last failed refresh, or `null` when the last one succeeded —
+  /// the same failure the Home shows, so the converter states stay consistent.
+  String? get errorMessage => _repository.errorMessage.value;
+
   // Single consolidated list of currencies
   final RxList<Currency> currencies = List.generate(
     5,
@@ -49,6 +53,7 @@ class ConverterController extends GetxController {
     _updateCurrenciesAndInit();
 
     ever(_repository.isLoading, (_) => update());
+    ever(_repository.errorMessage, (_) => update());
   }
 
   void _updateCurrenciesAndInit() {

--- a/lib/features/converter/presentation/page/converter_page.dart
+++ b/lib/features/converter/presentation/page/converter_page.dart
@@ -7,6 +7,7 @@ import '../../../../config/theme/colors/colors_values.dart';
 import '../../../../core/helpers/currency_helpers.dart';
 import '../../../../shared/domain/entities/currency.dart';
 // import '../../../../shared/presentation/controller/currency_controller.dart';
+import '../../../../shared/presentation/widgets/app_state_view.dart';
 import '../../../../shared/presentation/widgets/base_layout.dart';
 import '../../../../shared/presentation/widgets/base_modal.dart';
 import '../../../../shared/presentation/widgets/custom_refresh_indicator.dart';

--- a/lib/features/converter/presentation/widget/converter_body.dart
+++ b/lib/features/converter/presentation/widget/converter_body.dart
@@ -6,31 +6,42 @@ class _ConverterBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) => GetBuilder<ConverterController>(
     builder: (controller) {
+      final String? error = controller.errorMessage;
+
       return CustomRefreshIndicator.adaptive(
         onRefresh: () async {
           await controller.refreshConverterData();
         },
         child: SingleChildScrollView(
           physics: const AlwaysScrollableScrollPhysics(),
-          child: Stack(
-            alignment: Alignment.center,
-            children: [
-              Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  SizedBox(height: 16),
-                  _CurrencyInputCard(currency: controller.fromCurrency),
-                  const SizedBox(height: 32),
-                  _CurrencyInputCard(
-                    currency: controller.toCurrency,
-                    isInput: false,
-                  ),
-                  SizedBox(height: 16),
-                ],
-              ),
-              _SwapCurrencyButton(),
-            ],
-          ),
+          // The same failure the Home shows: when the rates could not be loaded
+          // there is nothing to convert with, so the error state replaces the
+          // inputs (and offers a retry) instead of showing an empty converter.
+          child: error != null
+              ? AppStateView.error(
+                  message: error,
+                  onRetry: controller.refreshConverterData,
+                  isBusy: controller.isLoading,
+                )
+              : Stack(
+                  alignment: Alignment.center,
+                  children: [
+                    Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        SizedBox(height: 16),
+                        _CurrencyInputCard(currency: controller.fromCurrency),
+                        const SizedBox(height: 32),
+                        _CurrencyInputCard(
+                          currency: controller.toCurrency,
+                          isInput: false,
+                        ),
+                        SizedBox(height: 16),
+                      ],
+                    ),
+                    _SwapCurrencyButton(),
+                  ],
+                ),
         ),
       );
     },

--- a/lib/features/home/presentation/page/home_page.dart
+++ b/lib/features/home/presentation/page/home_page.dart
@@ -8,6 +8,7 @@ import '../../../../core/helpers/currency_helpers.dart';
 import '../../../../core/i18n/app_messages.dart';
 import '../../../../shared/domain/entities/currency.dart';
 import '../../../../shared/presentation/controller/settings_controller.dart';
+import '../../../../shared/presentation/widgets/app_state_view.dart';
 import '../../../../shared/presentation/widgets/base_layout.dart';
 import '../../../../shared/presentation/widgets/custom_badged.dart';
 import '../../../../shared/presentation/widgets/custom_refresh_indicator.dart';

--- a/lib/features/home/presentation/widgets/home_body.dart
+++ b/lib/features/home/presentation/widgets/home_body.dart
@@ -45,10 +45,6 @@ class _HomeBodyAverageCurrency extends StatelessWidget {
   Widget build(BuildContext context) => GetBuilder<HomeController>(
     builder: (controller) {
       final String? error = controller.errorMessage;
-      // While the first refresh has not succeeded the list still holds the
-      // skeleton placeholders, so showing them once loading stopped would pass
-      // fake rates off as real ones.
-      final bool showCurrencies = controller.hasAverageData || error == null;
 
       return CustomRefreshIndicator.adaptive(
         onRefresh: () async {
@@ -59,11 +55,16 @@ class _HomeBodyAverageCurrency extends StatelessWidget {
           // which is exactly the case in the error state.
           physics: const AlwaysScrollableScrollPhysics(),
           children: [
-            if (error != null) ...[
-              _ErrorAdvisorCard(message: error),
-              SizedBox(height: 8),
-            ],
-            if (showCurrencies) ...[
+            if (error != null)
+              AppStateView.error(
+                message: error,
+                onRetry: controller.refreshHomeData,
+                isBusy: controller.isLoading,
+              )
+            else if (controller.hasAverageData &&
+                controller.averageCurrencies.isEmpty)
+              AppStateView.empty(onRetry: controller.refreshHomeData)
+            else ...[
               _CurrencyDollarAverageCard(),
               for (var e in controller.averageCurrencies) ...[
                 SizedBox(height: 8),
@@ -83,7 +84,6 @@ class _HomeBodyBCVCurrency extends StatelessWidget {
   Widget build(BuildContext context) => GetBuilder<HomeController>(
     builder: (controller) {
       final String? error = controller.errorMessage;
-      final bool showCurrencies = controller.hasBcvData || error == null;
 
       return CustomRefreshIndicator.adaptive(
         onRefresh: () async {
@@ -94,11 +94,15 @@ class _HomeBodyBCVCurrency extends StatelessWidget {
           // which is exactly the case in the error state.
           physics: const AlwaysScrollableScrollPhysics(),
           children: [
-            if (error != null) ...[
-              _ErrorAdvisorCard(message: error),
-              SizedBox(height: 8),
-            ],
-            if (showCurrencies) ...[
+            if (error != null)
+              AppStateView.error(
+                message: error,
+                onRetry: controller.refreshHomeData,
+                isBusy: controller.isLoading,
+              )
+            else if (controller.hasBcvData && controller.bcvCurrencies.isEmpty)
+              AppStateView.empty(onRetry: controller.refreshHomeData)
+            else ...[
               _BCVAdvisorCard(),
               SizedBox(height: 16),
               ...controller.bcvCurrencies.map(

--- a/lib/features/home/presentation/widgets/home_widgets.dart
+++ b/lib/features/home/presentation/widgets/home_widgets.dart
@@ -171,62 +171,6 @@ class _BCVDollarCard extends StatelessWidget {
   }
 }
 
-/// Shown when the last refresh failed, with the detail reported by the backend
-/// error envelope and a way to retry.
-class _ErrorAdvisorCard extends StatelessWidget {
-  const _ErrorAdvisorCard({required this.message});
-
-  final String message;
-
-  @override
-  Widget build(BuildContext context) => GetBuilder<HomeController>(
-    builder: (controller) => CustomBadged(
-      borderRadius: 12,
-      color: ColorValues.textErrorPrimary(context),
-      hMargin: 3,
-      child: Padding(
-        padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        child: Row(
-          children: [
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    AppMessages.loadingError,
-                    style: TextStyle(
-                      color: ColorValues.textErrorPrimary(context),
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  Text(
-                    message,
-                    maxLines: 3,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      color: ColorValues.textSecondary(context),
-                      fontSize: 12,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            TextButton(
-              onPressed: controller.isLoading
-                  ? null
-                  : controller.refreshHomeData,
-              child: Text(
-                AppMessages.retryAction,
-                style: TextStyle(color: ColorValues.textErrorPrimary(context)),
-              ),
-            ),
-          ],
-        ),
-      ),
-    ),
-  );
-}
-
 class _BCVAdvisorCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) => GetBuilder<HomeController>(

--- a/lib/shared/presentation/widgets/app_state_view.dart
+++ b/lib/shared/presentation/widgets/app_state_view.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+
+import '../../../config/theme/colors/colors_values.dart';
+import '../../../core/constants/constants.dart';
+import '../../../core/i18n/app_messages.dart';
+
+/// Which exceptional state a view represents. Kept apart from the message so
+/// "no data" reads visually different from "something failed", even when the
+/// text is short (a criterion of #11).
+enum AppStateKind { error, empty }
+
+/// A shared, branded state view for the exceptional screens — error and empty —
+/// used by both Home and Converter.
+///
+/// It replaces the minimal advisor cards that used to live inside
+/// `home_widgets.dart`: a flat line of text with no illustration and no clear
+/// recovery. This one is centred, uses the project palette (and, for the empty
+/// state, the app logo), works in light and dark, and — for errors — offers a
+/// retry that re-requests the data.
+///
+/// What the states **say** (which message for which failure) is #18's job; this
+/// is how they **look**. So the caller passes the already-resolved [message];
+/// the error state shows the `loadingError` headline above it.
+class AppStateView extends StatelessWidget {
+  const AppStateView.error({
+    super.key,
+    required String message,
+    this.onRetry,
+    this.isBusy = false,
+  }) : kind = AppStateKind.error,
+       _message = message;
+
+  const AppStateView.empty({super.key, String? message, this.onRetry})
+    : kind = AppStateKind.empty,
+      _message = message,
+      isBusy = false;
+
+  final AppStateKind kind;
+  final String? _message;
+
+  /// Re-requests the data. When null, no retry button is shown.
+  final VoidCallback? onRetry;
+
+  /// While a retry is in flight the button is disabled, so a double tap does not
+  /// fire two refreshes.
+  final bool isBusy;
+
+  bool get _isError => kind == AppStateKind.error;
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = _isError
+        ? ColorValues.textErrorPrimary(context)
+        : ColorValues.textQuaternary(context);
+
+    final title = _isError
+        ? AppMessages.loadingError
+        : AppMessages.emptyStateTitle;
+    final message = _message ?? (_isError ? '' : AppMessages.emptyStateMessage);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 40, horizontal: 24),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _illustration(context, accent),
+          const SizedBox(height: 20),
+          Text(
+            title,
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              color: _isError ? accent : ColorValues.textPrimary(context),
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          if (message.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              maxLines: 3,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                color: ColorValues.textSecondary(context),
+                fontSize: 14,
+              ),
+            ),
+          ],
+          if (onRetry != null) ...[
+            const SizedBox(height: 24),
+            FilledButton.icon(
+              onPressed: isBusy ? null : onRetry,
+              icon: const Icon(Icons.refresh_rounded, size: 18),
+              label: Text(AppMessages.retryAction),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  /// Error → an error icon in a tinted circle (the error palette). Empty → the
+  /// app logo, faded, so the two states never look alike.
+  Widget _illustration(BuildContext context, Color accent) {
+    if (_isError) {
+      return Container(
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: accent.withValues(alpha: 0.12),
+        ),
+        child: Icon(Icons.cloud_off_rounded, color: accent, size: 40),
+      );
+    }
+    return Opacity(
+      opacity: 0.55,
+      child: Image.asset(
+        Constants.appLogoAsset,
+        width: 72,
+        height: 72,
+        // The empty state must not itself fail if the asset is missing.
+        errorBuilder: (_, _, _) =>
+            Icon(Icons.inbox_rounded, color: accent, size: 48),
+      ),
+    );
+  }
+}

--- a/test/shared/presentation/widgets/app_state_view_test.dart
+++ b/test/shared/presentation/widgets/app_state_view_test.dart
@@ -1,0 +1,121 @@
+import 'package:bcv_tracker_app/core/i18n/app_messages.dart';
+import 'package:bcv_tracker_app/core/i18n/app_translations.dart';
+import 'package:bcv_tracker_app/shared/presentation/widgets/app_state_view.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+
+/// Wraps [child] in the minimum GetX + Material frame the view needs: the
+/// translations (so `AppMessages` resolves instead of showing raw keys) and a
+/// `Theme` (so `ColorValues` can read the active brightness).
+Future<void> _pump(
+  WidgetTester tester,
+  Widget child, {
+  Brightness brightness = Brightness.light,
+}) async {
+  Get.testMode = true;
+  await tester.pumpWidget(
+    GetMaterialApp(
+      translations: AppTranslations(),
+      locale: const Locale('es', 'ES'),
+      fallbackLocale: const Locale('en', 'US'),
+      theme: ThemeData(brightness: brightness),
+      home: Scaffold(body: Center(child: child)),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  tearDown(() => Get.reset());
+
+  testWidgets('error state shows the loadingError headline and the message', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      const AppStateView.error(message: 'Sin conexión a internet'),
+    );
+
+    expect(find.text(AppMessages.loadingError), findsOneWidget);
+    expect(find.text('Sin conexión a internet'), findsOneWidget);
+    // The error illustration, not the empty one.
+    expect(find.byIcon(Icons.cloud_off_rounded), findsOneWidget);
+  });
+
+  testWidgets('error state renders a retry button that calls onRetry', (
+    tester,
+  ) async {
+    var retries = 0;
+    await _pump(
+      tester,
+      AppStateView.error(message: 'Falló', onRetry: () => retries++),
+    );
+
+    // `FilledButton.icon` builds a private subclass, so the label is the stable
+    // handle on the retry action.
+    final retry = find.text(AppMessages.retryAction);
+    expect(retry, findsOneWidget);
+
+    await tester.tap(retry);
+    await tester.pump();
+    expect(retries, 1);
+  });
+
+  testWidgets('error state disables the retry button while busy', (
+    tester,
+  ) async {
+    var retries = 0;
+    await _pump(
+      tester,
+      AppStateView.error(
+        message: 'Falló',
+        onRetry: () => retries++,
+        isBusy: true,
+      ),
+    );
+
+    await tester.tap(find.text(AppMessages.retryAction));
+    await tester.pump();
+    // A disabled button swallows the tap, so a second refresh never fires.
+    expect(retries, 0);
+  });
+
+  testWidgets('error state without onRetry shows no retry button', (
+    tester,
+  ) async {
+    await _pump(tester, const AppStateView.error(message: 'Falló'));
+
+    expect(find.text(AppMessages.retryAction), findsNothing);
+  });
+
+  testWidgets('empty state shows its own title and message', (tester) async {
+    await _pump(tester, const AppStateView.empty());
+
+    expect(find.text(AppMessages.emptyStateTitle), findsOneWidget);
+    expect(find.text(AppMessages.emptyStateMessage), findsOneWidget);
+    // The empty state must not reuse the error headline.
+    expect(find.text(AppMessages.loadingError), findsNothing);
+    expect(find.byIcon(Icons.cloud_off_rounded), findsNothing);
+  });
+
+  testWidgets('empty state accepts a custom message', (tester) async {
+    await _pump(
+      tester,
+      const AppStateView.empty(message: 'Todavía no sigues ningún mercado'),
+    );
+
+    expect(find.text('Todavía no sigues ningún mercado'), findsOneWidget);
+    expect(find.text(AppMessages.emptyStateMessage), findsNothing);
+  });
+
+  testWidgets('renders in dark mode without throwing', (tester) async {
+    await _pump(
+      tester,
+      const AppStateView.error(message: 'Falló'),
+      brightness: Brightness.dark,
+    );
+
+    expect(find.text(AppMessages.loadingError), findsOneWidget);
+  });
+}


### PR DESCRIPTION
# Descripción

Unifica los estados excepcionales de la app —error y vacío— en un único widget con branding, `AppStateView`, y lo integra en Home y Converter.

Antes, el error se mostraba con `_ErrorAdvisorCard`: una línea de texto dentro de una tarjeta, sin ilustración y sin una acción de recuperación clara; y no existía un estado de "sin datos" real. Ahora ambas pantallas comparten un mismo componente centrado, con la paleta del proyecto:

1. **Estado de error**: icono `cloud_off` en un círculo teñido con el color de error, el titular `loadingError`, el mensaje ya resuelto (el mapeo de #18) y un botón de reintento que vuelve a solicitar los datos (deshabilitado mientras hay una recarga en curso, para que un doble toque no dispare dos refrescos).
2. **Estado vacío**: el logo de la app atenuado, con su propio título y copy, para que "no hay datos" nunca se lea igual que "algo falló".

Cambios concretos:

- Nuevo `lib/shared/presentation/widgets/app_state_view.dart` con los constructores `AppStateView.error(...)` y `AppStateView.empty(...)`.
- Integración en ambas pestañas de Home (`home_body.dart`) y en el cuerpo del Converter (`converter_body.dart`); se elimina `_ErrorAdvisorCard` y el flag muerto `showCurrencies`.
- `ConverterController` expone `errorMessage` y lo puentea a la vista con `ever(...) => update()`, igual que Home.
- Nueva constante `Constants.appLogoAsset` y las dos claves i18n del estado vacío (`emptyStateTitle`, `emptyStateMessage`) en los **10 idiomas** (60 claves, paridad mantenida).
- Tests de widget para cada rama de `AppStateView` (error con/sin reintento, botón deshabilitado, estado vacío con y sin mensaje, y render en modo oscuro).

Issue de GitHub relacionado: Closes #11

Rama: `refactor/DTA-023`

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad (cambio no-breaking que agrega funcionalidad)
- [ ] 🛠️ Corrección de errores (cambio no-breaking que arregla un error)
- [ ] ❌ Cambio importante (arreglo o característica que haría que la funcionalidad existente no funcionara como se esperaba)
- [ ] 📝 Actualización de la documentación
- [x] 🧹 Code refactoring (modificación de la estructura interna del código sin modificar las APIs)
- [ ] ✅ Build configuration change (modificación de los archivos para hacer deploy)
- [ ] 🗑️ Chore (actividades que no modifican la interacción con la app, por ejemplo, modificar el archivo de lints)

## ¿Cómo se ha probado esto?

- [x] `flutter analyze` sin advertencias nuevas.
- [x] `flutter test` en verde (158 tests, incluidos los 7 nuevos de `AppStateView`).
- [x] Estado de error en Home (ambas pestañas) y Converter: se muestra el mensaje mapeado + reintento; el reintento vuelve a pedir datos y se deshabilita mientras carga.
- [x] Estado vacío en Home cuando la lista llega vacía tras una carga exitosa.
- [x] Verificado en tema claro y oscuro; paridad i18n comprobada con el script de la convención (60 claves).

**Configuración de prueba**:

- Plataforma y versión de SO (Android / iOS): entorno de tests de Flutter (VM).
- Dispositivo o emulador: tests de widget (`flutter test`).
- Tema (claro/oscuro) e idioma probados: claro y oscuro; español (fallback inglés).

## Lista de Verificación

- [x] He agregado las nuevas dependencias (`pubspec.yaml`) en la descripción — no hay nuevas dependencias.
- [x] He agregado las nuevas variables de entorno (solo los nombres) a la descripción — no hay nuevas variables.
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código, particularmente en áreas difíciles de entender
- [x] He realizado los cambios correspondientes a la documentación — no requiere cambios en `CLAUDE.md`/`README.md`.
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente con mis cambios
- [ ] La app compila y el flujo afectado se probó en un dispositivo o emulador real
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas (ver `i18n-convention.md`)
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper de cálculo, incluí sus tests en este mismo PR (ver `test-coverage.md`)
- [x] No introduje modelos (`shared/data/model/`) en la UI ni en los controladores (ver `entities-vs-models.md`)
