### PR TITLE
[🛠️ Fix: DTA-025] - Consumir saved-currencies vía POST con Body

### DIFF
--- a/lib/core/constants/market_constants.dart
+++ b/lib/core/constants/market_constants.dart
@@ -17,9 +17,10 @@ class Markets {
 
   /// Markets rendered in the average tab, in display order.
   ///
-  /// `saved-currencies` answers with every market it knows once `fill_missing`
-  /// is on (nine of them today), so this list is what decides which ones reach
-  /// the UI — and in which order, since the backend orders by database id.
+  /// These are exactly the markets requested in the `saved-currencies` POST Body
+  /// (`DollarEndpoints.currentDollarBody`); a market absent from that Body is
+  /// `off` on the backend and never arrives. The order here is the display
+  /// order, since the backend orders its rows by database id.
   static const List<String> averageTab = <String>[
     bcv,
     exchangeMonitor,

--- a/lib/shared/data/datasource/dollar_api/dollar_api_rest.dart
+++ b/lib/shared/data/datasource/dollar_api/dollar_api_rest.dart
@@ -7,6 +7,7 @@ import 'package:dio/dio.dart';
 import '../../../../core/logging/app_logger.dart';
 import '../../../../core/network/api_exception.dart';
 import '../../../../core/network/http_manager.dart';
+import '../../../../core/network/http_operation.dart';
 import '../../model/model.dart';
 
 class DollarApiRest implements IDollarApi {
@@ -46,7 +47,13 @@ class DollarApiRest implements IDollarApi {
 
   @override
   Future<List<CurrencyModel>> getCurrentDollar() async {
-    final data = await _getData(DollarEndpoints.currentDollar);
+    // saved-currencies is a POST carrying the per-market Body (see
+    // DollarEndpoints.currentDollarBody); the response envelope is unchanged.
+    final data = await _getData(
+      DollarEndpoints.currentDollar,
+      method: HttpOperation.post,
+      body: DollarEndpoints.currentDollarBody,
+    );
 
     if (data is! List) {
       throw const ApiException.malformed(
@@ -75,10 +82,21 @@ class DollarApiRest implements IDollarApi {
   /// Performs the request and returns the `data` field of the backend envelope
   /// (`{status, message, data}`), translating every failure into an
   /// [ApiException] that carries the backend message.
-  Future<Object?> _getData(String endpoint) async {
+  ///
+  /// [method] and [body] let a caller POST a structured Body (as
+  /// `saved-currencies` needs); they default to a plain GET.
+  Future<Object?> _getData(
+    String endpoint, {
+    HttpOperation method = HttpOperation.get,
+    Map<String, dynamic>? body,
+  }) async {
     final Response<dynamic> response;
     try {
-      response = await _client.request(endpoint: _apiUrl + endpoint);
+      response = await _client.request(
+        endpoint: _apiUrl + endpoint,
+        method: method,
+        body: body,
+      );
     } on DioException catch (e, s) {
       // HttpManager accepts every status code, so Dio only throws when there is
       // no response at all (connectivity, DNS, timeout, TLS).
@@ -103,16 +121,16 @@ class DollarApiRest implements IDollarApi {
       throw ApiException.network(e.message ?? e.type.name);
     }
 
-    final body = response.data;
+    final rawBody = response.data;
 
     if (response.statusCode != 200 && response.statusCode != 201) {
       throw ApiException.fromResponse(
         statusCode: response.statusCode,
-        body: body,
+        body: rawBody,
       );
     }
 
-    if (body is! String || body.isEmpty) {
+    if (rawBody is! String || rawBody.isEmpty) {
       throw const ApiException.malformed(
         'El backend respondió con un cuerpo vacío.',
       );
@@ -120,7 +138,7 @@ class DollarApiRest implements IDollarApi {
 
     final Object? envelope;
     try {
-      envelope = json.decode(body);
+      envelope = json.decode(rawBody);
     } catch (e, s) {
       AppLogger.warning(
         'Backend responded with a non-JSON body',

--- a/lib/shared/data/datasource/dollar_api/dollar_endpoints.dart
+++ b/lib/shared/data/datasource/dollar_api/dollar_endpoints.dart
@@ -12,48 +12,43 @@ class DollarEndpoints {
 
   static const String _apiEndpoints = '/api/$_apiVersion/$_country';
 
-  /// Sources and filters for `saved-currencies`.
-  ///
-  /// `fill_missing` fetches live every market left at `false`, and there is no
-  /// way to leave a market out: one at `true` is read from the database and one
-  /// at `false` is scraped live, but both come back. So this map does not pick
-  /// *which* markets arrive — [Markets.averageTab] does that on the client —
-  /// it picks **where each one comes from**:
-  ///
-  /// - live (`false`) only the three the app shows as fresh rates. Each live
-  ///   source adds latency and is a failure point: the backend gathers them
-  ///   without `return_exceptions`, so one source answering 502 fails the whole
-  ///   request.
-  /// - from the database (`true`) the rest, which is cheap, plus BCV and
-  ///   Exchange Monitor, refreshed by the backend cron six times a day.
-  ///
-  /// Once the per-market Body (#71) is deployed this whole dance is replaced by
-  /// `off` for the markets we do not want and `average` for the crypto ones.
-  static const Map<String, String> _currentDollarParams = {
-    // Live.
-    'yadio': 'false',
-    'binance': 'false',
-    'bybit': 'false',
-    // From the database.
-    'bcv': 'true',
-    'exchange_monitor': 'true',
-    'okx': 'true',
-    'bitget': 'true',
-    'airtm': 'true',
-    'dolarapi': 'true',
-    'fill_missing': 'true',
-    // Only the official dollar out of the BCV, only the dollar out of Yadio
-    // (it also publishes euro and bitcoin) and only the estimated average of
-    // Exchange Monitor ("Monitor Dólar").
-    'enforce_bcv_dollar': 'true',
-    'enforce_yadio_dollar': 'true',
-    'enforce_em_average': 'true',
-  };
+  /// `saved-currencies` is a **POST** since the backend replaced its query-param
+  /// flags (`fill_missing`, `enforce_*`, one boolean per market) with a
+  /// structured Body — a state machine per market (`MarketSelection`, backend
+  /// issue #71). GET-with-body is not reliable across clients, hence POST.
+  static const String currentDollar = '$_apiEndpoints/saved-currencies';
 
-  static final String currentDollar = Uri(
-    path: '$_apiEndpoints/saved-currencies',
-    queryParameters: _currentDollarParams,
-  ).toString();
+  /// Body sent to `saved-currencies`: the state (`mode`) requested per market.
+  ///
+  /// A market **absent** from the map is treated as `off` by the backend, so
+  /// this map alone decides which markets arrive — it lists exactly the ones the
+  /// average tab shows ([Markets.averageTab]); `okx`, `bitget`, `airtm` and
+  /// `dolarapi` are left out on purpose.
+  ///
+  /// The modes reproduce what the old flags produced:
+  /// - `bcv: bd-solo-dolar` — from the database (cheap, cron-refreshed), only
+  ///   the official dollar (was `bcv=true` + `enforce_bcv_dollar`).
+  /// - `yadio: solo-dolar` — live, only the dollar; Yadio also quotes euro and
+  ///   bitcoin (was `yadio=false` + `enforce_yadio_dollar`).
+  /// - `binance`/`bybit: average` — the crypto average per asset, `(buy+sell)/2`
+  ///   computed by the backend (was live, both sides merged on the client).
+  /// - `exchange_monitor: own+monitor` — its own value plus the estimated
+  ///   average ("Monitor Dólar"). The old `enforce_em_average` returned only the
+  ///   average; the new contract has no "average-only" mode, so this is the
+  ///   closest (backend issue #89 flags it for review).
+  ///
+  /// Every live source is a failure point — the backend gathers them without
+  /// `return_exceptions`, so one answering 502 fails the whole request — which
+  /// is why only the markets shown are requested and BCV stays on the database.
+  static const Map<String, dynamic> currentDollarBody = {
+    'markets': {
+      'bcv': 'bd-solo-dolar',
+      'yadio': 'solo-dolar',
+      'binance': 'average',
+      'bybit': 'average',
+      'exchange_monitor': 'own+monitor',
+    },
+  };
 
   static const String currentBCVDollar = '$_apiEndpoints/bcv/with-memory';
 }

--- a/test/shared/data/dollar_api_rest_test.dart
+++ b/test/shared/data/dollar_api_rest_test.dart
@@ -7,13 +7,18 @@ import 'package:bcv_tracker_app/shared/data/datasource/dollar_api/dollar_api_res
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-/// Returns a canned response (or failure) instead of hitting the network.
+/// Returns a canned response (or failure) instead of hitting the network, and
+/// records the outgoing request so a test can assert the method, path and body.
 class _FakeHttpManager extends HttpManager {
   _FakeHttpManager({this.statusCode = 200, this.responseBody, this.failure});
 
   final int statusCode;
   final Object? responseBody;
   final DioException? failure;
+
+  HttpOperation? sentMethod;
+  String? sentEndpoint;
+  Map<String, dynamic>? sentBody;
 
   @override
   Future<Response<dynamic>> request({
@@ -23,6 +28,9 @@ class _FakeHttpManager extends HttpManager {
     Map<String, dynamic>? customHeader,
     String? clientCode,
   }) async {
+    sentMethod = method;
+    sentEndpoint = endpoint;
+    sentBody = body;
     if (failure != null) throw failure!;
     return Response(
       requestOptions: RequestOptions(path: endpoint),
@@ -47,6 +55,38 @@ DollarApiRest _api({
 
 void main() {
   group('getCurrentDollar()', () {
+    test('POSTs the per-market Body to saved-currencies', () async {
+      // The backend replaced the GET query-param flags with a POST Body
+      // (MarketSelection, backend #71); the app must send exactly that.
+      final fake = _FakeHttpManager(
+        responseBody: '{"status":"Success","message":"ok","data":[]}',
+      );
+      await DollarApiRest(
+        apiUrl: 'https://backend.test',
+        client: fake,
+      ).getCurrentDollar();
+
+      expect(fake.sentMethod, HttpOperation.post);
+      expect(
+        fake.sentEndpoint,
+        'https://backend.test/api/v1/venezuela/saved-currencies',
+      );
+      // No leftover query params on the path.
+      expect(fake.sentEndpoint, isNot(contains('?')));
+      expect(fake.sentEndpoint, isNot(contains('fill_missing')));
+      // The Body is the MarketSelection: only the average-tab markets, each
+      // with the mode that reproduces the old flags.
+      expect(fake.sentBody, {
+        'markets': {
+          'bcv': 'bd-solo-dolar',
+          'yadio': 'solo-dolar',
+          'binance': 'average',
+          'bybit': 'average',
+          'exchange_monitor': 'own+monitor',
+        },
+      });
+    });
+
     test('maps the data list of the envelope', () async {
       final result = await _api(
         body:


### PR DESCRIPTION
# Descripción

El backend migró `saved-currencies` a **`POST /api/v1/venezuela/saved-currencies`** con un **Body estructurado** (`MarketSelection`, issue #71 del backend), reemplazando los query params `fill_missing` / `enforce_*` / por-mercado. La app seguía llamándolo con **GET + query params**, así que el endpoint dejó de devolver las tasas y el **tab promedio** quedaba sin datos.

Este PR cambia el consumo a POST con Body. La respuesta del backend no cambió (mismo envelope `{status, message, data:[CurrencySchema]}`), así que el parseo (`CurrencyModel.fromJson`) queda intacto.

Cambios:

1. `dollar_endpoints.dart`: `currentDollar` es ahora el path plano (sin query); nueva constante `currentDollarBody` con el `MarketSelection`.
2. `dollar_api_rest.dart`: `getCurrentDollar()` hace **POST** con ese Body; `_getData` acepta `method`/`body` (por defecto GET), sin tocar el manejo del envelope ni de errores.
3. `market_constants.dart`: comentario de `averageTab` actualizado (ya no hay `fill_missing`).
4. Test del datasource: afirma el **método POST**, el **path** (sin query string) y el **Body** enviado.

**Body enviado** (solo los mercados del tab promedio; los ausentes = `off`):

```json
{ "markets": {
  "bcv": "bd-solo-dolar",
  "yadio": "solo-dolar",
  "binance": "average",
  "bybit": "average",
  "exchange_monitor": "own+monitor"
} }
```

Mapeo desde los flags viejos: `bcv=true + enforce_bcv_dollar` → `bd-solo-dolar`; `yadio=false + enforce_yadio_dollar` → `solo-dolar`; `binance/bybit=false` (cripto en vivo) → `average`; `okx/bitget/airtm/dolarapi` (no se muestran) → `off`.

> ⚠️ **Decisión a confirmar — Exchange Monitor.** Antes se pedía desde BD con `enforce_em_average` (solo el "Monitor Dólar"). El contrato nuevo **no** tiene un modo "solo average"; se implementó con **`own+monitor`**, el más cercano, que devuelve el valor propio de EM **y** el Monitor Dólar — es decir, una **tarjeta EM extra** y **una llamada en vivo más** (antes EM venía de BD). Alternativa si lo prefieres: **`bd-todas`** (desde BD, sin llamada en vivo, pero trae todas las divisas de EM). Dímelo y lo ajusto.

Issue de GitHub relacionado: Closes #89

Rama: `fix/DTA-025`

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad (cambio no-breaking que agrega funcionalidad)
- [x] 🛠️ Corrección de errores (cambio no-breaking que arregla un error)
- [ ] ❌ Cambio importante (arreglo o característica que haría que la funcionalidad existente no funcionara como se esperaba)
- [ ] 📝 Actualización de la documentación
- [ ] 🧹 Code refactoring (modificación de la estructura interna del código sin modificar las APIs)
- [ ] ✅ Build configuration change (modificación de los archivos para hacer deploy)
- [ ] 🗑️ Chore (actividades que no modifican la interacción con la app, por ejemplo, modificar el archivo de lints)

## ¿Cómo se ha probado esto?

- [x] `flutter analyze` sin advertencias nuevas.
- [x] `flutter test` en verde (169 tests; nuevo test afirma POST + path + body).
- [ ] **Pendiente en dispositivo real**: verificar contra el backend que el tab promedio carga las tasas con el nuevo POST (no se puede simular el backend real desde la suite).

**Configuración de prueba**:

- Plataforma y versión de SO (Android / iOS)
- Dispositivo o emulador
- Tema (claro/oscuro) e idioma probados

## Lista de Verificación

- [x] He agregado las nuevas dependencias (`pubspec.yaml`) en la descripción — no hay.
- [x] He agregado las nuevas variables de entorno (solo los nombres) — no hay.
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código, particularmente en áreas difíciles de entender
- [x] He realizado los cambios correspondientes a la documentación (dartdoc + comentario de `market_constants`)
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente con mis cambios
- [ ] La app compila y el flujo afectado se probó en un dispositivo o emulador real — **pendiente** (requiere el backend real)
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas — no se agregó copy.
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper de cálculo, incluí sus tests (ver `test-coverage.md`)
- [x] No introduje modelos (`shared/data/model/`) en la UI ni en los controladores.
