### PR TITLE
[🗑️ Chore: DTA-026] - Preparar release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+Todos los cambios notables de este proyecto se documentan en este archivo.
+
+El formato está basado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/),
+y el proyecto sigue [Semantic Versioning](https://semver.org/lang/es/).
+
+## [1.0.1] - 2026-08-07
+
+Primera versión de producción funcional tras `v1.0.0` (que solo contenía el
+andamiaje inicial). Restaura la carga de tasas, endurece la app y añade la red
+de pruebas y CI.
+
+### Added
+- Mensajes de error diferenciados por tipo de fallo (sin conexión, timeout,
+  servidor, respuesta inesperada…), traducidos en los 10 idiomas.
+- Estados de error y vacío con branding (icono/logo, paleta del proyecto y
+  botón de reintento) compartidos por Home y Converter.
+- Migración a Material 3 (`ColorScheme` por tema, componentes on-brand)
+  preservando el aspecto de la app.
+- `DESIGN.md` como fuente del sistema de diseño, con tokens y reglas de agentes
+  en `.agents/`.
+- Logging estructurado con redacción de URLs (sin filtrar tokens).
+- Validación de PR en CI (GitHub Actions: `flutter analyze` + `flutter test`) y
+  golden tests de las pantallas en tema claro y oscuro.
+- Suite de tests para controladores, repositorios, datasource, helpers, i18n y
+  estados de pantalla.
+- Validación de `CURRENCY_BACK` al arrancar, con error claro si falta o no es
+  una URL válida.
+
+### Changed
+- `saved-currencies` se consume vía **POST con Body por mercado**
+  (`MarketSelection`), tras la migración del backend.
+- Navegación mediante rutas nombradas de GetX; GetX importado por su API
+  pública.
+- Análisis estático estricto y eliminación de dependencias declaradas sin usar.
+
+### Fixed
+- Las tasas del tab promedio vuelven a cargar (el backend pasó `saved-currencies`
+  de GET a POST).
+- El conversor ya no divide por una tasa inutilizable (evita `Infinity`/`NaN`).
+- Un código de idioma desconocido ya no rompe la pantalla de Ajustes.
+- Validación de certificado TLS restaurada: no se aceptan certificados
+  inválidos.
+- Traducciones de nombres de divisa corregidas.
+- Restaurado el alfa del color de *warning*.
+- La lista de divisas del BCV se convierte correctamente en `toEntity()`.
+- Un `.env` ilegible se reporta en vez de tumbar el arranque.
+
+[1.0.1]: https://github.com/Teixeira49/bcv_tracker_app/compare/v1.0.0...v1.0.1

--- a/README.md
+++ b/README.md
@@ -106,5 +106,5 @@ Las convenciones de flujo de trabajo son **idénticas a las del backend** (mismo
 
 ---
 
-**Versión actual del proyecto:** 1.0.0+1
+**Versión actual del proyecto:** 1.0.1+2
 **SDK de Dart compatible:** ^3.9.0

--- a/docs/release/RELEASE_v1.0.1.md
+++ b/docs/release/RELEASE_v1.0.1.md
@@ -1,0 +1,61 @@
+# Release Notes - v1.0.1 🚀
+
+**Fecha de lanzamiento:** 07 de Agosto de 2026
+
+## Visión General
+
+`v1.0.1` es la primera versión de producción realmente funcional de BCV Tracker
+tras la `v1.0.0`, que solo contenía el andamiaje inicial y la licencia. Esta
+promoción trae al fin todo el trabajo acumulado en `development`: **restaura la
+carga de tasas** (el backend migró `saved-currencies` a POST y la app se había
+quedado sin datos en el tab promedio), **hace la app resistente a fallos** con
+mensajes de error claros y estados con branding, y **levanta la red de seguridad**
+del proyecto (tests, golden tests y validación en CI). Para el usuario, la app
+vuelve a mostrar las tasas y deja de romperse cuando algo va mal.
+
+## Registro de Cambios
+
+### UI/UX
+- Estados de **error** y **vacío** rediseñados con el branding (icono/logo,
+  paleta del proyecto y botón de reintento), compartidos por Home y Converter.
+- Migración a **Material 3** preservando el aspecto (ColorScheme por tema,
+  componentes on-brand).
+- Mensajes de error **comprensibles y traducidos** según el tipo de fallo.
+
+### Datos / Red
+- `saved-currencies` se consume vía **POST con Body por mercado**
+  (`MarketSelection`), acorde al nuevo contrato del backend.
+- El conversor ya no divide por una tasa inutilizable (`Infinity`/`NaN`).
+- Validación de **certificado TLS** restaurada; `CURRENCY_BACK` validada al
+  arrancar; logging estructurado con redacción de URLs.
+
+### Ingeniería / Estructura
+- Rutas nombradas de GetX; GetX importado por su API pública; dependencias
+  muertas eliminadas; análisis estático estricto.
+- `DESIGN.md` como fuente del sistema de diseño y convenciones de agentes en
+  `.agents/`.
+
+### Calidad
+- **CI de validación de PR** (GitHub Actions: analyze + test) en cada PR.
+- Suite de tests (controladores, repositorios, datasource, helpers, i18n) y
+  **golden tests** de las pantallas en tema claro y oscuro.
+
+### i18n
+- Corregidas traducciones de nombres de divisa; paridad de claves verificada por
+  test en los 10 idiomas.
+
+## Compatibilidad
+
+- **Requiere** un backend que sirva `saved-currencies` como **POST** con el Body
+  `MarketSelection` (contrato v1 actual de `bcv_tracker_backend`). Una instalación
+  apuntando a un backend anterior (GET) no cargará el tab promedio.
+- Sin cambios en `minSdkVersion` ni en el deployment target de iOS.
+- Sin migraciones de datos locales (`SharedPreferences`).
+
+## Próximos Pasos
+
+- Selección dinámica de mercados seguidos desde Ajustes (línea del Body por
+  mercado, #71 del backend).
+- Mostrar la versión de la app en Ajustes (`package_info_plus`).
+
+*BCV Tracker - Monitorizando la economía con precisión y elegancia.*

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+1
+version: 1.0.1+2
 
 environment:
   sdk: ^3.9.0

--- a/release_notes.json
+++ b/release_notes.json
@@ -1,0 +1,10 @@
+[
+  {
+    "language": "en-US",
+    "text": "The average-market rates load again, and the app now shows a clear message with a retry button when something fails or you're offline, instead of a blank screen.\n\n• Redesigned error and empty states\n• The converter no longer shows wrong results\n• Stability, security and translation fixes"
+  },
+  {
+    "language": "es-ES",
+    "text": "Vuelven a cargar las tasas del mercado promedio, y ahora la app te muestra un mensaje claro con un botón para reintentar cuando algo falla o no hay conexión, en vez de quedarse en blanco.\n\n• Estados de error y vacío rediseñados\n• El conversor ya no muestra resultados erróneos\n• Correcciones de estabilidad, seguridad y traducciones"
+  }
+]


### PR DESCRIPTION
Preparación del release **v1.0.1** (bump + papeleo), previa a la promoción `development → master`.

- `pubspec.yaml` 1.0.0+1 → **1.0.1+2** y la línea de versión del `README` en sincronía (únicas dos fuentes que se editan; Android/iOS/codemagic derivan).
- `CHANGELOG.md` inicializado con la entrada `[1.0.1]` (Keep a Changelog).
- `docs/release/RELEASE_v1.0.1.md` con la nota de release completa.
- `release_notes.json` (en-US, es-ES) para distribución Firebase/tiendas.

No toca `android/`, `ios/` ni `codemagic.yaml`. Este PR entra a `development`; luego abro la promoción `development → master` que lo incluye.