### PR TITLE
[📝 Doc: DTA-039] - Documentar todo lib/ con dartdoc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,90 @@ flutter test
 
 ---
 
+## 📝 Documentación del Código
+
+Todo `lib/` se documenta con **dartdoc** (`///`). La norma del proyecto no es «describir lo que hace la línea» sino **explicar la decisión**: por qué el campo es opcional, qué contrato del backend se respeta, qué pasa si el dato no llega. La regla completa, con el checklist por tipo de cambio, está en [`documentation-convention.md`](.agents/rules/documentation-convention.md); esto es lo que hay que saber para escribir la primera.
+
+### Qué documentar
+
+| Elemento | Qué tiene que decir |
+|---|---|
+| **Clase** | Qué representa y **qué papel juega en su capa**. Una línea, y un párrafo más si encierra una decisión |
+| **Entidad de dominio** | Los campos cuyo significado no es evidente, y **por qué son opcionales** cuando lo son. Las constantes estáticas (`empty`, `emptySkeletonizer`, `pivotCurrency`) llevan la suya: sin eso, la siguiente persona añade una cuarta |
+| **Modelo / endpoint** | Qué campos son opcionales **en el contrato**, qué normalización se aplica y qué versión del backend lo introdujo |
+| **Controlador GetX** | Qué vista alimenta, de qué servicio observa, y **qué dispara cada `ever()`** — es control de flujo invisible desde la vista |
+| **Observable público** | Qué representa y cuándo cambia |
+| **Método público** | El contrato: qué devuelve, qué lanza, y qué pasa en el borde (lista vacía, tasa cero, campo ausente) |
+
+### Qué **no** documentar
+
+Esto es tan importante como lo anterior, y es la parte que se suele hacer mal:
+
+- **Lo que el nombre ya dice.** `/// Returns the name.` sobre `String get name` es ruido; oculta las líneas que sí importan.
+- **Getters y setters triviales**, `copyWith`, `toString`.
+- **Los registros mecánicos.** `AppMessages` (79 getters de i18n), `ColorValues` (78 accesores de color) y `AppIcons` (18 rutas de asset) llevan docstring **en la clase** —que explica el registro, la separación en dos capas, y la regla de los diez idiomas— y **ninguno en sus miembros**. Un `/// El color blanco del texto` sobre `textWhite` no informa a nadie. Los pocos miembros que sí lo llevan son los que tienen una razón: mira `AppMessages.officialRate` y `AppMessages.noSearchResultsMessage`.
+- **Bloques de código comentado**: se borran, para eso está git.
+
+### Estilo
+
+- Empieza por una **frase corta y afirmativa**, terminada en punto. Es lo que sale en el índice de `dart doc`.
+- Después de una línea en blanco, el porqué. Usa `**negrita**` para el hallazgo que alguien podría deshacer sin darse cuenta.
+- Referencia símbolos con `[Corchetes]` **solo si están importados en ese archivo**; si no, comillas simples de código, o `dart doc` avisa de una referencia que no resuelve.
+- Cita el issue que tomó la decisión (`(#59)`) — es lo que permite reconstruir el porqué un año después.
+- En inglés, como el resto del código y de los mensajes de commit.
+
+### Medir la cobertura
+
+El lint `public_member_api_docs` **no está activo**, y es deliberado: activarlo obligaría a escribir exactamente los comentarios que la sección anterior prohíbe. De los 303 avisos que reporta hoy, **170 caen en esos tres registros mecánicos** (`colors_values.dart` 77, `app_messages.dart` 76, `icons_constants.dart` 17).
+
+Para medir de todos modos, actívalo un momento. Ojo con el **cómo**: hay que insertarlo en el bloque `rules:` que ya existe, no añadir un `linter:` nuevo al final — dos claves `linter:` en el mismo YAML y el analizador se queda con una, así que el lint no se aplica y el comando responde `0` como si todo estuviera documentado.
+
+```bash
+cp analysis_options.yaml /tmp/ao.bak
+python3 -c "
+s = open('analysis_options.yaml').read()
+s = s.replace('  rules:', '  rules:\n    public_member_api_docs: true', 1)
+open('analysis_options.yaml', 'w').write(s)
+"
+flutter analyze 2>&1 | grep public_member_api_docs | sed -E 's#^.*(lib/[^:]+):.*#\1#' | sort | uniq -c | sort -rn
+
+cp /tmp/ao.bak analysis_options.yaml   # ← no olvides esto
+git diff --quiet analysis_options.yaml && echo 'restaurado'
+```
+
+Lo que **sí** debe estar al 100 % son las **clases**: cada tipo público de `lib/` lleva su docstring. Comprobarlo:
+
+```bash
+python3 - <<'EOF'
+import re, glob
+d = re.compile(r'^\s*(?:abstract\s+|sealed\s+|final\s+|base\s+|interface\s+)*(class|mixin|enum|extension|typedef)\s+([A-Za-z_]\w*)')
+tot = doc = 0
+for f in sorted(glob.glob('lib/**/*.dart', recursive=True)):
+    lines = open(f, encoding='utf-8').read().split('\n')
+    for i, ln in enumerate(lines):
+        m = d.match(ln)
+        if not m or m.group(2).startswith('_'):
+            continue
+        tot += 1
+        j = i - 1
+        while j >= 0 and (lines[j].strip().startswith('@') or not lines[j].strip()):
+            j -= 1
+        if j >= 0 and lines[j].strip().startswith('///'):
+            doc += 1
+        else:
+            print(f'sin docstring: {f}:{m.group(2)}')
+print(f'{doc}/{tot} tipos publicos documentados')
+EOF
+```
+
+Y para leerla como la leería alguien de fuera:
+
+```bash
+dart doc .          # genera doc/api/
+```
+
+---
+
 ## 🏷️ Versionado y Changelog
 
 El proyecto sigue **[Semantic Versioning](https://semver.org/lang/es/)** (`MAJOR.MINOR.PATCH`, con tags `vX.Y.Z`) y mantiene un historial formal en `CHANGELOG.md` con el formato **[Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/)**.

--- a/lib/config/bindings/initial_bindings.dart
+++ b/lib/config/bindings/initial_bindings.dart
@@ -13,6 +13,18 @@ import '../../shared/domain/repositories/dollar_repositories.dart';
 import '../../shared/presentation/controller/settings_controller.dart';
 import '../enviroment/enviroment.dart';
 
+/// The app's whole dependency graph, in one file.
+///
+/// Everything is registered here and resolved with `Get.find()`; nothing constructs
+/// a controller inside a widget, because a second instance would listen to the same
+/// service while only the registered one is bound to the view — and the bug
+/// surfaces as "the screen does not update", far from its cause. See
+/// `.agents/rules/dependency-injection.md`.
+///
+/// **Two entry points, and the split is load-bearing.** [dependencies] is called by
+/// `GetMaterialApp` from its `initState` and **not awaited**, so anything the first
+/// frame has to read cannot be registered there. That goes in [initServices],
+/// which `main` awaits before `runApp`.
 class InitialBinding extends Bindings {
   /// Services that must be **fully constructed before the first frame**.
   ///

--- a/lib/config/enviroment/enviroment.dart
+++ b/lib/config/enviroment/enviroment.dart
@@ -56,6 +56,17 @@ class EnvironmentError {
   String toString() => 'EnvironmentError($variable, ${issue.name})';
 }
 
+/// The only place the app reads `.env`.
+///
+/// Every `dotenv.env[...]` lookup lives here, so the configuration contract is one
+/// file rather than a habit spread across datasources. A variable added to `.env`
+/// has to be added here, to `.env.example` **with a placeholder value**, to the
+/// README, and to the `Crear .env` step of all three Codemagic workflows — see
+/// `.agents/rules/environment-variables.md`, and note that a missing CI variable
+/// builds fine and ships an app with no configuration.
+///
+/// [load] never throws and [validate] reports instead: a bad `.env` is a problem to
+/// show the user on a real screen, not a crash before the first frame.
 class Environment {
   /// Key of the backend URL in `.env`. Kept as a constant because both the
   /// getter and the validation name it, and a typo in either would be silent.

--- a/lib/config/routes/pages.dart
+++ b/lib/config/routes/pages.dart
@@ -4,9 +4,17 @@ import 'package:get/get.dart';
 import '../../features/dashboard/presentation/page/dashboard_page.dart';
 import '../../features/splash/presentation/page/splash_page.dart';
 
+/// The routing table `GetMaterialApp` is built with.
+///
+/// Every constant in [AppRoutes] has exactly one `GetPage` here. **Transitions
+/// belong on the page, not at the call site**: the splash calls a bare
+/// `Get.offAllNamed(AppRoutes.home)` and inherits the fade declared below, so the
+/// animation cannot differ between two places that navigate to the same screen.
 class AppPages {
+  /// Route the app opens on.
   static const initPage = AppRoutes.splash;
 
+  /// Every screen the app can navigate to, by name.
   static final List<GetPage<dynamic>> routes = [
     GetPage(name: AppRoutes.splash, page: () => const SplashPage()),
     // The splash → home transition lives here, on the route, not at the call

--- a/lib/config/routes/routes.dart
+++ b/lib/config/routes/routes.dart
@@ -1,4 +1,20 @@
+/// Names of the app's routes, and the only place they are spelled out.
+///
+/// Navigation references a constant here — `Get.toNamed(AppRoutes.home)` — never a
+/// literal and never a widget: passing a widget couples the caller to the
+/// destination's constructor and leaves that screen out of the routing table
+/// entirely. See `.agents/rules/navigation-convention.md`.
+///
+/// **Only two, and that is correct.** Tabs are not routes (they move
+/// `NavigationController.selectedIndex`) and neither are modals — the settings
+/// dialog, the currency detail and the currency selector are all opened directly
+/// and closed with `Get.back()`. The price is that a modal is not reachable by
+/// deep link; when one needs to be, it gains a `GetPage` here that resolves its
+/// data from a route parameter.
 abstract class AppRoutes {
+  /// The entry point. Shows the brand, then replaces itself with [home].
   static const splash = '/splash';
+
+  /// The dashboard: the tab bar and both tabs.
   static const home = '/home';
 }

--- a/lib/config/theme/colors/colors_constants.dart
+++ b/lib/config/theme/colors/colors_constants.dart
@@ -1,5 +1,19 @@
 import 'package:flutter/material.dart';
 
+/// The brand palette, as raw `MaterialColor` swatches.
+///
+/// The **lowest** layer of colour: literal values and nothing else. Widgets do not
+/// read this — they read `ColorValues`, which picks a shade per theme. That split
+/// is what makes light and dark a single decision per token instead of a
+/// conditional at every call site.
+///
+/// No `Color(0xFF...)` exists outside `lib/config/theme/`; the 137 uses in the app
+/// all resolve through here. `DESIGN.md` declares these tokens first and this file
+/// implements them — see `.agents/rules/design-system.md`.
+///
+/// The launch-screen navy `#08253A` is deliberately **not** here: it belongs to the
+/// brand's artwork rather than to the interface palette, and lives in
+/// `assets/brand/`.
 class AppColors {
   AppColors._();
 

--- a/lib/config/theme/colors/colors_values.dart
+++ b/lib/config/theme/colors/colors_values.dart
@@ -1,6 +1,21 @@
 import 'package:flutter/material.dart';
 import 'colors_constants.dart'; // Asegúrate de que este import apunte a tu archivo
 
+/// Every colour the UI asks for, resolved for the active theme.
+///
+/// The layer widgets actually call: each accessor takes a `BuildContext`, reads the
+/// brightness and returns the right shade from `AppColors`. That is why a widget
+/// never needs a `Theme.of(context).brightness ==` branch of its own.
+///
+/// The accessors are intentionally undocumented one by one: their names *are* the
+/// documentation (`textWhite`, `borderPrimary`, `utilityBrand500`), and a line
+/// saying "the white text colour" above `textWhite` is the kind of comment
+/// `.agents/rules/documentation-convention.md` explicitly tells you not to write.
+/// What is worth knowing is the two-layer split above, and that these — not
+/// `Theme.of(context).colorScheme` — remain the source for the app's own widgets
+/// even after the Material 3 migration
+/// ([#44](https://github.com/Teixeira49/bcv_tracker_app/issues/44)); the
+/// `ColorScheme` mainly feeds Material's built-in components.
 class ColorValues {
   // -------------------------------------------------------
   // <---------------- Text color values ------------------>

--- a/lib/config/theme/icons/icons_constants.dart
+++ b/lib/config/theme/icons/icons_constants.dart
@@ -1,3 +1,14 @@
+/// Asset paths for every icon, flag and logo the app draws.
+///
+/// Paths in one place so a renamed or moved asset breaks in a single file instead
+/// of at each `SvgPicture.asset` call — a wrong path is a runtime failure in
+/// Flutter, not a compile error, so centralising is the only thing that makes it
+/// catchable.
+///
+/// The individual constants carry no docstrings on purpose: the name and the path
+/// together already say everything (`flagVenezuelaIcon`), and
+/// `.agents/rules/documentation-convention.md` rules out comments that repeat the
+/// code.
 class AppIcons {
   static const String imagesRoute = 'assets/images';
   static const String iconsRoute = 'assets/icons';

--- a/lib/config/theme/width/width_values.dart
+++ b/lib/config/theme/width/width_values.dart
@@ -1,5 +1,18 @@
 part 'width_constants.dart';
 
+/// The 8-point spacing and radius scale.
+///
+/// Sizes come from this scale rather than from bare numbers in an `EdgeInsets`, so
+/// the app's rhythm is one set of decisions. If a design needs a value that is not
+/// on the scale, the question to ask first is whether it should use one that is.
+///
+/// **Adoption is partial, and knowingly so.** `features/currency_detail/` was built
+/// on the scale; older widgets still carry loose numbers. New UI uses these, and
+/// touching an old widget is the moment to migrate its paddings — the boy-scout
+/// rule in `.agents/rules/constants-centralization.md`.
+///
+/// `final` rather than `const` because the values are computed from the base unit;
+/// that is also why they cannot appear in a `const` constructor.
 class WidthValues {
   // ---------------------------------------------------
   // <---------------- Radius values ------------------>

--- a/lib/core/constants/constants.dart
+++ b/lib/core/constants/constants.dart
@@ -1,3 +1,9 @@
+/// App-wide values that are neither colours, copy, nor configuration.
+///
+/// Durations, date formats and the app title: things with a business meaning that
+/// would otherwise be magic numbers scattered across widgets. Anything that
+/// changes per environment is **not** here — that is `Environment` and the `.env`
+/// file (`.agents/rules/environment-variables.md`).
 class Constants {
   const Constants._();
 

--- a/lib/core/helpers/currency_helpers.dart
+++ b/lib/core/helpers/currency_helpers.dart
@@ -10,6 +10,16 @@ import '../../config/theme/icons/icons_constants.dart';
 import '../../features/home/domain/entities/currency_country.dart';
 import '../../shared/domain/entities/currency.dart';
 
+/// Turns rate data into the strings and dressing the UI shows.
+///
+/// The seam between what the backend sends and what a screen can render: a
+/// translated name for a currency code, a flag, a symbol, an amount formatted for
+/// display, a date kept in the right timezone. Pure functions, so their tests need
+/// neither fakes nor GetX.
+///
+/// **Formatting happens here and only here.** The controllers keep full precision
+/// and this rounds at the point of display — the order that fixed the converter's
+/// original rounding bug, and one that must not be inverted. See [castAmount].
 class CurrencyHelpers {
   static CurrencyCountry castCurrencyCountry({required String currencyCode}) {
     switch (currencyCode) {

--- a/lib/core/i18n/app_messages.dart
+++ b/lib/core/i18n/app_messages.dart
@@ -1,5 +1,22 @@
 import 'package:get/get.dart';
 
+/// Every string the user can read, as typed getters.
+///
+/// The **only** file in the app that calls `.tr`. Widgets go through these getters
+/// instead, which buys autocompletion, a central inventory, and a compile error
+/// when a key is removed — where a raw `'homeView'.tr` in a widget would just
+/// render the key on screen.
+///
+/// A new key goes into **all ten** language files in the same commit. Miss one and
+/// GetX shows the raw key for that language; nothing throws, and it surfaces only
+/// by switching language by hand. `.agents/rules/i18n-convention.md` has the
+/// parity script.
+///
+/// The getters below are deliberately left without individual docstrings: the key
+/// name and the getter name are the same word, and a comment restating it is what
+/// `.agents/rules/documentation-convention.md` calls out as noise. The few that
+/// *are* documented are the ones with a reason — see [officialRate] and
+/// [noSearchResultsMessage].
 class AppMessages {
   static String get homeView => 'homeView'.tr;
 

--- a/lib/core/i18n/app_translations.dart
+++ b/lib/core/i18n/app_translations.dart
@@ -1,6 +1,17 @@
 import 'package:bcv_tracker_app/core/i18n/languages/_languages.dart';
 import 'package:get/get.dart';
 
+/// Assembles the ten language maps for GetX.
+///
+/// The single registration point: [keys] is what `GetMaterialApp(translations:)`
+/// receives, and it is also what `translation_parity_test.dart` reads — testing the
+/// registration rather than the files means the suite also fails if a language map
+/// stops being wired in, not only if a key goes missing.
+///
+/// The locale codes here are the contract. `SettingsController.languageOptions`
+/// must match them exactly, which it did not until
+/// [#98](https://github.com/Teixeira49/bcv_tracker_app/issues/98) corrected `en_EN`
+/// and `ja_JA`.
 class AppTranslations extends Translations {
   @override
   Map<String, Map<String, String>> get keys => {

--- a/lib/core/network/api_error_messages.dart
+++ b/lib/core/network/api_error_messages.dart
@@ -5,7 +5,7 @@ import 'api_exception.dart';
 ///
 /// The backend's own `message` is written for developers (and goes to the log,
 /// #19); the user needs to know whether the problem is theirs (no connection)
-/// or the service's, and what to do about it. The mapping is by [kind] first —
+/// or the service's, and what to do about it. The mapping is by `kind` first —
 /// so "no connection" is never confused with "the server failed" — and then by
 /// the HTTP code the backend assigns meaning to (408 slow source, 502 source
 /// down, 422 mode not allowed, 500 internal). Anything else falls to a

--- a/lib/core/network/http_manager.dart
+++ b/lib/core/network/http_manager.dart
@@ -12,8 +12,26 @@ import 'http_operation.dart';
 
 // Project imports:
 
-enum HttpManagerUtilError { error }
+/// Placeholder discriminator kept for the transport's own error path.
+///
+/// A single-value enum, which is as much as it needs to be: callers never see it,
+/// because failures leave this layer as `ApiException`.
+enum HttpManagerUtilError {
+  /// The transport failed. The cause travels in the exception, not here.
+  error,
+}
 
+/// The app's HTTP client — Dio, configured once.
+///
+/// Every request goes through here so the timeout, the headers and the logging
+/// are one decision rather than a per-datasource habit. `DollarApiRest` takes an
+/// instance, which is what lets a test hand it a fake and assert **the outgoing
+/// contract** (the path and the method actually sent) without a network.
+///
+/// It **maps transport failures to `ApiException`**. A `DioException` must not
+/// escape this file: the layers above have no business knowing which client
+/// fetched the data, and `.agents/rules/test-coverage.md` requires a test for each
+/// of non-2xx, timeout and empty body.
 class HttpManager {
   BaseOptions _dioOptions(
     String endpoint,

--- a/lib/features/converter/presentation/controller/converter_controller.dart
+++ b/lib/features/converter/presentation/controller/converter_controller.dart
@@ -4,25 +4,55 @@ import '../../../../shared/domain/conversion.dart';
 import '../../../../shared/domain/entities/currency.dart';
 import '../../domain/entities/convertible_currency.dart';
 
+/// Drives the full converter: which pair, how much, and the result.
+///
+/// **The pivot rule is the thing to understand here.** Every rate the backend
+/// publishes is quoted in bolívares, so there is no cross-rate for `USD → EUR`;
+/// the converter therefore keeps [Currency.pivotCurrency] on **one side at all
+/// times** and reads `USD → EUR` as `USD → VES → EUR`. [selectCurrency] enforces
+/// that invariant rather than trusting callers, which is why picking a second
+/// non-VES currency moves the other side to VES instead of refusing.
+///
+/// Unlike `HomeController` this holds state of its own — the pair and the amount
+/// — and that state **survives between visits to the tab**, deliberately: a user
+/// coming back to a calculation finds it where they left it. Which is also why
+/// [preloadFromDetail] is the only thing allowed to overwrite it, and only on an
+/// explicit tap.
+///
+/// The arithmetic is **not** here: `CurrencyConversion` in `shared/domain/` owns
+/// it, and the detail sheet's quick converter calls the same functions. That is
+/// what makes "both converters agree" a test rather than a hope.
 class ConverterController extends GetxController {
   final CurrencyRepository _repository = Get.find<CurrencyRepository>();
 
+  /// Whether a refresh is in flight — the same one Home shows, so the two
+  /// screens never disagree about whether the app is busy.
   bool get isLoading => _repository.isLoading.value;
 
   /// Detail of the last failed refresh, or `null` when the last one succeeded —
   /// the same failure the Home shows, so the converter states stay consistent.
   String? get errorMessage => _repository.errorMessage.value;
 
-  // Single consolidated list of currencies
+  /// Every rate the user can pick from, official and parallel in one list.
+  ///
+  /// Consolidated because the converter asks "which rate", not "which tab": the
+  /// selector shows them together. Deduplicated on `keyName + platform + name` by
+  /// [_updateCurrenciesAndInit], since the BCV dollar and a parallel dollar are
+  /// different rates that share a code.
+  ///
+  /// Starts as skeleton placeholders, like the service's own lists.
   final RxList<Currency> currencies = List.generate(
     5,
     (e) => Currency.emptySkeletonizer,
   ).obs;
 
+  /// Refetches the rates. Bound to the converter's pull-to-refresh and to retry.
   Future<void> refreshConverterData() async {
     await _repository.refreshData();
   }
 
+  /// The bolívar, held as a field so the pivot rule reads as a comparison rather
+  /// than a literal. See [Currency.pivotCurrency].
   Currency pivotCurrency = Currency.pivotCurrency;
 
   final Rx<ConvertibleCurrency> _fromCurrency = ConvertibleCurrency(
@@ -30,8 +60,11 @@ class ConverterController extends GetxController {
     convertedValue: 0.0,
   ).obs;
 
+  /// The side the user types into, with the amount they typed.
   ConvertibleCurrency get fromCurrency => _fromCurrency.value;
 
+  /// Replaces the input side. Setting it does **not** recalculate — call
+  /// [calculator] after, which is what every path here does.
   set fromCurrency(ConvertibleCurrency value) => _fromCurrency.value = value;
 
   final Rx<ConvertibleCurrency> _toCurrency = ConvertibleCurrency(
@@ -39,8 +72,11 @@ class ConverterController extends GetxController {
     convertedValue: 0.0,
   ).obs;
 
+  /// The side the result is expressed in, with that result.
   ConvertibleCurrency get toCurrency => _toCurrency.value;
 
+  /// Replaces the output side. Like [fromCurrency], does not recalculate on its
+  /// own.
   set toCurrency(ConvertibleCurrency value) => _toCurrency.value = value;
 
   @override
@@ -116,6 +152,7 @@ class ConverterController extends GetxController {
     }
   }
 
+  /// The rate line under each card — `1.0 ≈ 826.84`, in the pair's own units.
   String getRoundedCurrency() =>
       '${fromCurrency.originalValue} ≈ ${toCurrency.originalValue}';
 
@@ -131,6 +168,14 @@ class ConverterController extends GetxController {
     toRate: toCurrency.currency.value,
   );
 
+  /// Picks [selected] for the input side when [isInput], the output side
+  /// otherwise, keeping the pivot rule.
+  ///
+  /// Returns `null` when nothing changed (the same rate was already there),
+  /// `true` when the pair moved. The four branches in the body are the rule made
+  /// explicit: same rate, the other side's rate (so swap), a new rate, and the
+  /// case where neither side would be VES — which moves the *other* side to the
+  /// pivot rather than rejecting the choice the user just made.
   bool? selectCurrency(Currency selected, {required bool isInput}) {
     final Currency current = isInput
         ? fromCurrency.currency
@@ -239,6 +284,14 @@ class ConverterController extends GetxController {
     calculator(amount);
   }
 
+  /// Flips the pair, **carrying each figure with its currency**.
+  ///
+  /// The figure belongs to its currency, so `USD 2 | VES 1653` inverts to
+  /// `VES 1653 | USD 2`, not to `VES 2`. Leaving the amount behind would silently
+  /// change the question — it would ask what two bolívares are worth and answer
+  /// `0.00`, which reads as a broken converter rather than a correct answer to a
+  /// question nobody asked. The detail sheet's quick converter follows the same
+  /// model.
   void swapCurrencies() {
     final ConvertibleCurrency temp = fromCurrency;
     fromCurrency = toCurrency;
@@ -246,6 +299,17 @@ class ConverterController extends GetxController {
     calculator(fromCurrency.convertedValue.toString());
   }
 
+  /// Parses what the user typed and publishes the converted result.
+  ///
+  /// Takes the **raw string**, not a number: `1.` and `1.0` are the same value
+  /// and not the same text, and writing a parsed value back would move the caret.
+  /// It is also the single place that decides what a string means — empty field,
+  /// lone separator, decimal comma — which is why [preloadFromDetail] routes
+  /// through here instead of parsing the handed-over amount itself.
+  ///
+  /// The full precision is kept in state; rounding happens only at display, in
+  /// `CurrencyHelpers.castAmount`. That order is the fix for the converter's
+  /// original rounding bug and must not be inverted.
   void calculator(String value) {
     if (value.isEmpty) {
       fromCurrency = fromCurrency.copyWith(convertedValue: 0.0);

--- a/lib/features/converter/presentation/page/converter_page.dart
+++ b/lib/features/converter/presentation/page/converter_page.dart
@@ -24,6 +24,13 @@ part '../widget/converter_buttons.dart';
 part '../widget/converter_modals.dart';
 part '../widget/converter_widgets.dart';
 
+/// The full converter: a pair of rates, an amount and the result.
+///
+/// Reads `ConverterController`, whose pair **survives between visits to this tab**
+/// — deliberately, so a calculation can be returned to. The one thing allowed to
+/// replace it is the detail sheet's hand-off
+/// ([#103](https://github.com/Teixeira49/bcv_tracker_app/issues/103)), and only on
+/// an explicit tap.
 class ConverterPage extends StatelessWidget {
   const ConverterPage({super.key});
 

--- a/lib/features/currency_detail/presentation/widgets/currency_detail_slots.dart
+++ b/lib/features/currency_detail/presentation/widgets/currency_detail_slots.dart
@@ -44,7 +44,7 @@ part of '../page/currency_detail_sheet.dart';
 /// The empty sliver every unfilled slot renders.
 const Widget _noSection = SliverToBoxAdapter(child: SizedBox.shrink());
 
-/// Historical evolution of the rate — **reserved for [#5]**.
+/// Historical evolution of the rate — **reserved for [#5](https://github.com/Teixeira49/bcv_tracker_app/issues/5)**.
 ///
 /// Blocked upstream: there is no historical endpoint yet
 /// (`bcv_tracker_backend#14`). When it exists, the series is fetched by
@@ -67,7 +67,7 @@ class CurrencyDetailChartSlot extends StatelessWidget {
   Widget build(BuildContext context) => _noSection;
 }
 
-/// Share and save — **reserved for [#7]**.
+/// Share and save — **reserved for [#7](https://github.com/Teixeira49/bcv_tracker_app/issues/7)**.
 ///
 /// A row of actions on the rate: share it as text or image, pin it as a
 /// favourite. Saving needs somewhere to persist to — `SettingsController` and
@@ -77,7 +77,7 @@ class CurrencyDetailChartSlot extends StatelessWidget {
 /// Placed under the facts so the sheet reads as *information first, actions
 /// after*.
 ///
-/// **Still empty after [#103].** That issue's one action —hand the rate to the
+/// **Still empty after [#103](https://github.com/Teixeira49/bcv_tracker_app/issues/103).** That issue's one action —hand the rate to the
 /// full converter— is not an action *on the rate*, it is a continuation of the
 /// quick converter, so it lives in that section's heading row instead of here.
 /// See [_OpenInConverterButton].
@@ -149,7 +149,7 @@ class _OpenInConverterButton extends StatelessWidget {
   );
 }
 
-/// Converter dedicated to this rate — **filled by [#39]**.
+/// Converter dedicated to this rate — **filled by [#39](https://github.com/Teixeira49/bcv_tracker_app/issues/39)**.
 ///
 /// An amount field that converts against [currency] only: the sheet already
 /// fixed which currency this is about, so offering a selector here would be

--- a/lib/features/dashboard/presentation/page/dashboard_page.dart
+++ b/lib/features/dashboard/presentation/page/dashboard_page.dart
@@ -7,6 +7,12 @@ import 'package:get/get.dart';
 import '../../../../config/theme/colors/colors_values.dart';
 import '../../../../shared/presentation/widgets/custom_bottom_navigator_bar.dart';
 
+/// The two tabs and the bar that switches them.
+///
+/// Uses an **`IndexedStack`**, so both pages stay mounted and each keeps its scroll
+/// position, its text field and its controller state while the other is showing.
+/// That is what makes leaving the converter and coming back to a half-finished
+/// calculation work, and it is the reason tabs are not routes.
 class DashboardPage extends GetView<NavigationController> {
   final List<Widget> pages = [const HomePage(), const ConverterPage()];
 

--- a/lib/features/home/domain/entities/currency_country.dart
+++ b/lib/features/home/domain/entities/currency_country.dart
@@ -1,10 +1,35 @@
+/// The country dressing that a currency code alone cannot supply.
+///
+/// A rate arrives from the backend as a code and a number; a card has to show a
+/// flag, a symbol and a translated name. This carries that, and it is built by
+/// `CurrencyHelpers.castCurrencyCountry` from the code — a lookup, not data the
+/// backend sends.
+///
+/// It lives under `features/home/` because the BCV card is what needs it: the
+/// average tab identifies rates by market instead, so it reads
+/// `CurrencyHelpers.castCurrencyDisplayName` and never touches this.
 class CurrencyCountry {
+  /// Country the currency belongs to, for context beside the code.
+  ///
+  /// **Hardcoded in Spanish** in `castCurrencyCountry` and not run through
+  /// `AppMessages`, which is a gap rather than a decision: it is the one string
+  /// here that does not follow `.agents/rules/i18n-convention.md`.
   final String countryName;
+
+  /// ISO code the lookup was made with, or `-` when the code is unknown.
   final String currencyCode;
+
+  /// Translated name of the currency, from `AppMessages`. This is what the card
+  /// titles itself with.
   final String currencyCountryName;
+
+  /// Asset path of the currency's symbol glyph, from `AppIcons`.
   final String currencySymbol;
+
+  /// Asset path of the country's flag, from `AppIcons`.
   final String countryFlag;
 
+  /// Groups the dressing for one currency code.
   CurrencyCountry({
     required this.countryName,
     required this.currencyCode,

--- a/lib/features/home/presentation/controller/home_controller.dart
+++ b/lib/features/home/presentation/controller/home_controller.dart
@@ -2,12 +2,34 @@ import 'package:get/get.dart';
 import '../../../../shared/data/repositories/currency_repository.dart';
 import '../../../../shared/domain/entities/currency.dart';
 
+/// Feeds the Home screen from [CurrencyRepository].
+///
+/// **Holds no state of its own.** Every getter unwraps an observable the service
+/// owns, and `onInit` bridges each one to `update()` so the `GetBuilder`s in the
+/// view repaint. That is the architecture's boundary: the view never names an
+/// `Rx` type, and there is exactly one copy of the rates in the app.
+///
+/// A consequence worth knowing before adding reactive state to the service: **if
+/// you add an observable here and forget its `ever`, the screen silently stops
+/// refreshing.** Nothing fails; it just never updates. See
+/// `.agents/skills/getx-architecture`.
 class HomeController extends GetxController {
   final CurrencyRepository _repository = Get.find<CurrencyRepository>();
 
+  /// Parallel market rates for the average tab, unwrapped.
+  ///
+  /// While [hasAverageData] is `false` these are the skeleton placeholders, not
+  /// rates — the view shimmers them rather than reading their numbers.
   List<Currency> get averageCurrencies => _repository.averageCurrencies;
+
+  /// Official rates for the BCV tab. Same placeholder contract, flagged by
+  /// [hasBcvData].
   List<Currency> get bcvCurrencies => _repository.bcvCurrencies;
+
+  /// Effective date of the official rates, as the BCV published it.
   String get bcvCurrentDate => _repository.bcvCurrentDate.value;
+
+  /// Whether a refresh is in flight, for the shimmer and the pull-to-refresh.
   bool get isLoading => _repository.isLoading.value;
 
   /// Detail of the last failed refresh, or `null` if the last one succeeded.
@@ -15,8 +37,18 @@ class HomeController extends GetxController {
 
   /// Whether each tab already has real rates to render (see [CurrencyRepository]).
   bool get hasAverageData => _repository.hasAverageData.value;
+
+  /// See [hasAverageData]; its counterpart for the BCV tab.
   bool get hasBcvData => _repository.hasBcvData.value;
 
+  /// Wires the service's observables to `update()`.
+  ///
+  /// Four workers, one per value the view reads. They are **not disposed**, which
+  /// is the leak catalogued in
+  /// [#45](https://github.com/Teixeira49/bcv_tracker_app/issues/45): `get` 4.7.3
+  /// disposes none on its own and this controller is registered `fenix`, so a
+  /// listener accumulates on every recreation against a `permanent` service. Any
+  /// new worker added here belongs in an `onClose` that this class still owes.
   @override
   void onInit() {
     super.onInit();
@@ -27,6 +59,8 @@ class HomeController extends GetxController {
     ever(_repository.errorMessage, (_) => update());
   }
 
+  /// Refetches both sides. Bound to pull-to-refresh and to the error state's
+  /// retry; the service is what decides what a partial failure means.
   Future<void> refreshHomeData() async {
     await _repository.refreshData();
   }

--- a/lib/features/home/presentation/page/home_page.dart
+++ b/lib/features/home/presentation/page/home_page.dart
@@ -22,6 +22,12 @@ part '../widgets/home_tab_bar.dart';
 
 part '../widgets/home_widgets.dart';
 
+/// The rate list, in two tabs: the parallel average and the official BCV rates.
+///
+/// The app's landing screen. Which tab opens first is the user's saved preference
+/// (`SettingsController.favMarketIndex`), and tapping a card opens the detail sheet
+/// with a **snapshot** of that rate — this list already holds the freshest copy the
+/// app has, so the sheet does not re-fetch.
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
 

--- a/lib/features/settings/presentation/page/settings_modal.dart
+++ b/lib/features/settings/presentation/page/settings_modal.dart
@@ -16,6 +16,14 @@ part '../widgets/settings_inputs.dart';
 
 part '../widgets/settings_widgets.dart';
 
+/// Language, theme and default market, in a centred dialog.
+///
+/// A **modal, not a route**: opened with `showBlurredDialog` and closed with
+/// `Get.back()`, so it is not registered in `AppPages`. Its selectors read
+/// `SettingsController` with `Obx` rather than `GetBuilder` — the controller is a
+/// `GetxService` since
+/// [#59](https://github.com/Teixeira49/bcv_tracker_app/issues/59) and `GetBuilder`
+/// is bound to `GetxController`.
 class SettingsModal extends StatelessWidget {
   const SettingsModal({super.key});
 

--- a/lib/features/splash/presentation/page/splash_page.dart
+++ b/lib/features/splash/presentation/page/splash_page.dart
@@ -11,6 +11,22 @@ import '../../../../core/constants/constants.dart';
 
 part '../widgets/splash_body.dart';
 
+/// The first Flutter screen: the brand, then Home.
+///
+/// It is the **second** of three screens on launch, not the first — the OS paints a
+/// native one before Flutter draws anything, and matching the two is what
+/// [#102](https://github.com/Teixeira49/bcv_tracker_app/issues/102) did.
+///
+/// Waits `Constants.splashDuration` and then `Get.offAllNamed(AppRoutes.home)`,
+/// clearing the stack so back does not return here. The fade belongs to the home
+/// route, not to this call. The wait also has to outlast the entry animation in
+/// `_SplashBody` (2200 ms): shortening one means shortening both.
+///
+/// It no longer covers anything functional. Until
+/// [#59](https://github.com/Teixeira49/bcv_tracker_app/issues/59) it accidentally
+/// hid the window in which the saved theme and language had not loaded yet; those
+/// are now awaited before the first frame, so this is a welcome screen and nothing
+/// more.
 class SplashPage extends StatefulWidget {
   const SplashPage({super.key});
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -64,6 +64,14 @@ class ConfigurationErrorApp extends StatelessWidget {
   }
 }
 
+/// The app itself, once the configuration is known to be usable.
+///
+/// Wires the routing table, the ten translations and the two themes. The theme and
+/// the locale come **from `SettingsController`, already loaded** — `main` awaits
+/// `InitialBinding.initServices()` before this can exist — and they are *passed*
+/// rather than applied, because `GetMaterialApp.initState` assigns `Get.locale`
+/// from its own argument and would overwrite anything set earlier
+/// ([#59](https://github.com/Teixeira49/bcv_tracker_app/issues/59)).
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 

--- a/lib/navigation/navigation_controller.dart
+++ b/lib/navigation/navigation_controller.dart
@@ -1,8 +1,24 @@
 import 'package:get/get.dart';
 
+/// Which tab of the dashboard is showing.
+///
+/// **Tabs are not routes.** `DashboardPage` keeps both pages alive in an
+/// `IndexedStack` and switches between them by this index, so moving between Home
+/// and the converter preserves each one's scroll position and state — and never
+/// touches the navigation stack. Changing tab is `changeIndex`, never
+/// `Get.toNamed`; see `.agents/rules/navigation-convention.md`.
+///
+/// The index maps to `DashboardPage.pages`: `0` Home, `1` the converter.
 class NavigationController extends GetxController {
+  /// Index of the visible tab. Observed directly with `Obx` by the dashboard and
+  /// the bottom bar, which are the only two widgets that care.
   var selectedIndex = 0.obs;
 
+  /// Shows the tab at [index].
+  ///
+  /// Also the way in from elsewhere: the detail sheet's "open in the converter"
+  /// action calls this after loading the rate
+  /// ([#103](https://github.com/Teixeira49/bcv_tracker_app/issues/103)).
   void changeIndex(int index) {
     selectedIndex.value = index;
   }

--- a/lib/shared/data/datasource/dollar_api/dollar_api.dart
+++ b/lib/shared/data/datasource/dollar_api/dollar_api.dart
@@ -1,7 +1,21 @@
 import '../../model/model.dart';
 
+/// The HTTP calls the app makes for exchange rates.
+///
+/// One step below `IDollarRepository` and the mirror of it in the data layer:
+/// this one traffics in **models**, that one in entities, and `DollarRepository`
+/// is the seam where `.toEntity()` runs. Splitting them is what lets a test fake
+/// the transport (`DollarApiRest` with a fake `HttpManager`) separately from
+/// faking the data (`IDollarRepository`).
+///
+/// Implementations throw `ApiException`, never a `DioException`: mapping the
+/// transport's own failures is the datasource's job, and
+/// `.agents/rules/test-coverage.md` requires a test for each of non-2xx,
+/// timeout and empty body.
 abstract class IDollarApi {
+  /// `GET`s the official rates and their effective date, unparsed into entities.
   Future<BcvCurrenciesModel> getCurrentBCVDollar();
 
+  /// `GET`s the parallel market rates, unparsed into entities.
   Future<List<CurrencyModel>> getCurrentDollar();
 }

--- a/lib/shared/data/datasource/dollar_api/dollar_api_rest.dart
+++ b/lib/shared/data/datasource/dollar_api/dollar_api_rest.dart
@@ -10,6 +10,16 @@ import '../../../../core/network/http_manager.dart';
 import '../../../../core/network/http_operation.dart';
 import '../../model/model.dart';
 
+/// [IDollarApi] over REST, through [HttpManager].
+///
+/// Builds the request from `DollarEndpoints`, deserialises with the models, and
+/// turns every transport failure into `ApiException` — nothing Dio-shaped leaves
+/// here.
+///
+/// The `HttpManager` is injectable for exactly one reason: it is what lets a test
+/// assert the **outgoing contract** — the path and the method actually sent — with a
+/// canned response and no network. `.agents/rules/test-coverage.md` requires that,
+/// plus a case each for non-2xx, timeout and empty body.
 class DollarApiRest implements IDollarApi {
   DollarApiRest({required String apiUrl, HttpManager? client})
     : _apiUrl = apiUrl,

--- a/lib/shared/data/model/bcv_currencies_model.dart
+++ b/lib/shared/data/model/bcv_currencies_model.dart
@@ -1,6 +1,12 @@
 import '../../domain/entities/bcv_currencies.dart';
 import 'currency_model.dart';
 
+/// Wire format of the official rates, and the seam back to `BcvCurrencies`.
+///
+/// **It extends the entity**, which is convenient and is also the trap: a model
+/// satisfies every signature that asks for an entity, so the compiler cannot
+/// tell you when one leaks upwards. [currencyModels] and [toEntity] exist
+/// precisely to make that conversion checkable — see their own comments.
 class BcvCurrenciesModel extends BcvCurrencies {
   BcvCurrenciesModel({
     required super.date,

--- a/lib/shared/data/model/currency_model.dart
+++ b/lib/shared/data/model/currency_model.dart
@@ -1,6 +1,18 @@
 import 'package:bcv_tracker_app/core/helpers/backend_date.dart';
 import 'package:bcv_tracker_app/shared/domain/entities/entities.dart';
 
+/// Wire format of one rate, and the seam back to [Currency].
+///
+/// Where the backend's shape is dealt with and then left behind: optional fields
+/// read with a fallback, `platform_img` empty strings turned into `null`, `num`
+/// widened to `double`, and dates normalised **once**. Nothing above the data layer
+/// should ever normalise something that came off the network.
+///
+/// It **extends the entity**, so a `CurrencyModel` satisfies every signature that
+/// asks for a `Currency` and the compiler cannot tell you when one leaks upward.
+/// `.toEntity()` is therefore mandatory even though returning `this` would compile
+/// — see `.agents/rules/entities-vs-models.md`, and the four places a new field has
+/// to touch.
 class CurrencyModel extends Currency {
   CurrencyModel({
     required super.name,

--- a/lib/shared/data/repositories/currency_repository.dart
+++ b/lib/shared/data/repositories/currency_repository.dart
@@ -7,18 +7,54 @@ import '../../domain/entities/entities.dart';
 import '../../domain/repositories/dollar_repositories.dart';
 import '../mapper/currency_normalizer.dart';
 
+/// The app's live exchange-rate state, shared by every feature.
+///
+/// A **`GetxService` registered `permanent`** in `initial_bindings.dart`, and the
+/// only place `Rx` rate state lives. Home, the converter and the detail sheet all
+/// observe this one instance rather than fetching for themselves, which is what
+/// keeps two screens from showing two different numbers for the same rate.
+///
+/// **Feature controllers do not expose these observables.** They read them and
+/// bridge changes with `ever(...) => update()`, so views use `GetBuilder` and
+/// never name an `Rx` type. That boundary is a retained decision — the audit
+/// proposed granular `Obx` and it was declined in
+/// [#60](https://github.com/Teixeira49/bcv_tracker_app/issues/60) — and its price
+/// is that **every worker must be disposed in `onClose`**
+/// ([#45](https://github.com/Teixeira49/bcv_tracker_app/issues/45)): `get` 4.7.3
+/// disposes none on its own, and this service outliving its observers means
+/// listeners otherwise accumulate on each `fenix` recreation.
+///
+/// See `.agents/skills/getx-architecture`.
 class CurrencyRepository extends GetxService {
   final IDollarRepository _dollarRepository = Get.find<IDollarRepository>();
 
+  /// Parallel market rates, one per market and currency.
+  ///
+  /// Starts as five [Currency.emptySkeletonizer] placeholders so the first frame
+  /// can draw a shimmering list the right shape. They are **not data** — check
+  /// [hasAverageData] before treating them as such, which is also why widget
+  /// tests clear these lists instead of letting the placeholder image resolve.
   final RxList<Currency> averageCurrencies = List.generate(
     5,
     (e) => Currency.emptySkeletonizer,
   ).obs;
+
+  /// Official BCV rates. Same placeholder contract as [averageCurrencies], with
+  /// [hasBcvData] as its flag.
   final RxList<Currency> bcvCurrencies = List.generate(
     5,
     (e) => Currency.emptySkeletonizer,
   ).obs;
+
+  /// Effective date the BCV reported, as published — empty until the first
+  /// successful refresh.
+  ///
+  /// Kept as the raw string for the reason `BcvCurrencies.date` explains: it
+  /// names a day for Venezuela, and converting it to a local `DateTime` moves it
+  /// a day west of Caracas.
   final RxString bcvCurrentDate = ''.obs;
+
+  /// Whether a refresh is in flight. Drives the shimmer and disables retry.
   final RxBool isLoading = false.obs;
 
   /// Detail of the last failed refresh, or `null` when the last one succeeded.
@@ -30,15 +66,33 @@ class CurrencyRepository extends GetxService {
 
   /// Whether each list already holds real rates. While `false` it still holds
   /// the `emptySkeletonizer` placeholders, which must not be shown as data.
+  ///
+  /// A flag rather than an `isEmpty` check, because the lists are **never**
+  /// empty: they start full of placeholders, so emptiness cannot distinguish
+  /// "still loading" from "loaded and genuinely nothing there".
   final RxBool hasAverageData = false.obs;
+
+  /// See [hasAverageData]; this is its counterpart for [bcvCurrencies].
   final RxBool hasBcvData = false.obs;
 
+  /// Kicks off the first fetch.
+  ///
+  /// `onReady` rather than `onInit` deliberately: it runs after the first frame,
+  /// so the shimmering placeholders are already on screen when the request
+  /// starts instead of the app opening on a blank panel.
   @override
   void onReady() {
     super.onReady();
     refreshData();
   }
 
+  /// Refetches both sides and republishes the state.
+  ///
+  /// **A partial failure is a real outcome, not an error.** The two requests hit
+  /// different upstream sources, so one can answer while the other is down; the
+  /// side that succeeded is published and [errorMessage] describes the side that
+  /// did not. Awaiting them together without `eagerError` is what makes that
+  /// possible — see the comment in the body.
   Future<void> refreshData() async {
     isLoading.value = true;
     try {

--- a/lib/shared/data/repositories/dollar_repositories.dart
+++ b/lib/shared/data/repositories/dollar_repositories.dart
@@ -3,7 +3,19 @@ import 'package:bcv_tracker_app/shared/data/datasource/dollar_api/dollar.dart';
 import 'package:bcv_tracker_app/shared/domain/entities/entities.dart';
 import 'package:bcv_tracker_app/shared/domain/repositories/repositories.dart';
 
+/// [IDollarRepository] over the REST datasource.
+///
+/// Two jobs, and nothing else: **convert models to entities**, so no object of
+/// the data layer escapes upwards (see `.agents/rules/entities-vs-models.md`),
+/// and **log the boundary** before letting the failure through.
+///
+/// It deliberately does not catch. The datasource has already turned transport
+/// problems into `ApiException`; swallowing one here would leave
+/// `CurrencyRepository` unable to tell a genuine empty market from a failed
+/// request, and the screen would show "no data" for what is really an outage.
 class DollarRepository implements IDollarRepository {
+  /// Takes the datasource it reads from. Resolved by the binding, never
+  /// constructed here — that is what makes it substitutable in tests.
   DollarRepository({required IDollarApi dollarApi}) : _dollarApi = dollarApi;
 
   final IDollarApi _dollarApi;

--- a/lib/shared/domain/entities/bcv_currencies.dart
+++ b/lib/shared/domain/entities/bcv_currencies.dart
@@ -1,10 +1,28 @@
 import 'currency.dart';
 
+/// The official rates, with the one date that applies to all of them.
+///
+/// A separate entity from a plain `List<Currency>` because the BCV publishes a
+/// **single effective date for the whole set**, not one per rate: it fixes a rate
+/// for a business day. Folding that date into each [Currency] would repeat it
+/// eight times and invite the four copies to drift.
+///
+/// Built from `BcvCurrenciesModel.toEntity()`.
 class BcvCurrencies {
   /// Effective date reported by the BCV. Optional in the backend contract
   /// (`BcvResponseData.date`): it is `null` when no platform date is stored yet.
+  ///
+  /// A **string**, not a `DateTime`, and deliberately so: it names a *day for
+  /// Venezuela*, not an instant. Parsing it to a local `DateTime` would move it
+  /// to the previous day for anyone west of Caracas, which is why
+  /// `CurrencyHelpers.parseDate` goes through `BackendDate.asPublished` and keeps
+  /// the wall clock.
   final String? date;
+
+  /// The official rates for [date] — the dollar, but also the euro, the yuan,
+  /// the lira and the rouble.
   final List<Currency> currencies;
 
+  /// Groups [currencies] under the [date] they are all effective on.
   BcvCurrencies({required this.date, required this.currencies});
 }

--- a/lib/shared/domain/entities/currency.dart
+++ b/lib/shared/domain/entities/currency.dart
@@ -1,13 +1,76 @@
+/// One exchange rate, as the app reasons about it.
+///
+/// The unit of the whole domain: Home lists these, the converter converts
+/// between two of them, and the detail sheet renders one. A rate is identified
+/// by **[keyName] + [platform]**, never by [keyName] alone — several markets
+/// quote the same currency at different prices, and matching on the code would
+/// silently pick whichever came first.
+///
+/// Built from `CurrencyModel.toEntity()`. Nothing in `features/` or in a
+/// controller should ever hold the model: see
+/// `.agents/rules/entities-vs-models.md` for the four places a new field has to
+/// touch, and why the compiler cannot catch that leak on its own.
 class Currency {
+  /// Human-readable name **as the source spells it**, in Spanish.
+  ///
+  /// Not for display on its own: the backend names rates in Spanish ("Dolar",
+  /// "Promedio"), so rendering this raw left the average tab untranslated in the
+  /// other nine languages. Go through `CurrencyHelpers.castCurrencyDisplayName`,
+  /// which falls back to this only for codes it does not know.
   final String name;
+
+  /// Code the source identifies the rate by — usually ISO 4217 (`USD`, `EUR`),
+  /// sometimes not.
+  ///
+  /// Exchange Monitor uses its own codes (`em`, `average`, `md`) even though all
+  /// of them quote the dollar, and the crypto markets quote `USDT`/`USDC`. Use
+  /// `CurrencyHelpers.castCurrencyDisplayCode` to show it, and
+  /// `Markets.dollarEquivalentCodes` to decide whether it counts as a dollar.
   final String keyName;
+
+  /// Market the rate comes from, verbatim from the backend
+  /// (`Banco Central de Venezuela`, `Binance`, `Yadio.io`…).
+  ///
+  /// Half of the identity of a rate, and what `CurrencyHelpers.isOfficialRate`
+  /// matches on. Compared against the constants in `Markets` rather than typed
+  /// literals, so a market renamed upstream fails visibly instead of quietly
+  /// changing category.
   final String platform;
+
+  /// Price in bolívares for one unit of this currency.
+  ///
+  /// **Can legitimately be `0.0`**: [empty] declares it, and the backend answers
+  /// with markets that have no data yet. Dividing by it does not throw in Dart —
+  /// it yields `Infinity`, or `NaN` when the dividend is zero too — so every
+  /// conversion goes through `CurrencyConversion`, which guards it.
   final double value;
+
+  /// Logo of the market, or `null` when the source publishes none.
+  ///
+  /// Optional in the contract, so it cannot be dereferenced. Also carries the
+  /// `placehold.co` placeholder while the first refresh is in flight, which is
+  /// why widget tests clear the skeleton lists instead of letting them resolve a
+  /// network image.
   final String? imgUrl;
+
+  /// When the source first published this rate, or `null` if it does not say.
+  ///
+  /// Absent from `bcv/with-memory`, so the detail sheet drops the row rather
+  /// than dashing it out.
   final DateTime? createDate;
+
+  /// When the rate was last refreshed, or `null` if the source does not say.
   final DateTime? updateDate;
+
+  /// Signed percentage change the source reports, or `null` when it reports none.
+  ///
+  /// `null` is **not** zero, and the difference matters on screen: `0%` reads as
+  /// "the rate held", while the absence means "nobody said". That is why
+  /// `CurrencyHelpers.castTendency` degrades to a placeholder instead.
   final double? tendency;
 
+  /// Creates a rate. `const` so [empty] and the fixtures can be compile-time
+  /// constants.
   const Currency({
     required this.name,
     required this.keyName,
@@ -41,6 +104,11 @@ class Currency {
     );
   }
 
+  /// A rate with nothing in it, for a slot that has no data and is not loading.
+  ///
+  /// Distinct from [emptySkeletonizer] on purpose: this one is **blank**, and
+  /// its `value: 0.00` is what makes `CurrencyConversion`'s guard reachable
+  /// through an ordinary path rather than only in tests.
   static const empty = Currency(
     name: '',
     platform: '',
@@ -50,6 +118,12 @@ class Currency {
     tendency: 0.00,
   );
 
+  /// A rate with plausible-looking content, to be covered by the shimmer while
+  /// the first request is in flight.
+  ///
+  /// Every field is filled — including the dates — because the skeleton draws
+  /// the **shape** of a loaded card, and a null date would collapse the row it
+  /// is meant to be standing in for. Not `const`: `DateTime.now()` is not.
   static final emptySkeletonizer = Currency(
     name: 'name',
     keyName: 'keyName',
@@ -61,6 +135,13 @@ class Currency {
     tendency: 1.0,
   );
 
+  /// The bolívar, and the axis every conversion turns on.
+  ///
+  /// The app converts through a pivot rather than between arbitrary pairs: every
+  /// rate the backend publishes is quoted **in bolívares**, so `USD → EUR` is
+  /// `USD → VES → EUR` and there is no cross-rate to invent. Its `value: 1.0` is
+  /// what makes the pivot disappear from the arithmetic. `ConverterController`
+  /// enforces that one side of the pair is always this.
   static final pivotCurrency = Currency(
     keyName: 'VES',
     name: 'Bolivares',

--- a/lib/shared/domain/entities/language.dart
+++ b/lib/shared/domain/entities/language.dart
@@ -1,9 +1,38 @@
-// Puedes poner esta clase en un archivo de modelos o al principio del archivo de la página de ajustes.
+/// One entry of the language selector in Settings.
+///
+/// A presentation-shaped entity: the app ships ten translations and this is how
+/// each is offered. Deliberately **not** derived from `AppTranslations.keys` —
+/// [name] and [flag] are copy for the user, and a locale code cannot produce
+/// either. `SettingsController.languageOptions` holds the list.
 class LanguageOption {
-  final String code; // ej: 'es', 'en'
-  final String name; // ej: 'Español', 'English'
-  final String flag; // ej: '🇪🇸', '🇬🇧' (emoji) o una ruta a un asset
+  /// Store-shaped locale code, `xx_YY`, matching a key `AppTranslations`
+  /// registers **exactly**.
+  ///
+  /// Exactness matters: it is what lets
+  /// `SettingsController.resolveDeviceLanguage` answer "does the device's locale
+  /// match a language we publish?" by comparison. Two of these used to be
+  /// invalid (`en_EN`, `ja_JA`) and only worked because GetX falls back on the
+  /// language code alone — corrected in
+  /// [#98](https://github.com/Teixeira49/bcv_tracker_app/issues/98), which also
+  /// added the migration for installs that had stored the old ones.
+  final String code;
 
+  /// The language's name **in that language** ("Español", "日本語").
+  ///
+  /// Never translated: someone looking for their own language scans for the word
+  /// they know, not for its name in a language they cannot read.
+  final String name;
+
+  /// Flag emoji shown beside [name].
+  ///
+  /// An emoji rather than an asset, so it needs no file per language and picks up
+  /// the platform's own rendering. Typed as `String` for that reason.
+  final String flag;
+
+  /// Creates an option. `const` so `SettingsController.defaultLanguage` can be a
+  /// compile-time constant and therefore identical by reference — which
+  /// `DropdownButtonFormField` relies on, since this class does not override
+  /// `==`.
   const LanguageOption({
     required this.code,
     required this.name,

--- a/lib/shared/domain/repositories/dollar_repositories.dart
+++ b/lib/shared/domain/repositories/dollar_repositories.dart
@@ -1,7 +1,29 @@
 import '../entities/entities.dart';
 
+/// What the app needs from a source of exchange rates.
+///
+/// The boundary between the domain and the network: everything above this
+/// depends on the interface, and `DollarRepository` is registered against it in
+/// `initial_bindings.dart` — which is what lets tests inject a fake with
+/// `Get.put<IDollarRepository>(...)` and never touch the network.
+///
+/// **Two methods and not one** because the two sides of the app are two
+/// requests: the official rates arrive with a shared effective date
+/// ([BcvCurrencies]) and the parallel ones do not. Merging them here would mean
+/// inventing a date for the markets that publish none.
+///
+/// Implementations return **entities and throw `ApiException`**. A `DioException`
+/// must never cross this line: the layers above have no business knowing which
+/// HTTP client fetched the data.
 abstract class IDollarRepository {
+  /// The official rates and the day they are effective on.
+  ///
+  /// Throws `ApiException` on a non-2xx, a timeout or an unparseable body.
   Future<BcvCurrencies> getCurrentBCVDollar();
 
+  /// The parallel market rates, one per market and currency.
+  ///
+  /// Already normalised by `CurrencyNormalizer`, so duplicates are merged and
+  /// markets the app does not list are dropped. Throws `ApiException` on failure.
   Future<List<Currency>> getCurrentDollar();
 }

--- a/lib/shared/presentation/widgets/base_bottom_sheet.dart
+++ b/lib/shared/presentation/widgets/base_bottom_sheet.dart
@@ -7,8 +7,8 @@ import '../../../core/i18n/app_messages.dart';
 
 /// Container of the app's draggable bottom sheets.
 ///
-/// Introduced with the currency detail ([#38]) and extracted here when the
-/// converter's currency selector moved to the same shape ([#40]) — the issue
+/// Introduced with the currency detail ([#38](https://github.com/Teixeira49/bcv_tracker_app/issues/38)) and extracted here when the
+/// converter's currency selector moved to the same shape ([#40](https://github.com/Teixeira49/bcv_tracker_app/issues/40)) — the issue
 /// itself asked for the container to be shared if the two ended up alike, and
 /// they did. `BaseModal` (an `AlertDialog`) stays for the centred dialogs:
 /// this is not a replacement for it, it is the other half of the pair.
@@ -40,7 +40,7 @@ import '../../../core/i18n/app_messages.dart';
 /// keyboard and the extents below are fractions of the height that is left.
 /// **Do not add that padding again** — it would apply twice and leave a gap the
 /// height of the keyboard. A sheet that opens with a field focused (the search
-/// of [#41]) will want a larger [initialExtent], since that fraction is taken
+/// of [#41](https://github.com/Teixeira49/bcv_tracker_app/issues/41)) will want a larger [initialExtent], since that fraction is taken
 /// from the reduced height.
 class BaseBottomSheet extends StatelessWidget {
   const BaseBottomSheet({

--- a/lib/shared/presentation/widgets/base_layout.dart
+++ b/lib/shared/presentation/widgets/base_layout.dart
@@ -7,11 +7,30 @@ import '../../../config/theme/colors/colors_values.dart';
 import '../../../config/theme/icons/icons_constants.dart';
 import '../../../features/settings/presentation/page/settings_modal.dart';
 
+/// The branded frame every top-level screen sits in.
+///
+/// Draws the dark strip with the logo, the title and the settings button, and
+/// hosts [child] underneath. Screens compose this rather than each building their
+/// own `Scaffold`, which is what keeps the strip identical between Home and the
+/// converter.
+///
+/// It measures against its own **box**, not the screen. That is not incidental:
+/// against `MediaQuery` the title kept its absolute offset while the body shrank
+/// under the keyboard, and ended up clipped behind the panel.
 class BaseLayout extends StatelessWidget {
+  /// Content below the branded strip. Null renders the frame alone, which is what
+  /// the splash and the error page want.
   final Widget? child;
+
+  /// Heading inside the strip. Must come from `AppMessages`
+  /// (`.agents/rules/i18n-convention.md`).
   final String? title;
+
+  /// Insets applied to [child], so each screen decides its own gutter without
+  /// touching the frame.
   final EdgeInsetsGeometry margins;
 
+  /// Wraps [child] in the branded frame.
   const BaseLayout({super.key, this.child, required this.margins, this.title});
 
   /// Where the title sits inside the branded strip, as a share of the height.

--- a/lib/shared/presentation/widgets/base_modal.dart
+++ b/lib/shared/presentation/widgets/base_modal.dart
@@ -3,7 +3,15 @@ import 'package:get/get.dart';
 
 import '../../../config/theme/colors/colors_values.dart';
 
+/// A centred dialog in the app's dressing.
+///
+/// The **centred** half of the modal story: use this for a short, self-contained
+/// choice like Settings, and `BaseBottomSheet` for anything that scrolls or that
+/// belongs to something the user tapped. `DESIGN.md` states which applies where.
+/// Opened through `showBlurredDialog`, never `Get.dialog` by hand, and closed
+/// with `Get.back()`.
 class BaseModal extends StatelessWidget {
+  /// Builds the dialog around [child].
   const BaseModal({
     super.key,
     required this.title,

--- a/lib/shared/presentation/widgets/custom_badged.dart
+++ b/lib/shared/presentation/widgets/custom_badged.dart
@@ -1,6 +1,11 @@
 import 'package:flutter/material.dart';
 
+/// A rounded, coloured pill around [child].
+///
+/// The app's one badge shape. Used for the variation indicator and the rate-type
+/// label, so those two cannot drift apart in radius or padding.
 class CustomBadged extends StatelessWidget {
+  /// Wraps [child] in a pill of [color].
   const CustomBadged({
     super.key,
     required this.child,
@@ -27,7 +32,13 @@ class CustomBadged extends StatelessWidget {
   );
 }
 
+/// [CustomBadged] that responds to a tap.
+///
+/// A separate class rather than a nullable `onTap` on [CustomBadged]: a pill that
+/// might be tappable is a pill whose ink and semantics are conditional, and the
+/// two read very differently to assistive tech.
 class CustomBadgedButton extends StatelessWidget {
+  /// Wraps [child] in a tappable pill of [color].
   const CustomBadgedButton({
     super.key,
     required this.child,

--- a/lib/shared/presentation/widgets/custom_bottom_navigator_bar.dart
+++ b/lib/shared/presentation/widgets/custom_bottom_navigator_bar.dart
@@ -6,7 +6,19 @@ import 'package:get/get.dart';
 import '../../../config/theme/colors/colors_values.dart';
 import '../../../navigation/navigation_controller.dart';
 
+/// The app's bottom tab bar.
+///
+/// **Kept as a custom component on purpose.** It is not a `BottomNavigationBar`,
+/// so the Material 3 migration
+/// ([#44](https://github.com/Teixeira49/bcv_tracker_app/issues/44)) left it alone
+/// and its colours still come from `ColorValues` rather than from
+/// `Theme.of(context).colorScheme`.
+///
+/// It **switches tabs, it does not navigate**: tapping moves
+/// `NavigationController.selectedIndex`, and `DashboardPage` keeps both pages
+/// alive in an `IndexedStack`. See `.agents/rules/navigation-convention.md`.
 class CustomBottomNavigatorBar extends StatelessWidget {
+  /// Builds the bar for [pageButtons], driven by [navigationController].
   const CustomBottomNavigatorBar({
     super.key,
     required this.navigationController,
@@ -109,9 +121,15 @@ class _CustomBottomNavigatorItem extends StatelessWidget {
   );
 }
 
+/// The sliding indicator above the selected tab.
+///
+/// Public only because it is built from the item widget; nothing outside this file
+/// should need it.
 class AnimatedBar extends StatelessWidget {
+  /// Draws the indicator, expanded when [isActive].
   const AnimatedBar({super.key, required this.isActive});
 
+  /// Whether this is the selected tab.
   final bool isActive;
 
   @override

--- a/lib/shared/presentation/widgets/custom_refresh_indicator.dart
+++ b/lib/shared/presentation/widgets/custom_refresh_indicator.dart
@@ -1,9 +1,25 @@
 import 'package:bcv_tracker_app/config/theme/colors/colors_values.dart';
 import 'package:flutter/material.dart';
 
-enum CustomRefreshIndicatorType { classic, adaptive, noSpinner }
+/// Which pull-to-refresh affordance [CustomRefreshIndicator] draws.
+enum CustomRefreshIndicatorType {
+  /// Material's own spinner.
+  classic,
 
+  /// The platform's spinner — Material on Android, Cupertino on iOS.
+  adaptive,
+
+  /// No spinner at all: the gesture still refreshes, but the screen shows its own
+  /// loading state instead. Used where a shimmer is already saying it.
+  noSpinner,
+}
+
+/// Pull-to-refresh in one place, with a choice of affordance.
+///
+/// Wraps the platform indicators so [indicatorType] is the only decision a screen
+/// makes, and so `onRefresh` has one signature across the app.
 class CustomRefreshIndicator extends StatelessWidget {
+  /// Wraps [child] in a refresh gesture that calls `onRefresh`.
   const CustomRefreshIndicator({
     required this.onRefresh,
     required this.child,

--- a/lib/shared/presentation/widgets/custom_skeletonizer.dart
+++ b/lib/shared/presentation/widgets/custom_skeletonizer.dart
@@ -3,7 +3,14 @@ import 'package:skeletonizer/skeletonizer.dart';
 
 import '../../../config/theme/colors/colors_values.dart';
 
+/// Shimmer placeholder in the brand's colours.
+///
+/// Wraps `skeletonizer` so the shimmer is one decision instead of a per-screen
+/// choice of greys. Its input is a **real widget tree filled with placeholder
+/// data** — `Currency.emptySkeletonizer`, not empty strings — because the shimmer
+/// traces the shape of what is coming, and a blank field collapses to nothing.
 class CustomSkeletonizer extends StatelessWidget {
+  /// Shimmers [child] while [isLoading]; renders it untouched otherwise.
   const CustomSkeletonizer({
     super.key,
     required this.isLoading,

--- a/lib/shared/presentation/widgets/performance_indicator_widget.dart
+++ b/lib/shared/presentation/widgets/performance_indicator_widget.dart
@@ -3,9 +3,21 @@ import 'package:flutter/material.dart';
 
 import 'custom_badged.dart';
 
+/// The signed percentage badge on a rate — an arrow, a figure and a colour.
+///
+/// Only rendered when the source actually reported a change: a rate whose
+/// `tendency` is `null` shows **no badge at all**, because `0%` reads as "the rate
+/// held" and that is a claim the source did not make. Callers decide; this widget
+/// takes a non-null [value].
+///
+/// Guarded by a golden test in light and dark, since the three states are colour
+/// decisions.
 class PerformanceIndicatorWidget extends StatelessWidget {
+  /// The change to show, as a percentage. Zero renders the neutral state, which is
+  /// a real answer — not the same as an absent one.
   final double value;
 
+  /// Shows [value] as a badge.
   const PerformanceIndicatorWidget({super.key, required this.value});
 
   @override


### PR DESCRIPTION
# Descripción

`DTA-039`. La documentación en el código estaba desigual: **31 de 75 tipos públicos** tenían docstring, y capas enteras no tenían ninguno. Ahora los 75 lo tienen, siguiendo la norma que ya estaba escrita en [`documentation-convention.md`](.agents/rules/documentation-convention.md) — **explicar la decisión, no la línea**: por qué el campo es opcional, qué contrato del backend se respeta, qué pasa si el dato no llega.

## Por capas, en el orden que pide el issue

1. **Entidades de dominio.** Los campos llevan su contrato: por qué `Currency.value` puede ser legítimamente `0.0` y qué implica al dividir (en Dart no lanza: da `Infinity`, o `NaN`), por qué `tendency == null` **no es** `0%`, por qué una tasa se identifica por `keyName + platform` y nunca por el código solo. Y qué hace cada una de las tres constantes estáticas: `empty`, `emptySkeletonizer` y `pivotCurrency` son tres porque responden a tres preguntas distintas, y sin eso escrito la siguiente persona añade una cuarta.
2. **Repositorios y datasources.** Lo interesante de esta capa es la **frontera que cada uno sostiene**: ninguna `DioException` por encima del datasource, ningún modelo por encima de `DollarRepository`. Y por qué `.toEntity()` es obligatorio aunque devolver `this` compilaría — el modelo extiende la entidad, así que el compilador no puede avisarte.
3. **Controladores y servicios GetX.** Los invariantes: la regla pivote y por qué `selectCurrency` mueve el *otro* lado a VES en vez de rechazar la elección; por qué la pareja del conversor sobrevive entre visitas a la pestaña; y el puente `ever → update()`, cuyo precio es que un worker olvidado hace que una pantalla **deje de refrescarse en silencio**.
4. **Widgets compartidos.** Cuál de los dos contenedores de modal aplica y por qué, por qué la barra inferior sigue siendo un componente propio tras Material 3, y por qué el shimmer recibe un árbol con datos de relleno en vez de campos vacíos.

## La mitad más útil de este PR es la que **no** documenta nada

Tres archivos concentran **170 de los 303** miembros públicos sin docstring: `ColorValues` (77 accesores de color), `AppMessages` (76 getters de i18n) y `AppIcons` (17 rutas de asset).

Un comentario sobre `textWhite` que diga «el color blanco del texto» es exactamente lo que la regla del proyecto manda no escribir: ruido que tapa las líneas que sí importan. Así que esas clases llevan un docstring **a nivel de clase**, y ninguno en sus miembros:

- `ColorValues` explica la **separación en dos capas** (`AppColors` son los valores crudos, esto resuelve el shade por tema) y por qué sigue siendo la fuente para los widgets propios incluso después de Material 3.
- `AppMessages` explica que es **el único archivo que llama a `.tr`**, y la regla de los diez idiomas: si falta uno, GetX pinta la clave cruda y nada falla.
- `AppIcons` explica por qué centralizar rutas: una ruta mal escrita es un fallo **en runtime**, no de compilación.

**Nombrarlo como decisión es lo que evita que alguien «termine el trabajo» más adelante.**

### Por eso `public_member_api_docs` se queda **apagado**

Activarlo forzaría esos 170 comentarios. Y como `flutter analyze` es fatal en CI, no sería un aviso con el que se pueda convivir: sería un build roto hasta escribirlos todos. La convención ahora lo dice explícitamente y da el comando para medir cuando haga falta, en vez de imponerlo.

## La convención, escrita para una persona

`CONTRIBUTING.md` gana la sección **📝 Documentación del Código** — el criterio pedía README o CONTRIBUTING, y ahí ya había una línea que apuntaba a la regla agéntica. Lleva: qué documentar por tipo de símbolo, **qué no**, el estilo (incluida la trampa de `[Corchetes]` con símbolos no importados), y dos comandos para medir cobertura.

> **Los dos comandos se ejecutaron antes de escribirlos.** Y hizo falta: la primera versión del de la lint añadía un segundo bloque `linter:` al final del YAML. El analizador se queda con **una** de las dos claves, así que el lint no se aplicaba y el comando respondía `0` — es decir, «todo está documentado» cuando faltaban 303. La versión corregida inserta dentro del bloque `rules:` que ya existe, y la guía advierte de la trampa junto al comando.

## `dart doc` a 0 avisos

El criterio opcional queda cumplido: **de 8 avisos a 0**. Siete eran referencias `[#N]` a issues, que dartdoc intenta resolver como símbolos y nunca puede — ahora son enlaces markdown, así que siguen siendo clicables y además llevan a GitHub. El octavo era un `[kind]` que nombraba el parámetro de otra función.

Es el **único cambio que no es un comentario** en todo el PR.

No hay dependencias nuevas ni variables de entorno nuevas. No se renombró nada, no se movió nada y no se tocó ninguna lógica.

Issue de GitHub relacionado: Closes #4

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad (cambio no-breaking que agrega funcionalidad)
- [ ] 🛠️ Corrección de errores (cambio no-breaking que arregla un error)
- [ ] ❌ Cambio importante (arreglo o característica que haría que la funcionalidad existente no funcionara como se esperaba)
- [x] 📝 Actualización de la documentación
- [ ] 🧹 Code refactoring (modificación de la estructura interna del código sin modificar las APIs)
- [ ] ✅ Build configuration change (modificación de los archivos para hacer deploy)
- [ ] 🗑️ Chore (actividades que no modifican la interacción con la app, por ejemplo, modificar el archivo de lints)

## ¿Cómo se ha probado esto?

- [x] **`flutter analyze` limpio** y **337 tests en verde**, goldens incluidos. Nada podía romperse: el diff son comentarios, salvo las referencias de doc.
- [x] **Cobertura de tipos al 100 %** — `75/75`, comprobado con el script que queda en `CONTRIBUTING.md`, ejecutado **verbatim** desde ahí.
- [x] **El comando de la lint, ejecutado en las dos formas.** La incorrecta (append de `linter:`) devuelve `0`; la correcta devuelve 303 con el desglose por archivo. Es lo que destapó el error de la guía.
- [x] **`dart doc .` → `Found 0 warnings and 0 errors`**, 81 librerías. `doc/api/` se borró después y está en `.gitignore`, así que no entra al repo.
- [x] `dart format .` sin cambios pendientes.

**Configuración de prueba**: macOS, Flutter 3.38.3 (la versión fijada). Sin dispositivo: no hay nada que ver en pantalla, el cambio es documentación.

### Lo que decidí no hacer, y por qué

Merece revisión explícita, porque es una lectura del alcance y no un olvido:

1. **No documenté los 303 miembros públicos**, solo los que llevan un contrato. Los 170 de los tres registros mecánicos están cubiertos por el docstring de su clase. La alternativa habría sido cumplir la letra del criterio produciendo ruido que la propia regla del repo prohíbe.
2. **No activé la lint**, por lo dicho arriba. Si prefieres que se active y se escriban los 170, es un PR aparte y conviene decidirlo a la vista de este.
3. **No toqué `countryName` de `CurrencyCountry`**, que está hardcodeado en español y no pasa por `AppMessages`. Lo **documenté como la laguna que es** en vez de arreglarlo: el issue excluye tocar lógica, y añadir cinco claves de i18n en diez idiomas no es un cambio de documentación. Queda señalado para su propio issue.

## Lista de Verificación

- [x] He agregado las nuevas dependencias (`pubspec.yaml`) en la descripción — no hay
- [x] He agregado las nuevas variables de entorno (solo los nombres) a la descripción — no hay
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código — y encontré el comando roto de la guía haciéndola
- [x] He comentado mi código, particularmente en áreas difíciles de entender — es literalmente el objeto del PR
- [x] He realizado los cambios correspondientes a la documentación — `CONTRIBUTING.md`
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente con mis cambios
- [ ] La app compila y el flujo afectado se probó en un dispositivo o emulador real — **no aplica**: no hay flujo afectado, el diff son comentarios
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas — no hay copy nueva
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper de cálculo, incluí sus tests en este mismo PR — no cambió ninguna lógica, así que la suite existente es la verificación
- [x] No introduje modelos (`shared/data/model/`) en la UI ni en los controladores
