### PR TITLE
[✅ Build: DTA-034] - Notas reales del tester desde release_notes.json

### DIFF
--- a/.agents/rules/release-notes.md
+++ b/.agents/rules/release-notes.md
@@ -3,6 +3,8 @@ description: Formato y contenido de las notas de versión que consume Codemagic 
 paths:
   - "release_notes.json"
   - "release_notes*.txt"
+  - "tool/release_notes_txt.dart"
+  - "test/tool/release_notes_txt_test.dart"
   - "CHANGELOG.md"
   - "docs/release/**"
   # Los cuatro de arriba aún no existen en el repo, así que por sí solos dejaban
@@ -34,7 +36,7 @@ PR mergeado
 
 ## El archivo que lee Codemagic
 
-Codemagic recoge automáticamente un archivo llamado **`release_notes.json`** (o `release_notes.txt`) situado en el **directorio de trabajo del proyecto**, que aquí es la raíz del repositorio. No hay que declararlo en `codemagic.yaml`.
+Codemagic reconoce un archivo llamado **`release_notes.json`** (o `release_notes.txt`) situado en el **directorio de trabajo del proyecto**, que aquí es la raíz del repositorio. Para el correo de build y Slack basta con que esté ahí; para que llegue a Firebase App Distribution hace falta el paso que describe [Cómo llega el archivo al tester](#cómo-llega-el-archivo-al-tester).
 
 ```json
 [
@@ -63,23 +65,43 @@ Para el envío a revisión de App Store, cada entrada admite además `descriptio
 
    Escribe **primero la versión de 500** y expándela si hace falta. Comprimir 4.000 a 500 produce un texto amputado; ampliar 500 bien escritos es trivial.
 
-## ⚠️ Hoy la app no recoge este archivo
+## Cómo llega el archivo al tester
 
-Codemagic solo publica `release_notes.json` automáticamente cuando la distribución va por su bloque **`publishing:`**. Los tres workflows de `codemagic.yaml` invocan el CLI de Firebase a mano en un paso de script:
+Codemagic solo publica `release_notes.json` **por su cuenta** cuando la distribución va por su bloque `publishing:`. Los tres workflows de `codemagic.yaml` invocan el CLI de Firebase a mano, y el CLI toma **texto plano**, no el JSON multi-idioma. Durante un tiempo eso significó que las notas eran literalmente `Build #12 – rama master` —una línea que repite lo que la consola de Firebase ya muestra encima— y que este archivo se ignoraba. **Ya no** (#93):
 
 ```yaml
-firebase appdistribution:distribute \
-  --release-notes "Build #${CM_BUILD_NUMBER:-1} – rama ${CM_BRANCH:-master}"
+# 1) Antes de compilar: deriva el .txt del .json, y falla si el .json está mal
+- name: Derivar notas del tester
+  script: dart run tool/release_notes_txt.dart
+
+# 2) Al distribuir: el CLI lee el .txt derivado
+- name: Distribuir a Firebase App Distribution
+  script: |
+    firebase appdistribution:distribute \
+      ... \
+      --release-notes-file release_notes.txt
 ```
 
-Esa cadena no dice nada al tester: repite el número de build que ya se ve en la consola. Mientras siga así, `release_notes.json` **se ignora**. Hay dos salidas, y conviene decidirla antes de la primera versión que se quiera anunciar de verdad:
+Lo que hay que saber para escribir las notas:
 
-- **Pasar el archivo a mano** — cambio mínimo, funciona con el script actual:
-  ```yaml
-  --release-notes-file release_notes.txt
-  ```
-  (el CLI de Firebase toma texto plano, no el JSON multi-idioma)
-- **Migrar al bloque `publishing: firebase:`** de Codemagic — entonces las notas, el correo y Slack salen del `release_notes.json` sin tocar nada más.
+- **`release_notes.json` sigue siendo la única fuente.** El `.txt` es un artefacto de build, está gitignored y no se edita nunca. Dos archivos con la misma prosa se desincronizan, y el que nadie lee lo hace primero.
+- **El tester lee `es-ES`.** [`tool/release_notes_txt.dart`](../../tool/release_notes_txt.dart) recorre `kPreferredLanguages` —hoy `es-ES`, luego `en-US`— y cae al **primer idioma del archivo** si no encuentra ninguno, que es la misma regla que aplica Codemagic. Esa coincidencia es deliberada: si algún día se migra al bloque `publishing:`, lo que se publica no cambia sin que nadie se entere.
+- **`en-US` sigue siendo obligatoria** aunque no sea la que ve el tester, y el script **falla el build** si falta. Es la entrada que Codemagic manda al correo y a Slack.
+- **No hay fallback a una cadena genérica.** Un JSON ausente, roto o con una entrada vacía tumba el build en el paso 1, en segundos y antes de compilar. Es a propósito: degradar en silencio a "Build #N" es exactamente cómo las notas dejaron de llegar la primera vez.
+- Lo cubre `test/tool/release_notes_txt_test.dart`, que además valida el `release_notes.json` real del repo contra el límite de 500 caracteres y la prohibición de `<`/`>`. Un release que deje el archivo mal rompe la suite antes de llegar a CI.
+
+### Por qué este camino y no `publishing: firebase:`
+
+Migrar al bloque `publishing: firebase:` de Codemagic también resuelve el problema, lee el JSON nativamente y borra los tres scripts del CLI. Se descartó por ahora, no por gusto:
+
+| | `--release-notes-file` (elegido) | `publishing: firebase:` |
+|---|---|---|
+| Credenciales | Ninguna nueva; sigue la autenticación actual | Pide `firebase_service_account` (el **contenido** del JSON de service account) o el `firebase_token` que Firebase marcó como deprecado. `GOOGLE_APPLICATION_CREDENTIALS` es una **ruta** y ese bloque no la acepta |
+| Idioma que ve el tester | El que se elija; hoy `es-ES` | Fijo: `en-US` |
+| Verificable antes de mergear | Sí, la derivación corre en local y tiene tests | No, hace falta lanzar un build real |
+| Si sale mal | El paso falla en segundos | Los workflows solo se disparan en push a `master`: se descubre en el peor momento |
+
+Sigue siendo el destino razonable a largo plazo. El día que el service account esté confirmado en la consola de Codemagic, la migración es cambiar los scripts por el bloque — y `kPreferredLanguages` documenta qué se pierde al hacerlo.
 
 ## Qué idiomas escribir
 
@@ -110,7 +132,8 @@ Tres criterios:
 - [ ] Sin `<`, `>`, markdown ni enlaces.
 - [ ] El contenido es coherente con `CHANGELOG.md` y con `docs/release/RELEASE_v<X.Y.Z>.md`, y ninguno contradice lo que el PR realmente cambió.
 - [ ] Los códigos de locale llevan guion y existen (`es-ES`, `ja-JP`).
-- [ ] Si la distribución sigue yendo por script, las notas se pasan con `--release-notes-file`; si no, no llegan.
+- [ ] `flutter test test/tool/` pasa: valida el JSON real contra los límites de arriba, así que si esta lista está bien la suite lo confirma sola.
+- [ ] Nadie ha commiteado un `release_notes.txt`: se deriva en cada build y está gitignored.
 
 ## Relación con las otras reglas
 

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,8 @@ app.*.map.json
 .mcp.local.json
 # Alchemist writes the actual/diff images here when a golden fails; never commit them.
 test/**/failures/
+
+# Notas del tester: `release_notes.json` es la fuente y sí se versiona; el .txt
+# lo deriva `tool/release_notes_txt.dart` en cada build (#93). Dos archivos con
+# la misma prosa se desincronizan, y el que nadie lee lo hace primero.
+release_notes.txt

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -37,6 +37,13 @@ workflows:
       - name: Instalar dependencias
         script: flutter pub get
 
+      # Antes de compilar, a propósito: si las notas están mal, el build cae en
+      # segundos en vez de a los quince minutos. El script no tiene fallback a
+      # una cadena genérica — un fallback silencioso es exactamente cómo las
+      # notas dejaron de llegar (#93).
+      - name: Derivar notas del tester
+        script: dart run tool/release_notes_txt.dart
+
       - name: Analizar código
         script: flutter analyze
 
@@ -63,7 +70,7 @@ workflows:
             build/app/outputs/flutter-apk/app-release.apk \
             --app "$FIREBASE_APP_ID_ANDROID" \
             --groups "testers-pre-produccion" \
-            --release-notes "Build #${CM_BUILD_NUMBER:-1} – rama ${CM_BRANCH:-master}"
+            --release-notes-file release_notes.txt
 
     artifacts:
       - build/app/outputs/flutter-apk/app-release.apk
@@ -124,6 +131,12 @@ workflows:
       - name: Instalar dependencias Flutter
         script: flutter pub get
 
+      # Mismo paso, mismo motivo y mismo sitio que en `android-firebase`: las
+      # notas se derivan antes de compilar para que un JSON roto no cueste un
+      # build entero (#93).
+      - name: Derivar notas del tester
+        script: dart run tool/release_notes_txt.dart
+
       - name: Instalar pods
         script: |
           cd ios
@@ -158,7 +171,7 @@ workflows:
             $(find build/ios/ipa -name "*.ipa" | head -1) \
             --app "$FIREBASE_APP_ID_IOS" \
             --groups "testers-pre-produccion" \
-            --release-notes "Build #${CM_BUILD_NUMBER:-1} – rama ${CM_BRANCH:-master}"
+            --release-notes-file release_notes.txt
 
     artifacts:
       - build/ios/ipa/*.ipa
@@ -220,6 +233,12 @@ workflows:
       - name: Instalar dependencias Flutter
         script: flutter pub get
 
+      # Un solo paso para las dos distribuciones: Android e iOS leen el mismo
+      # `release_notes.txt`, así que el tester ve exactamente el mismo texto en
+      # las dos plataformas (#93).
+      - name: Derivar notas del tester
+        script: dart run tool/release_notes_txt.dart
+
       - name: Instalar pods
         script: |
           cd ios
@@ -255,7 +274,7 @@ workflows:
             build/app/outputs/flutter-apk/app-release.apk \
             --app "$FIREBASE_APP_ID_ANDROID" \
             --groups "testers-pre-produccion" \
-            --release-notes "Build #${CM_BUILD_NUMBER:-1} – rama ${CM_BRANCH:-master}"
+            --release-notes-file release_notes.txt
 
       - name: Distribuir iOS a Firebase
         script: |
@@ -263,10 +282,14 @@ workflows:
             $(find build/ios/ipa -name "*.ipa" | head -1) \
             --app "$FIREBASE_APP_ID_IOS" \
             --groups "testers-pre-produccion" \
-            --release-notes "Build #${CM_BUILD_NUMBER:-1} – rama ${CM_BRANCH:-master}"
+            --release-notes-file release_notes.txt
 
     artifacts:
       - build/app/outputs/flutter-apk/app-release.apk
+      # El .sha1 lo emite `flutter build apk` junto al binario y `android-firebase`
+      # ya lo adjuntaba; aquí faltaba. Es la huella con la que un tester puede
+      # comprobar que el APK que descargó es el que produjo este build.
+      - build/app/outputs/flutter-apk/app-release.apk.sha1
       - build/ios/ipa/*.ipa
       - /tmp/xcodebuild_logs/*.log
 

--- a/docs/lista_de_tests.md
+++ b/docs/lista_de_tests.md
@@ -2,7 +2,7 @@
 
 Este documento es el **inventario de la suite**: primero lo que ya está cubierto, después lo que queda por hacer (roadmap). Mantenlo al día al agregar tests — la regla [`test-coverage.md`](../.agents/rules/test-coverage.md) exige que toda fuente, endpoint, controlador o helper de cálculo nuevo nazca con sus tests, y el check de PR de #27 (`flutter test` en GitHub Actions) lo hace cumplir en cada PR.
 
-## Cobertura actual (42 archivos, 270 tests)
+## Cobertura actual (44 archivos, 294 tests)
 
 | Área | Archivo | Qué cubre |
 |---|---|---|
@@ -45,6 +45,7 @@ Este documento es el **inventario de la suite**: primero lo que ya está cubiert
 | | `test/core/i18n/search_folds_published_names_test.dart` | **(#104, #41)** La tilde de «Dólar» en `es_ES`, que buscar sin tilde encuentra el nombre publicado, y que la tabla de plegado cubre los diacríticos que la app realmente envía |
 | | `test/config/routes/app_pages_test.dart` | Registro de rutas nombradas |
 | | `test/config/theme/colors_constants_test.dart` | Opacidad de la paleta (alpha de 8 dígitos) |
+| **Tooling / CI** | `test/tool/release_notes_txt_test.dart` | **(#93)** La derivación de `release_notes.json` al `.txt` que lee Firebase: elección de idioma, fallback, y que **nunca** produce notas vacías (JSON roto, entrada sin texto, sin `en-US`). Valida además el `release_notes.json` real contra el límite de 500 caracteres de Google Play y los `<`/`>` que Apple rechaza |
 
 > Todos los tests **mockean la red**: ninguno llama al backend real (fakes de `HttpManager` / `IDollarApi` / `IDollarRepository`). Las imágenes de red en los widget tests se evitan vaciando los placeholders del skeleton.
 

--- a/test/tool/release_notes_txt_test.dart
+++ b/test/tool/release_notes_txt_test.dart
@@ -1,0 +1,197 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../tool/release_notes_txt.dart';
+
+/// The derivation that turns `release_notes.json` into the plain text Firebase
+/// App Distribution shows a tester (#93).
+///
+/// Worth testing even though it is a build script: it produces **the only text
+/// the tester reads**, it runs on a machine nobody is watching, and its failure
+/// mode is silent — notes that are empty, in the wrong language, or the wrong
+/// version's. The real file at the repository root is exercised too, so the
+/// suite fails if a release ever leaves it malformed.
+void main() {
+  String notes(List<Map<String, String>> entries) =>
+      renderReleaseNotes(jsonEncode(entries));
+
+  group('picking the language', () {
+    test('Spanish wins, because that is who tests this app', () {
+      expect(
+        notes(<Map<String, String>>[
+          <String, String>{'language': 'en-US', 'text': 'English notes'},
+          <String, String>{'language': 'es-ES', 'text': 'Notas en español'},
+        ]),
+        'Notas en español\n',
+      );
+    });
+
+    test('order in the file does not decide it — the preference does', () {
+      expect(
+        notes(<Map<String, String>>[
+          <String, String>{'language': 'es-ES', 'text': 'Notas en español'},
+          <String, String>{'language': 'en-US', 'text': 'English notes'},
+        ]),
+        'Notas en español\n',
+      );
+    });
+
+    test('English serves when Spanish is not written', () {
+      expect(
+        notes(<Map<String, String>>[
+          <String, String>{'language': 'en-US', 'text': 'English notes'},
+        ]),
+        'English notes\n',
+      );
+    });
+
+    test('an explicit language overrides the preference', () {
+      expect(
+        renderReleaseNotes(
+          jsonEncode(<Map<String, String>>[
+            <String, String>{'language': 'en-US', 'text': 'English notes'},
+            <String, String>{'language': 'es-ES', 'text': 'Notas en español'},
+          ]),
+          preferredLanguages: const <String>['en-US'],
+        ),
+        'English notes\n',
+      );
+    });
+
+    test('an unknown preference falls back to the first entry in the file', () {
+      // The same rule Codemagic applies, so a later migration to its own
+      // publishing block cannot quietly change what gets published.
+      expect(
+        renderReleaseNotes(
+          jsonEncode(<Map<String, String>>[
+            <String, String>{'language': 'pt-PT', 'text': 'Notas em português'},
+            <String, String>{'language': 'en-US', 'text': 'English notes'},
+          ]),
+          preferredLanguages: const <String>['ja-JP'],
+        ),
+        'Notas em português\n',
+      );
+    });
+  });
+
+  group('what the tester actually sees', () {
+    test('bullets and blank lines survive verbatim', () {
+      // Firebase renders the text as-is. Reflowing it would break the shape the
+      // notes were written in.
+      const String text = 'Line one.\n\n• First bullet\n• Second bullet';
+      expect(
+        notes(<Map<String, String>>[
+          <String, String>{'language': 'en-US', 'text': text},
+        ]),
+        '$text\n',
+      );
+    });
+
+    test(
+      'surrounding blank space is trimmed and one newline is guaranteed',
+      () {
+        expect(
+          notes(<Map<String, String>>[
+            <String, String>{'language': 'en-US', 'text': '\n\n  Notes  \n\n'},
+          ]),
+          'Notes\n',
+        );
+      },
+    );
+  });
+
+  group('it refuses to distribute empty notes', () {
+    // Every one of these used to end as "Build #N – rama master" reaching the
+    // tester. Failing loudly is the point: a silent fallback is how the notes
+    // stopped arriving in the first place.
+    test('invalid JSON', () {
+      expect(
+        () => renderReleaseNotes('{not json'),
+        throwsA(isA<ReleaseNotesException>()),
+      );
+    });
+
+    test('a JSON object instead of an array', () {
+      expect(
+        () => renderReleaseNotes('{"language": "en-US", "text": "x"}'),
+        throwsA(isA<ReleaseNotesException>()),
+      );
+    });
+
+    test('an empty array', () {
+      expect(
+        () => renderReleaseNotes('[]'),
+        throwsA(isA<ReleaseNotesException>()),
+      );
+    });
+
+    test('an entry whose text is blank', () {
+      expect(
+        () => notes(<Map<String, String>>[
+          <String, String>{'language': 'en-US', 'text': '   '},
+        ]),
+        throwsA(isA<ReleaseNotesException>()),
+      );
+    });
+
+    test('an entry with no language code', () {
+      expect(
+        () => renderReleaseNotes('[{"text": "orphan"}]'),
+        throwsA(isA<ReleaseNotesException>()),
+      );
+    });
+
+    test('no en-US entry, even when another language would have served', () {
+      // en-US is what Codemagic publishes to email and Slack, so its absence is
+      // worth stopping for even though this script would have used es-ES.
+      expect(
+        () => notes(<Map<String, String>>[
+          <String, String>{'language': 'es-ES', 'text': 'Notas en español'},
+        ]),
+        throwsA(
+          isA<ReleaseNotesException>().having(
+            (ReleaseNotesException e) => e.message,
+            'message',
+            contains('en-US'),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('the real release_notes.json at the repository root', () {
+    // `flutter test` runs with the package root as the working directory, the
+    // same assumption `translation_parity_test.dart` already makes.
+    late final String source = File('release_notes.json').readAsStringSync();
+
+    test('exists and derives without throwing', () {
+      expect(File('release_notes.json').existsSync(), isTrue);
+      expect(renderReleaseNotes(source).trim(), isNotEmpty);
+    });
+
+    test('the tester gets Spanish', () {
+      expect(renderReleaseNotes(source), contains('tasas'));
+    });
+
+    test('every language fits the 500 characters Google Play allows', () {
+      // The tightest limit of the four channels the same file feeds, and the
+      // one the rule says to write for first.
+      final List<dynamic> entries = jsonDecode(source) as List<dynamic>;
+      for (final dynamic entry in entries) {
+        final Map<String, dynamic> map = entry as Map<String, dynamic>;
+        expect(
+          (map['text'] as String).length,
+          lessThanOrEqualTo(500),
+          reason: '${map['language']} exceeds the Google Play limit',
+        );
+      }
+    });
+
+    test('no angle bracket, which App Store review rejects', () {
+      expect(source, isNot(contains('<')));
+      expect(renderReleaseNotes(source), isNot(contains('>')));
+    });
+  });
+}

--- a/tool/release_notes_txt.dart
+++ b/tool/release_notes_txt.dart
@@ -1,0 +1,194 @@
+/// Derives the plain-text release notes Firebase App Distribution shows to a
+/// tester, from the multi-language `release_notes.json` at the repository root.
+///
+/// **Why this script exists.** Codemagic reads `release_notes.json` on its own
+/// only when distribution goes through its `publishing:` block. The three
+/// workflows call the Firebase CLI by hand, and the CLI's `--release-notes-file`
+/// takes **plain text**, not the multi-language JSON — so without a step in the
+/// middle the file is simply ignored, which is what #93 is about. The notes used
+/// to be `Build #12 – rama master`, a line that repeats what the Firebase
+/// console already shows above it and tells the tester nothing about what to
+/// try.
+///
+/// **Why derive instead of committing a `.txt`.** Two files with the same prose
+/// drift, and the one nobody reads drifts first. `release_notes.json` stays the
+/// single source `.agents/rules/release-notes.md` describes; the `.txt` is a
+/// build artifact and is gitignored.
+///
+/// **Why it runs early in the workflow.** A malformed or missing notes file
+/// fails the build in seconds instead of after a fifteen-minute compile, and
+/// there is no silent fallback to a generic string on purpose: falling back is
+/// how the notes would quietly stop arriving again with nobody noticing.
+///
+/// ```bash
+/// dart run tool/release_notes_txt.dart              # → release_notes.txt
+/// dart run tool/release_notes_txt.dart --language en-US
+/// dart run tool/release_notes_txt.dart --output /tmp/notes.txt
+/// ```
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+/// Where the notes are read from, relative to the working directory.
+const String kDefaultInput = 'release_notes.json';
+
+/// Where the derived plain text is written. The name is the one Codemagic
+/// itself looks for, so the build email picks the notes up too.
+const String kDefaultOutput = 'release_notes.txt';
+
+/// Store locale codes tried in order, first match wins.
+///
+/// **Spanish before English, deliberately.** `.agents/rules/release-notes.md`
+/// makes `en-US` mandatory because that is the entry Codemagic's own
+/// integration publishes, and that constraint still holds — the entry has to
+/// exist. But this script picks the language, and the tester group for this app
+/// reads Spanish. English stays as the fallback the rule guarantees is there.
+const List<String> kPreferredLanguages = <String>['es-ES', 'en-US'];
+
+/// Raised when the notes cannot be derived. The message is what the build log
+/// shows, so it says what to fix rather than what went wrong internally.
+class ReleaseNotesException implements Exception {
+  ReleaseNotesException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+/// The text a tester will read, picked out of [jsonText].
+///
+/// Walks [preferredLanguages] in order and falls back to the **first entry in
+/// the file** when none of them is present — the same rule Codemagic applies,
+/// so switching to its `publishing:` block later cannot change what gets
+/// published without anyone noticing.
+///
+/// Throws a [ReleaseNotesException] when the file is not the shape the rule
+/// documents: a JSON array of objects with `language` and `text`. Distributing
+/// with empty notes is the failure this whole change exists to remove, so it is
+/// never the outcome.
+String renderReleaseNotes(
+  String jsonText, {
+  List<String> preferredLanguages = kPreferredLanguages,
+}) {
+  final Object? decoded;
+  try {
+    decoded = jsonDecode(jsonText);
+  } on FormatException catch (error) {
+    throw ReleaseNotesException(
+      'release_notes.json is not valid JSON: ${error.message}',
+    );
+  }
+
+  if (decoded is! List) {
+    throw ReleaseNotesException(
+      'release_notes.json must be a JSON array of '
+      '{"language": ..., "text": ...} objects.',
+    );
+  }
+  if (decoded.isEmpty) {
+    throw ReleaseNotesException('release_notes.json has no entries.');
+  }
+
+  // Keyed by language so the preference walk is a lookup, but the original
+  // order is kept separately: the fallback is positional, not alphabetical.
+  final Map<String, String> byLanguage = <String, String>{};
+  final List<String> inFileOrder = <String>[];
+
+  for (final Object? entry in decoded) {
+    if (entry is! Map) {
+      throw ReleaseNotesException(
+        'Every entry of release_notes.json must be an object; found '
+        '${entry.runtimeType}.',
+      );
+    }
+    final Object? language = entry['language'];
+    final Object? text = entry['text'];
+    if (language is! String || language.trim().isEmpty) {
+      throw ReleaseNotesException(
+        'An entry of release_notes.json has no "language" code.',
+      );
+    }
+    if (text is! String || text.trim().isEmpty) {
+      throw ReleaseNotesException(
+        'The "$language" entry of release_notes.json has no "text".',
+      );
+    }
+    byLanguage[language] = text;
+    inFileOrder.add(language);
+  }
+
+  // `en-US` is mandatory per the rule, and its absence is worth stopping for
+  // even when another language would have served here: the build email, Slack
+  // and any future migration to Codemagic's own block all read that entry.
+  if (!byLanguage.containsKey('en-US')) {
+    throw ReleaseNotesException(
+      'release_notes.json must carry an "en-US" entry — it is the one '
+      'Codemagic publishes to email, Slack and Firebase. Found: '
+      '${inFileOrder.join(', ')}.',
+    );
+  }
+
+  for (final String language in preferredLanguages) {
+    final String? text = byLanguage[language];
+    if (text != null) {
+      return _normalise(text);
+    }
+  }
+  return _normalise(byLanguage[inFileOrder.first]!);
+}
+
+/// Trims the surrounding blank space and guarantees a trailing newline.
+///
+/// The Firebase console renders the notes verbatim, so a stray leading blank
+/// line shows up as one.
+String _normalise(String text) => '${text.trim()}\n';
+
+void main(List<String> args) {
+  String input = kDefaultInput;
+  String output = kDefaultOutput;
+  List<String> languages = kPreferredLanguages;
+
+  for (int i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--input':
+        input = args[++i];
+      case '--output':
+        output = args[++i];
+      case '--language':
+        // An explicit choice wins outright; the file's own order still backs it
+        // up if that language is missing.
+        languages = <String>[args[++i]];
+      default:
+        stderr.writeln('Unknown argument: ${args[i]}');
+        exit(64); // EX_USAGE
+    }
+  }
+
+  final File source = File(input);
+  if (!source.existsSync()) {
+    stderr.writeln(
+      'release notes: $input not found. It lives at the repository root and '
+      'is required to distribute — see .agents/rules/release-notes.md.',
+    );
+    exit(66); // EX_NOINPUT
+  }
+
+  final String notes;
+  try {
+    notes = renderReleaseNotes(
+      source.readAsStringSync(),
+      preferredLanguages: languages,
+    );
+  } on ReleaseNotesException catch (error) {
+    stderr.writeln('release notes: $error');
+    exit(65); // EX_DATAERR
+  }
+
+  File(output).writeAsStringSync(notes);
+  stdout.writeln(
+    'release notes: wrote $output (${notes.trim().length} chars) '
+    'from $input',
+  );
+}


### PR DESCRIPTION
# Descripción

`DTA-034`. Los tres workflows de `codemagic.yaml` distribuían a Firebase con `--release-notes "Build #${CM_BUILD_NUMBER:-1} – rama ${CM_BRANCH:-master}"`: una línea que repite lo que la consola de Firebase ya muestra justo encima y que no le dice al tester **qué probar**. Mientras tanto `release_notes.json` llevaba en la raíz desde v1.0.1 sin que nadie lo leyera, porque Codemagic solo lo recoge por su cuenta a través de su bloque `publishing:`, y estos workflows llaman al CLI de Firebase a mano — y el `--release-notes-file` del CLI toma **texto plano**, no el JSON multi-idioma.

**Camino elegido: `--release-notes-file`, derivando el `.txt` del `.json`.** El JSON sigue siendo la única fuente; el `.txt` es un artefacto de build y está gitignored. Dos archivos con la misma prosa se desincronizan, y el que nadie lee lo hace primero.

1. **`tool/release_notes_txt.dart`** — recorre una preferencia de idioma (`es-ES`, luego `en-US`, luego la **primera entrada del archivo**) y escribe `release_notes.txt`. Ese último fallback es a propósito el mismo que aplica Codemagic: si algún día se migra a su bloque, lo que se publica no cambia sin que nadie se entere.
2. **Los 4 puntos de distribución** de los 3 workflows (`android-firebase`, `ios-firebase`, y los dos de `all-platforms-firebase`) pasan ahora `--release-notes-file release_notes.txt`. Ni un solo `Build #N` queda en el archivo.
3. **17 tests nuevos** en `test/tool/release_notes_txt_test.dart`.

### Tres cosas que son decisiones, no valores por defecto

- **El paso corre antes de compilar.** Un JSON roto tumba el build en segundos en vez de a los quince minutos.
- **No hay fallback a una cadena genérica.** Archivo ausente, JSON inválido, texto en blanco o falta de `en-US` fallan el build. Degradar en silencio es exactamente cómo las notas dejaron de llegar la primera vez; volver a hacerlo sería reintroducir el bug con otra cara.
- **El tester lee español.** `en-US` sigue siendo obligatoria porque es la entrada que Codemagic manda al correo y a Slack —y el script falla si falta—, pero no es el idioma del grupo de testers de esta app.

### Por qué no `publishing: firebase:`

Era el otro candidato y **sigue siendo el destino razonable a largo plazo**. No se tomó ahora:

| | `--release-notes-file` (elegido) | `publishing: firebase:` |
|---|---|---|
| Credenciales | Ninguna nueva | Pide `firebase_service_account` (el **contenido** del JSON de service account) o el `firebase_token` deprecado. `GOOGLE_APPLICATION_CREDENTIALS` es una **ruta** y ese bloque no la acepta |
| Idioma que ve el tester | El que se elija; hoy `es-ES` | Fijo: `en-US` |
| Verificable antes de mergear | Sí | No, hace falta lanzar un build real |
| Si sale mal | El paso falla en segundos | Los workflows solo se disparan en push a `master`: se descubre en el peor momento |

El día que el service account esté confirmado en la consola, la migración es cambiar los scripts por el bloque. La comparación queda escrita en `.agents/rules/release-notes.md`, cuya sección «⚠️ Hoy la app no recoge este archivo» **decía justo lo contrario de lo que ahora es cierto** y se reescribió en este mismo PR.

### Consistencia entre los 3 workflows

- Los tres tienen el paso `Derivar notas del tester` en la misma posición (#3, justo después de `flutter pub get`).
- Los cuatro `distribute` usan la misma bandera y el mismo archivo. En `all-platforms-firebase` un único paso alimenta las dos plataformas, así que el tester lee **el mismo texto** en Android y en iOS.
- **`all-platforms-firebase` era el único que no adjuntaba `app-release.apk.sha1`** como artifact. Corregido: es la huella con la que un tester comprueba que el APK que descargó es el que produjo ese build.

No hay dependencias nuevas (el script solo usa `dart:convert` y `dart:io`) ni variables de entorno nuevas.

Issue de GitHub relacionado: Closes #93

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad (cambio no-breaking que agrega funcionalidad)
- [x] 🛠️ Corrección de errores (cambio no-breaking que arregla un error)
- [ ] ❌ Cambio importante (arreglo o característica que haría que la funcionalidad existente no funcionara como se esperaba)
- [x] 📝 Actualización de la documentación
- [ ] 🧹 Code refactoring (modificación de la estructura interna del código sin modificar las APIs)
- [x] ✅ Build configuration change (modificación de los archivos para hacer deploy)
- [ ] 🗑️ Chore (actividades que no modifican la interacción con la app, por ejemplo, modificar el archivo de lints)

## ¿Cómo se ha probado esto?

`flutter analyze` limpio y **294 tests en verde** (17 nuevos).

Y lo que no basta con testear, ejecutado de verdad en local:

- [x] **La derivación, tal cual la correrá el runner.** `dart run tool/release_notes_txt.dart` desde la raíz → `release_notes.txt` con las notas en español **verbatim**, viñetas y saltos de línea incluidos (332 caracteres).
- [x] **El override de idioma.** `--language en-US` → las notas en inglés (288 caracteres).
- [x] **El camino de fallo.** `--input /tmp/nope.json` → mensaje que dice qué arreglar y **exit 66**, así que el paso rompe el build en vez de distribuir en silencio.
- [x] **El `.txt` está gitignored.** `git check-ignore -v release_notes.txt` lo confirma; no puede colarse en un commit.
- [x] **Los binarios y los artifacts (Android).** `flutter build apk --release` con los mismos flags del workflow → `app-release.apk` (53,3 MB) y `app-release.apk.sha1` en **exactamente** las rutas declaradas, y el `.sha1` coincide con `shasum -a 1` del APK.
- [x] **El YAML parsea** y los tres workflows quedan verificados por estructura: paso de derivación presente y en la misma posición, 4 pasos de distribución, los 4 con `--release-notes-file`, cero ocurrencias de `Build #`.

**Configuración de prueba**:

- macOS, Flutter 3.38.3 (la versión fijada en los cuatro sitios)
- Sin dispositivo: el cambio no toca la app, solo el pipeline
- Tema e idioma: N/A

### ⚠️ Lo que NO pude verificar, y por qué

- **La IPA y sus artifacts.** `flutter build ipa` necesita certificado y perfil de aprovisionamiento de Apple, que este entorno no tiene. Los workflows de iOS están además desactivados (`triggering: events: []`). La ruta `build/ios/ipa/*.ipa` no se tocó en este PR: es la que ya estaba.
- **El build real de Codemagic.** Los workflows solo se disparan en push a `master`, así que la primera ejecución de verdad será la próxima promoción de release. Por eso el paso de derivación se puso **antes** de compilar y sin fallback silencioso: si algo va mal, se ve en el log en el primer minuto.
- **Una divergencia que dejo señalada y no toco:** `ios-firebase` compila la IPA con `--export-options-plist=/usr/local/lib/flutter/packages/flutter_tools/templates/app/ios.tmpl/ExportOptions.plist` y `all-platforms-firebase` no. Es una ruta hardcodeada del runner y ninguno de los dos workflows es ejecutable hoy, así que igualarlos a ciegas —en cualquiera de las dos direcciones— sería cambiar algo relacionado con firma sin poder comprobarlo. Queda fuera del alcance de #93; merece su propio issue cuando iOS se active.

## Lista de Verificación

- [x] He agregado las nuevas dependencias (`pubspec.yaml`) en la descripción — no hay; el script usa solo `dart:convert` y `dart:io`
- [x] He agregado las nuevas variables de entorno (solo los nombres) a la descripción — no hay
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código, particularmente en áreas difíciles de entender
- [x] He realizado los cambios correspondientes a la documentación — `.agents/rules/release-notes.md` (la sección obsoleta reescrita, más el `paths:` ampliado a los dos archivos nuevos) y `docs/lista_de_tests.md`
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente con mis cambios
- [ ] La app compila y el flujo afectado se probó en un dispositivo o emulador real — **no aplica**: el cambio es del pipeline, no de la app. El APK release sí se compiló para comprobar los artifacts
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas — no hay copy de UI nueva
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper de cálculo, incluí sus tests en este mismo PR
- [x] No introduje modelos (`shared/data/model/`) en la UI ni en los controladores
