### PR TITLE
[💚 CI: DTA-027] - Notificaciones de build a javiertxr@gmail.com

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -67,7 +67,7 @@ workflows:
     publishing:
       email:
         recipients:
-          - jtexeira@estei.app
+          - javiertxr@gmail.com
         notify:
           success: true
           failure: true
@@ -157,7 +157,7 @@ workflows:
     publishing:
       email:
         recipients:
-          - jtexeira@estei.app
+          - javiertxr@gmail.com
         notify:
           success: true
           failure: true
@@ -258,7 +258,7 @@ workflows:
     publishing:
       email:
         recipients:
-          - jtexeira@estei.app
+          - javiertxr@gmail.com
         notify:
           success: true
           failure: true


### PR DESCRIPTION
Cambia el destinatario de las notificaciones de build de Codemagic.

- `publishing: email: recipients:` de los 3 workflows (android/ios/all-platforms): `jtexeira@estei.app` → **`javiertxr@gmail.com`**.
- Sin otros cambios (los grupos de testers de Firebase y la mecánica de notas no se tocan; eso es #93).

Verificado: 0 referencias a `jtexeira@estei.app`, 3 a `javiertxr@gmail.com`.

Closes #94