### PR TITLE
[📝 Doc: DTA-040] - Regla de cobertura que no puede retroceder

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -83,6 +83,7 @@ Reglas que el asistente debe respetar. Cada archivo lleva un `description` en el
 | [`environment-variables.md`](rules/environment-variables.md) | Sincroniza `Environment`, `.env.example`, README y `codemagic.yaml` al tocar variables de entorno |
 | [`test-coverage.md`](rules/test-coverage.md) | Toda fuente, endpoint, controlador o helper de cálculo nace con sus tests en el mismo PR |
 | [`documentation-convention.md`](rules/documentation-convention.md) | Todo lo público nace documentado con dartdoc, explicando el porqué y no el qué |
+| [`documentation-coverage.md`](rules/documentation-coverage.md) | El nivel que no puede retroceder: 75/75 tipos, cero avisos de `dart doc`, y las tres exenciones declaradas |
 | [`logging-convention.md`](rules/logging-convention.md) | Todo pasa por `AppLogger` con niveles; cada `catch` de un límite registra su causa; en release nada sensible ni URLs en crudo |
 | [`design-system.md`](rules/design-system.md) | `DESIGN.md` es la fuente de verdad visual; un token nuevo se declara ahí primero y luego en `config/theme/`; verificar en claro y oscuro |
 

--- a/.agents/rules/documentation-coverage.md
+++ b/.agents/rules/documentation-coverage.md
@@ -1,0 +1,101 @@
+---
+description: El nivel de documentación que no puede retroceder — invariante medible de cobertura de dartdoc en lib/, dónde es más estricto, qué está exento y por qué, y qué hacer al añadir o modificar código. Aplica al tocar cualquier .dart de lib/.
+paths:
+  - "lib/**/*.dart"
+  - "analysis_options.yaml"
+  - "CONTRIBUTING.md"
+---
+
+# Cobertura de Documentación
+
+`documentation-convention.md` dice **cómo** se escribe un docstring y **qué no** documentar. Esta dice **qué no se puede perder**. La relación entre las dos es la misma que hay entre una guía de estilo de tests y [`test-coverage.md`](test-coverage.md): una describe la forma, la otra el mínimo exigible.
+
+El riesgo concreto que evita es el que la propia convención ya nombra, y que un pase de documentación no arregla por sí solo:
+
+> una clase nueva que se agrega **después** de un pase de documentación queda con lagunas, y la próxima persona que la toque —o el próximo agente— repite el error que el comentario ausente habría evitado.
+
+Nada del tooling lo impide. Una clase sin docstring compila, `flutter analyze` sigue limpio y CI sigue verde. La única cosa que sostiene el nivel es esta regla, aplicada en la revisión.
+
+## El invariante
+
+[#4](https://github.com/Teixeira49/bcv_tracker_app/issues/4) llevó `lib/` de 31 de 75 tipos públicos documentados a **75 de 75**, y `dart doc` de 8 avisos a **0**. Eso es el suelo, no el techo:
+
+| Ámbito | Exigencia | Estado |
+|---|---|---|
+| **Todo `lib/`** | Cada **tipo** público (`class`, `mixin`, `enum`, `extension`, `typedef`) con docstring | 75/75 |
+| **`shared/domain/` y `shared/data/`** | Además, cada **miembro** público con docstring | 0 huecos |
+| **Todo `lib/`** | `dart doc` sin avisos ni errores | 0 avisos |
+
+Las capas de contrato son más estrictas porque es donde un dato sin documentar cuesta de verdad: un campo que el backend declara opcional y que alguien desreferencia, una normalización que se repite porque nadie sabía que ya estaba hecha, un `.toEntity()` que parece redundante y no lo es.
+
+**Si tu cambio baja cualquiera de esas tres cifras, está incompleto.**
+
+## Exenciones, declaradas aquí y en ningún otro sitio
+
+Tres clases están **exentas a nivel de miembro**, a propósito:
+
+| Clase | Miembros | Por qué |
+|---|---|---|
+| `ColorValues` | 77 accesores de color | El nombre *es* la documentación |
+| `AppMessages` | 76 getters de i18n | Idem: la clave y el getter son la misma palabra |
+| `AppIcons` | 17 rutas de asset | Idem |
+
+Son **170 de los 303** miembros públicos sin docstring del proyecto. Comentarlos uno a uno produciría exactamente el ruido que `documentation-convention.md` prohíbe (`/// El color blanco del texto` sobre `textWhite`), y ese ruido tapa las líneas que sí informan.
+
+Lo que estas tres clases llevan es un docstring **de clase** que explica el registro completo: la separación en dos capas del color, la regla de los diez idiomas, por qué centralizar rutas de asset. Eso es lo que hay que mantener al día.
+
+> ⚠️ **La exención no es una invitación a ampliarla.** Vale para un registro mecánico —muchos miembros, todos del mismo tipo, cada nombre autoexplicativo— y para nada más. Un miembro que encierra una decisión, un borde o un contrato del backend se documenta, esté donde esté. Si crees que tu caso es una cuarta exención, la discusión va en la PR, y esta tabla se amplía en el mismo commit o no se amplía.
+
+### Por eso `public_member_api_docs` está apagado
+
+Activar el lint forzaría esos 170 comentarios. Y como CI corre `flutter analyze` **sin** `--no-fatal-*`, no sería un aviso con el que se pueda convivir: sería el build roto hasta escribirlos todos. La decisión se tomó en #4 y se mantiene.
+
+El lint sigue siendo la mejor forma de **medir**. Cómo activarlo un momento sin dejarlo puesto, y la trampa del YAML que hace que reporte `0` cuando en realidad no se aplicó, está en [`CONTRIBUTING.md`](../../CONTRIBUTING.md#-documentación-del-código) — no se repite aquí para que haya un solo sitio que actualizar.
+
+## Cuándo aplica, y qué hacer
+
+### 1. Añades un tipo público
+Lleva docstring **en el mismo commit**. Una línea de qué representa y qué papel juega en su capa; un párrafo más si encierra una decisión. Si está en `shared/domain/` o `shared/data/`, también cada miembro público.
+
+### 2. Añades un miembro público a un tipo de las capas de contrato
+Lleva docstring. Para una entidad, lo que hay que decir casi nunca es qué contiene el campo —eso lo dice el nombre— sino **qué pasa cuando no está**: por qué es opcional en el contrato, qué se muestra en su lugar, qué no se puede desreferenciar.
+
+### 3. Cambias lo que hace un símbolo ya documentado
+**Su docstring entra en el mismo diff.** Esto es la mitad de la regla y la que ningún script puede medir: un comentario que describe el comportamiento anterior **miente con autoridad**, y es peor que la ausencia — quien lo lee no vuelve a comprobar el código.
+
+Señales de que un docstring quedó rancio:
+
+- Nombra un símbolo que renombraste o borraste.
+- Explica un caso borde que tu cambio eliminó, o calla uno que introdujo.
+- Cita un issue como pendiente cuando ya se cerró (o al revés).
+- Da un número —«los diez idiomas», «75 claves», «dos secciones»— que tu cambio movió.
+
+### 4. Borras código
+Borra su docstring con él, y comprueba que ningún otro lo referencia con `[Corchetes]`: `dart doc` avisa de la referencia huérfana, y el invariante de cero avisos es lo que hace que ese aviso se vea.
+
+### 5. Mueves o renombras un tipo
+Las referencias `[Corchetes]` de otros archivos solo resuelven si el símbolo está importado ahí. Al mover algo, `dart doc` es lo que dice qué se rompió.
+
+## Verificación
+
+```bash
+flutter analyze     # limpio
+flutter test        # verde
+dart doc .          # "Found 0 warnings and 0 errors."
+```
+
+Y la cobertura de tipos, que es el número que no puede bajar de 75/75 — el script está en [`CONTRIBUTING.md`](../../CONTRIBUTING.md#medir-la-cobertura), junto al de miembros.
+
+`dart doc` escribe en `doc/api/`, que está gitignored: bórralo después si te molesta, pero no lo commitees.
+
+## Lo que esta regla **no** tiene
+
+**No hay nada que haga fallar la PR por una cobertura que baje.** Se evaluó un test en `test/` —el patrón que `translation_parity_test.dart` ya usa para la paridad de i18n, que sí falla el build— y se decidió dejar esta regla como documento por ahora.
+
+Conviene ser honesto sobre lo que eso implica: el invariante de arriba lo sostiene **la revisión de la PR**, no el tooling. Si empieza a retroceder, la respuesta no es reescribir esta regla con más énfasis, es convertirla en un test.
+
+## Relación con las otras reglas
+
+- [`documentation-convention.md`](documentation-convention.md) — **cómo** se escribe: el tono, el checklist por tipo de cambio, y la lista de lo que no se documenta. Esta regla es su contraparte cuantitativa.
+- [`test-coverage.md`](test-coverage.md) — la misma idea aplicada a los tests, y el modelo del que esta regla toma la forma.
+- [`entities-vs-models.md`](entities-vs-models.md) — los cuatro puntos que toca un campo nuevo. El paso 1 y el 2 incluyen su docstring; esta regla es lo que lo exige.

--- a/.claude/rules/documentation-coverage.md
+++ b/.claude/rules/documentation-coverage.md
@@ -1,0 +1,1 @@
+../../.agents/rules/documentation-coverage.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ BCV Tracker is a Flutter mobile app that displays real-time Venezuelan Central B
 
 This file is the **map** of the codebase; `.agents/rules/` holds the **binding conventions**. When they disagree, the rules win — and the contradiction gets fixed in the same PR.
 
-`.agents/` is the single source. `.claude/rules/` and `.claude/skills/` are symlinks into it, so Claude Code discovers both natively and no file exists twice. **How each loads differs, and it matters:** four rules are always in context, fourteen load only when you touch the files they govern, and skills load on demand from their description. If you are about to do something a path-scoped rule covers and it has not loaded, open it.
+`.agents/` is the single source. `.claude/rules/` and `.claude/skills/` are symlinks into it, so Claude Code discovers both natively and no file exists twice. **How each loads differs, and it matters:** four rules are always in context, fifteen load only when you touch the files they govern, and skills load on demand from their description. If you are about to do something a path-scoped rule covers and it has not loaded, open it.
 
 ### Always in context — the git and GitHub procedures
 
@@ -39,6 +39,7 @@ No file edit can trigger these, so they are unconditional. Shared verbatim with 
 | `.agents/rules/environment-variables.md` | `config/enviroment/`, `.env.example`, `codemagic.yaml`, `README.md` |
 | `.agents/rules/test-coverage.md` | `test/`, `shared/data/`, any `controller/`, `core/helpers/` |
 | `.agents/rules/documentation-convention.md` | any `.dart` under `lib/` |
+| `.agents/rules/documentation-coverage.md` | any `.dart` under `lib/`, `analysis_options.yaml`, `CONTRIBUTING.md` |
 | `.agents/rules/version-sources.md` | `pubspec.yaml`, `android/`, `ios/`, `codemagic.yaml` |
 | `.agents/rules/release-versioning.md` | `pubspec.yaml`, `CHANGELOG.md`, `docs/release/` |
 | `.agents/rules/version-value-proposal.md` | `pubspec.yaml`, `CHANGELOG.md`, `docs/release/` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ BCV Tracker is a Flutter mobile app that displays real-time Venezuelan Central B
 
 This file is the **map** of the codebase; `.agents/rules/` holds the **binding conventions**. When they disagree, the rules win — and the contradiction gets fixed in the same PR.
 
-`.agents/` is the single source. `.claude/rules/` and `.claude/skills/` are symlinks into it, so Claude Code discovers both natively and no file exists twice. **How each loads differs, and it matters:** four rules are always in context, fourteen load only when you touch the files they govern, and skills load on demand from their description. If you are about to do something a path-scoped rule covers and it has not loaded, open it.
+`.agents/` is the single source. `.claude/rules/` and `.claude/skills/` are symlinks into it, so Claude Code discovers both natively and no file exists twice. **How each loads differs, and it matters:** four rules are always in context, fifteen load only when you touch the files they govern, and skills load on demand from their description. If you are about to do something a path-scoped rule covers and it has not loaded, open it.
 
 ### Always in context — the git and GitHub procedures
 
@@ -39,6 +39,7 @@ No file edit can trigger these, so they are unconditional. Shared verbatim with 
 | `.agents/rules/environment-variables.md` | `config/enviroment/`, `.env.example`, `codemagic.yaml`, `README.md` |
 | `.agents/rules/test-coverage.md` | `test/`, `shared/data/`, any `controller/`, `core/helpers/` |
 | `.agents/rules/documentation-convention.md` | any `.dart` under `lib/` |
+| `.agents/rules/documentation-coverage.md` | any `.dart` under `lib/`, `analysis_options.yaml`, `CONTRIBUTING.md` |
 | `.agents/rules/version-sources.md` | `pubspec.yaml`, `android/`, `ios/`, `codemagic.yaml` |
 | `.agents/rules/release-versioning.md` | `pubspec.yaml`, `CHANGELOG.md`, `docs/release/` |
 | `.agents/rules/version-value-proposal.md` | `pubspec.yaml`, `CHANGELOG.md`, `docs/release/` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,14 @@ flutter test
 
 ## 📝 Documentación del Código
 
-Todo `lib/` se documenta con **dartdoc** (`///`). La norma del proyecto no es «describir lo que hace la línea» sino **explicar la decisión**: por qué el campo es opcional, qué contrato del backend se respeta, qué pasa si el dato no llega. La regla completa, con el checklist por tipo de cambio, está en [`documentation-convention.md`](.agents/rules/documentation-convention.md); esto es lo que hay que saber para escribir la primera.
+Todo `lib/` se documenta con **dartdoc** (`///`). La norma del proyecto no es «describir lo que hace la línea» sino **explicar la decisión**: por qué el campo es opcional, qué contrato del backend se respeta, qué pasa si el dato no llega. Esto es lo que hay que saber para escribir la primera; las dos reglas completas son:
+
+| Regla | Responde a |
+|---|---|
+| [`documentation-convention.md`](.agents/rules/documentation-convention.md) | **Cómo** se escribe, con el checklist por tipo de cambio |
+| [`documentation-coverage.md`](.agents/rules/documentation-coverage.md) | **Qué no se puede perder**: el invariante, dónde es más estricto, y las exenciones |
+
+El invariante, en una línea: **cada tipo público de `lib/` lleva docstring** (75/75 hoy), en `shared/domain/` y `shared/data/` **cada miembro público también**, y `dart doc` no reporta avisos. Si tu cambio baja cualquiera de esas tres cifras, está incompleto — y si cambias lo que hace un símbolo ya documentado, **su docstring entra en el mismo diff**: un comentario que describe el comportamiento anterior miente con autoridad, y es peor que ninguno.
 
 ### Qué documentar
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,90 @@ flutter test
 
 ---
 
+## 📝 Documentación del Código
+
+Todo `lib/` se documenta con **dartdoc** (`///`). La norma del proyecto no es «describir lo que hace la línea» sino **explicar la decisión**: por qué el campo es opcional, qué contrato del backend se respeta, qué pasa si el dato no llega. La regla completa, con el checklist por tipo de cambio, está en [`documentation-convention.md`](.agents/rules/documentation-convention.md); esto es lo que hay que saber para escribir la primera.
+
+### Qué documentar
+
+| Elemento | Qué tiene que decir |
+|---|---|
+| **Clase** | Qué representa y **qué papel juega en su capa**. Una línea, y un párrafo más si encierra una decisión |
+| **Entidad de dominio** | Los campos cuyo significado no es evidente, y **por qué son opcionales** cuando lo son. Las constantes estáticas (`empty`, `emptySkeletonizer`, `pivotCurrency`) llevan la suya: sin eso, la siguiente persona añade una cuarta |
+| **Modelo / endpoint** | Qué campos son opcionales **en el contrato**, qué normalización se aplica y qué versión del backend lo introdujo |
+| **Controlador GetX** | Qué vista alimenta, de qué servicio observa, y **qué dispara cada `ever()`** — es control de flujo invisible desde la vista |
+| **Observable público** | Qué representa y cuándo cambia |
+| **Método público** | El contrato: qué devuelve, qué lanza, y qué pasa en el borde (lista vacía, tasa cero, campo ausente) |
+
+### Qué **no** documentar
+
+Esto es tan importante como lo anterior, y es la parte que se suele hacer mal:
+
+- **Lo que el nombre ya dice.** `/// Returns the name.` sobre `String get name` es ruido; oculta las líneas que sí importan.
+- **Getters y setters triviales**, `copyWith`, `toString`.
+- **Los registros mecánicos.** `AppMessages` (79 getters de i18n), `ColorValues` (78 accesores de color) y `AppIcons` (18 rutas de asset) llevan docstring **en la clase** —que explica el registro, la separación en dos capas, y la regla de los diez idiomas— y **ninguno en sus miembros**. Un `/// El color blanco del texto` sobre `textWhite` no informa a nadie. Los pocos miembros que sí lo llevan son los que tienen una razón: mira `AppMessages.officialRate` y `AppMessages.noSearchResultsMessage`.
+- **Bloques de código comentado**: se borran, para eso está git.
+
+### Estilo
+
+- Empieza por una **frase corta y afirmativa**, terminada en punto. Es lo que sale en el índice de `dart doc`.
+- Después de una línea en blanco, el porqué. Usa `**negrita**` para el hallazgo que alguien podría deshacer sin darse cuenta.
+- Referencia símbolos con `[Corchetes]` **solo si están importados en ese archivo**; si no, comillas simples de código, o `dart doc` avisa de una referencia que no resuelve.
+- Cita el issue que tomó la decisión (`(#59)`) — es lo que permite reconstruir el porqué un año después.
+- En inglés, como el resto del código y de los mensajes de commit.
+
+### Medir la cobertura
+
+El lint `public_member_api_docs` **no está activo**, y es deliberado: activarlo obligaría a escribir exactamente los comentarios que la sección anterior prohíbe. De los 303 avisos que reporta hoy, **170 caen en esos tres registros mecánicos** (`colors_values.dart` 77, `app_messages.dart` 76, `icons_constants.dart` 17).
+
+Para medir de todos modos, actívalo un momento. Ojo con el **cómo**: hay que insertarlo en el bloque `rules:` que ya existe, no añadir un `linter:` nuevo al final — dos claves `linter:` en el mismo YAML y el analizador se queda con una, así que el lint no se aplica y el comando responde `0` como si todo estuviera documentado.
+
+```bash
+cp analysis_options.yaml /tmp/ao.bak
+python3 -c "
+s = open('analysis_options.yaml').read()
+s = s.replace('  rules:', '  rules:\n    public_member_api_docs: true', 1)
+open('analysis_options.yaml', 'w').write(s)
+"
+flutter analyze 2>&1 | grep public_member_api_docs | sed -E 's#^.*(lib/[^:]+):.*#\1#' | sort | uniq -c | sort -rn
+
+cp /tmp/ao.bak analysis_options.yaml   # ← no olvides esto
+git diff --quiet analysis_options.yaml && echo 'restaurado'
+```
+
+Lo que **sí** debe estar al 100 % son las **clases**: cada tipo público de `lib/` lleva su docstring. Comprobarlo:
+
+```bash
+python3 - <<'EOF'
+import re, glob
+d = re.compile(r'^\s*(?:abstract\s+|sealed\s+|final\s+|base\s+|interface\s+)*(class|mixin|enum|extension|typedef)\s+([A-Za-z_]\w*)')
+tot = doc = 0
+for f in sorted(glob.glob('lib/**/*.dart', recursive=True)):
+    lines = open(f, encoding='utf-8').read().split('\n')
+    for i, ln in enumerate(lines):
+        m = d.match(ln)
+        if not m or m.group(2).startswith('_'):
+            continue
+        tot += 1
+        j = i - 1
+        while j >= 0 and (lines[j].strip().startswith('@') or not lines[j].strip()):
+            j -= 1
+        if j >= 0 and lines[j].strip().startswith('///'):
+            doc += 1
+        else:
+            print(f'sin docstring: {f}:{m.group(2)}')
+print(f'{doc}/{tot} tipos publicos documentados')
+EOF
+```
+
+Y para leerla como la leería alguien de fuera:
+
+```bash
+dart doc .          # genera doc/api/
+```
+
+---
+
 ## 🏷️ Versionado y Changelog
 
 El proyecto sigue **[Semantic Versioning](https://semver.org/lang/es/)** (`MAJOR.MINOR.PATCH`, con tags `vX.Y.Z`) y mantiene un historial formal en `CHANGELOG.md` con el formato **[Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/)**.

--- a/lib/config/bindings/initial_bindings.dart
+++ b/lib/config/bindings/initial_bindings.dart
@@ -13,6 +13,18 @@ import '../../shared/domain/repositories/dollar_repositories.dart';
 import '../../shared/presentation/controller/settings_controller.dart';
 import '../enviroment/enviroment.dart';
 
+/// The app's whole dependency graph, in one file.
+///
+/// Everything is registered here and resolved with `Get.find()`; nothing constructs
+/// a controller inside a widget, because a second instance would listen to the same
+/// service while only the registered one is bound to the view — and the bug
+/// surfaces as "the screen does not update", far from its cause. See
+/// `.agents/rules/dependency-injection.md`.
+///
+/// **Two entry points, and the split is load-bearing.** [dependencies] is called by
+/// `GetMaterialApp` from its `initState` and **not awaited**, so anything the first
+/// frame has to read cannot be registered there. That goes in [initServices],
+/// which `main` awaits before `runApp`.
 class InitialBinding extends Bindings {
   /// Services that must be **fully constructed before the first frame**.
   ///

--- a/lib/config/enviroment/enviroment.dart
+++ b/lib/config/enviroment/enviroment.dart
@@ -56,6 +56,17 @@ class EnvironmentError {
   String toString() => 'EnvironmentError($variable, ${issue.name})';
 }
 
+/// The only place the app reads `.env`.
+///
+/// Every `dotenv.env[...]` lookup lives here, so the configuration contract is one
+/// file rather than a habit spread across datasources. A variable added to `.env`
+/// has to be added here, to `.env.example` **with a placeholder value**, to the
+/// README, and to the `Crear .env` step of all three Codemagic workflows — see
+/// `.agents/rules/environment-variables.md`, and note that a missing CI variable
+/// builds fine and ships an app with no configuration.
+///
+/// [load] never throws and [validate] reports instead: a bad `.env` is a problem to
+/// show the user on a real screen, not a crash before the first frame.
 class Environment {
   /// Key of the backend URL in `.env`. Kept as a constant because both the
   /// getter and the validation name it, and a typo in either would be silent.

--- a/lib/config/routes/pages.dart
+++ b/lib/config/routes/pages.dart
@@ -4,9 +4,17 @@ import 'package:get/get.dart';
 import '../../features/dashboard/presentation/page/dashboard_page.dart';
 import '../../features/splash/presentation/page/splash_page.dart';
 
+/// The routing table `GetMaterialApp` is built with.
+///
+/// Every constant in [AppRoutes] has exactly one `GetPage` here. **Transitions
+/// belong on the page, not at the call site**: the splash calls a bare
+/// `Get.offAllNamed(AppRoutes.home)` and inherits the fade declared below, so the
+/// animation cannot differ between two places that navigate to the same screen.
 class AppPages {
+  /// Route the app opens on.
   static const initPage = AppRoutes.splash;
 
+  /// Every screen the app can navigate to, by name.
   static final List<GetPage<dynamic>> routes = [
     GetPage(name: AppRoutes.splash, page: () => const SplashPage()),
     // The splash → home transition lives here, on the route, not at the call

--- a/lib/config/routes/routes.dart
+++ b/lib/config/routes/routes.dart
@@ -1,4 +1,20 @@
+/// Names of the app's routes, and the only place they are spelled out.
+///
+/// Navigation references a constant here — `Get.toNamed(AppRoutes.home)` — never a
+/// literal and never a widget: passing a widget couples the caller to the
+/// destination's constructor and leaves that screen out of the routing table
+/// entirely. See `.agents/rules/navigation-convention.md`.
+///
+/// **Only two, and that is correct.** Tabs are not routes (they move
+/// `NavigationController.selectedIndex`) and neither are modals — the settings
+/// dialog, the currency detail and the currency selector are all opened directly
+/// and closed with `Get.back()`. The price is that a modal is not reachable by
+/// deep link; when one needs to be, it gains a `GetPage` here that resolves its
+/// data from a route parameter.
 abstract class AppRoutes {
+  /// The entry point. Shows the brand, then replaces itself with [home].
   static const splash = '/splash';
+
+  /// The dashboard: the tab bar and both tabs.
   static const home = '/home';
 }

--- a/lib/config/theme/colors/colors_constants.dart
+++ b/lib/config/theme/colors/colors_constants.dart
@@ -1,5 +1,19 @@
 import 'package:flutter/material.dart';
 
+/// The brand palette, as raw `MaterialColor` swatches.
+///
+/// The **lowest** layer of colour: literal values and nothing else. Widgets do not
+/// read this — they read `ColorValues`, which picks a shade per theme. That split
+/// is what makes light and dark a single decision per token instead of a
+/// conditional at every call site.
+///
+/// No `Color(0xFF...)` exists outside `lib/config/theme/`; the 137 uses in the app
+/// all resolve through here. `DESIGN.md` declares these tokens first and this file
+/// implements them — see `.agents/rules/design-system.md`.
+///
+/// The launch-screen navy `#08253A` is deliberately **not** here: it belongs to the
+/// brand's artwork rather than to the interface palette, and lives in
+/// `assets/brand/`.
 class AppColors {
   AppColors._();
 

--- a/lib/config/theme/colors/colors_values.dart
+++ b/lib/config/theme/colors/colors_values.dart
@@ -1,6 +1,21 @@
 import 'package:flutter/material.dart';
 import 'colors_constants.dart'; // Asegúrate de que este import apunte a tu archivo
 
+/// Every colour the UI asks for, resolved for the active theme.
+///
+/// The layer widgets actually call: each accessor takes a `BuildContext`, reads the
+/// brightness and returns the right shade from `AppColors`. That is why a widget
+/// never needs a `Theme.of(context).brightness ==` branch of its own.
+///
+/// The accessors are intentionally undocumented one by one: their names *are* the
+/// documentation (`textWhite`, `borderPrimary`, `utilityBrand500`), and a line
+/// saying "the white text colour" above `textWhite` is the kind of comment
+/// `.agents/rules/documentation-convention.md` explicitly tells you not to write.
+/// What is worth knowing is the two-layer split above, and that these — not
+/// `Theme.of(context).colorScheme` — remain the source for the app's own widgets
+/// even after the Material 3 migration
+/// ([#44](https://github.com/Teixeira49/bcv_tracker_app/issues/44)); the
+/// `ColorScheme` mainly feeds Material's built-in components.
 class ColorValues {
   // -------------------------------------------------------
   // <---------------- Text color values ------------------>

--- a/lib/config/theme/icons/icons_constants.dart
+++ b/lib/config/theme/icons/icons_constants.dart
@@ -1,3 +1,14 @@
+/// Asset paths for every icon, flag and logo the app draws.
+///
+/// Paths in one place so a renamed or moved asset breaks in a single file instead
+/// of at each `SvgPicture.asset` call — a wrong path is a runtime failure in
+/// Flutter, not a compile error, so centralising is the only thing that makes it
+/// catchable.
+///
+/// The individual constants carry no docstrings on purpose: the name and the path
+/// together already say everything (`flagVenezuelaIcon`), and
+/// `.agents/rules/documentation-convention.md` rules out comments that repeat the
+/// code.
 class AppIcons {
   static const String imagesRoute = 'assets/images';
   static const String iconsRoute = 'assets/icons';

--- a/lib/config/theme/width/width_values.dart
+++ b/lib/config/theme/width/width_values.dart
@@ -1,5 +1,18 @@
 part 'width_constants.dart';
 
+/// The 8-point spacing and radius scale.
+///
+/// Sizes come from this scale rather than from bare numbers in an `EdgeInsets`, so
+/// the app's rhythm is one set of decisions. If a design needs a value that is not
+/// on the scale, the question to ask first is whether it should use one that is.
+///
+/// **Adoption is partial, and knowingly so.** `features/currency_detail/` was built
+/// on the scale; older widgets still carry loose numbers. New UI uses these, and
+/// touching an old widget is the moment to migrate its paddings — the boy-scout
+/// rule in `.agents/rules/constants-centralization.md`.
+///
+/// `final` rather than `const` because the values are computed from the base unit;
+/// that is also why they cannot appear in a `const` constructor.
 class WidthValues {
   // ---------------------------------------------------
   // <---------------- Radius values ------------------>

--- a/lib/core/constants/constants.dart
+++ b/lib/core/constants/constants.dart
@@ -1,3 +1,9 @@
+/// App-wide values that are neither colours, copy, nor configuration.
+///
+/// Durations, date formats and the app title: things with a business meaning that
+/// would otherwise be magic numbers scattered across widgets. Anything that
+/// changes per environment is **not** here — that is `Environment` and the `.env`
+/// file (`.agents/rules/environment-variables.md`).
 class Constants {
   const Constants._();
 

--- a/lib/core/helpers/currency_helpers.dart
+++ b/lib/core/helpers/currency_helpers.dart
@@ -10,6 +10,16 @@ import '../../config/theme/icons/icons_constants.dart';
 import '../../features/home/domain/entities/currency_country.dart';
 import '../../shared/domain/entities/currency.dart';
 
+/// Turns rate data into the strings and dressing the UI shows.
+///
+/// The seam between what the backend sends and what a screen can render: a
+/// translated name for a currency code, a flag, a symbol, an amount formatted for
+/// display, a date kept in the right timezone. Pure functions, so their tests need
+/// neither fakes nor GetX.
+///
+/// **Formatting happens here and only here.** The controllers keep full precision
+/// and this rounds at the point of display — the order that fixed the converter's
+/// original rounding bug, and one that must not be inverted. See [castAmount].
 class CurrencyHelpers {
   static CurrencyCountry castCurrencyCountry({required String currencyCode}) {
     switch (currencyCode) {

--- a/lib/core/i18n/app_messages.dart
+++ b/lib/core/i18n/app_messages.dart
@@ -1,5 +1,22 @@
 import 'package:get/get.dart';
 
+/// Every string the user can read, as typed getters.
+///
+/// The **only** file in the app that calls `.tr`. Widgets go through these getters
+/// instead, which buys autocompletion, a central inventory, and a compile error
+/// when a key is removed — where a raw `'homeView'.tr` in a widget would just
+/// render the key on screen.
+///
+/// A new key goes into **all ten** language files in the same commit. Miss one and
+/// GetX shows the raw key for that language; nothing throws, and it surfaces only
+/// by switching language by hand. `.agents/rules/i18n-convention.md` has the
+/// parity script.
+///
+/// The getters below are deliberately left without individual docstrings: the key
+/// name and the getter name are the same word, and a comment restating it is what
+/// `.agents/rules/documentation-convention.md` calls out as noise. The few that
+/// *are* documented are the ones with a reason — see [officialRate] and
+/// [noSearchResultsMessage].
 class AppMessages {
   static String get homeView => 'homeView'.tr;
 

--- a/lib/core/i18n/app_translations.dart
+++ b/lib/core/i18n/app_translations.dart
@@ -1,6 +1,17 @@
 import 'package:bcv_tracker_app/core/i18n/languages/_languages.dart';
 import 'package:get/get.dart';
 
+/// Assembles the ten language maps for GetX.
+///
+/// The single registration point: [keys] is what `GetMaterialApp(translations:)`
+/// receives, and it is also what `translation_parity_test.dart` reads — testing the
+/// registration rather than the files means the suite also fails if a language map
+/// stops being wired in, not only if a key goes missing.
+///
+/// The locale codes here are the contract. `SettingsController.languageOptions`
+/// must match them exactly, which it did not until
+/// [#98](https://github.com/Teixeira49/bcv_tracker_app/issues/98) corrected `en_EN`
+/// and `ja_JA`.
 class AppTranslations extends Translations {
   @override
   Map<String, Map<String, String>> get keys => {

--- a/lib/core/network/api_error_messages.dart
+++ b/lib/core/network/api_error_messages.dart
@@ -5,7 +5,7 @@ import 'api_exception.dart';
 ///
 /// The backend's own `message` is written for developers (and goes to the log,
 /// #19); the user needs to know whether the problem is theirs (no connection)
-/// or the service's, and what to do about it. The mapping is by [kind] first —
+/// or the service's, and what to do about it. The mapping is by `kind` first —
 /// so "no connection" is never confused with "the server failed" — and then by
 /// the HTTP code the backend assigns meaning to (408 slow source, 502 source
 /// down, 422 mode not allowed, 500 internal). Anything else falls to a

--- a/lib/core/network/http_manager.dart
+++ b/lib/core/network/http_manager.dart
@@ -12,8 +12,26 @@ import 'http_operation.dart';
 
 // Project imports:
 
-enum HttpManagerUtilError { error }
+/// Placeholder discriminator kept for the transport's own error path.
+///
+/// A single-value enum, which is as much as it needs to be: callers never see it,
+/// because failures leave this layer as `ApiException`.
+enum HttpManagerUtilError {
+  /// The transport failed. The cause travels in the exception, not here.
+  error,
+}
 
+/// The app's HTTP client — Dio, configured once.
+///
+/// Every request goes through here so the timeout, the headers and the logging
+/// are one decision rather than a per-datasource habit. `DollarApiRest` takes an
+/// instance, which is what lets a test hand it a fake and assert **the outgoing
+/// contract** (the path and the method actually sent) without a network.
+///
+/// It **maps transport failures to `ApiException`**. A `DioException` must not
+/// escape this file: the layers above have no business knowing which client
+/// fetched the data, and `.agents/rules/test-coverage.md` requires a test for each
+/// of non-2xx, timeout and empty body.
 class HttpManager {
   BaseOptions _dioOptions(
     String endpoint,

--- a/lib/features/converter/presentation/controller/converter_controller.dart
+++ b/lib/features/converter/presentation/controller/converter_controller.dart
@@ -4,25 +4,55 @@ import '../../../../shared/domain/conversion.dart';
 import '../../../../shared/domain/entities/currency.dart';
 import '../../domain/entities/convertible_currency.dart';
 
+/// Drives the full converter: which pair, how much, and the result.
+///
+/// **The pivot rule is the thing to understand here.** Every rate the backend
+/// publishes is quoted in bolívares, so there is no cross-rate for `USD → EUR`;
+/// the converter therefore keeps [Currency.pivotCurrency] on **one side at all
+/// times** and reads `USD → EUR` as `USD → VES → EUR`. [selectCurrency] enforces
+/// that invariant rather than trusting callers, which is why picking a second
+/// non-VES currency moves the other side to VES instead of refusing.
+///
+/// Unlike `HomeController` this holds state of its own — the pair and the amount
+/// — and that state **survives between visits to the tab**, deliberately: a user
+/// coming back to a calculation finds it where they left it. Which is also why
+/// [preloadFromDetail] is the only thing allowed to overwrite it, and only on an
+/// explicit tap.
+///
+/// The arithmetic is **not** here: `CurrencyConversion` in `shared/domain/` owns
+/// it, and the detail sheet's quick converter calls the same functions. That is
+/// what makes "both converters agree" a test rather than a hope.
 class ConverterController extends GetxController {
   final CurrencyRepository _repository = Get.find<CurrencyRepository>();
 
+  /// Whether a refresh is in flight — the same one Home shows, so the two
+  /// screens never disagree about whether the app is busy.
   bool get isLoading => _repository.isLoading.value;
 
   /// Detail of the last failed refresh, or `null` when the last one succeeded —
   /// the same failure the Home shows, so the converter states stay consistent.
   String? get errorMessage => _repository.errorMessage.value;
 
-  // Single consolidated list of currencies
+  /// Every rate the user can pick from, official and parallel in one list.
+  ///
+  /// Consolidated because the converter asks "which rate", not "which tab": the
+  /// selector shows them together. Deduplicated on `keyName + platform + name` by
+  /// [_updateCurrenciesAndInit], since the BCV dollar and a parallel dollar are
+  /// different rates that share a code.
+  ///
+  /// Starts as skeleton placeholders, like the service's own lists.
   final RxList<Currency> currencies = List.generate(
     5,
     (e) => Currency.emptySkeletonizer,
   ).obs;
 
+  /// Refetches the rates. Bound to the converter's pull-to-refresh and to retry.
   Future<void> refreshConverterData() async {
     await _repository.refreshData();
   }
 
+  /// The bolívar, held as a field so the pivot rule reads as a comparison rather
+  /// than a literal. See [Currency.pivotCurrency].
   Currency pivotCurrency = Currency.pivotCurrency;
 
   final Rx<ConvertibleCurrency> _fromCurrency = ConvertibleCurrency(
@@ -30,8 +60,11 @@ class ConverterController extends GetxController {
     convertedValue: 0.0,
   ).obs;
 
+  /// The side the user types into, with the amount they typed.
   ConvertibleCurrency get fromCurrency => _fromCurrency.value;
 
+  /// Replaces the input side. Setting it does **not** recalculate — call
+  /// [calculator] after, which is what every path here does.
   set fromCurrency(ConvertibleCurrency value) => _fromCurrency.value = value;
 
   final Rx<ConvertibleCurrency> _toCurrency = ConvertibleCurrency(
@@ -39,8 +72,11 @@ class ConverterController extends GetxController {
     convertedValue: 0.0,
   ).obs;
 
+  /// The side the result is expressed in, with that result.
   ConvertibleCurrency get toCurrency => _toCurrency.value;
 
+  /// Replaces the output side. Like [fromCurrency], does not recalculate on its
+  /// own.
   set toCurrency(ConvertibleCurrency value) => _toCurrency.value = value;
 
   @override
@@ -116,6 +152,7 @@ class ConverterController extends GetxController {
     }
   }
 
+  /// The rate line under each card — `1.0 ≈ 826.84`, in the pair's own units.
   String getRoundedCurrency() =>
       '${fromCurrency.originalValue} ≈ ${toCurrency.originalValue}';
 
@@ -131,6 +168,14 @@ class ConverterController extends GetxController {
     toRate: toCurrency.currency.value,
   );
 
+  /// Picks [selected] for the input side when [isInput], the output side
+  /// otherwise, keeping the pivot rule.
+  ///
+  /// Returns `null` when nothing changed (the same rate was already there),
+  /// `true` when the pair moved. The four branches in the body are the rule made
+  /// explicit: same rate, the other side's rate (so swap), a new rate, and the
+  /// case where neither side would be VES — which moves the *other* side to the
+  /// pivot rather than rejecting the choice the user just made.
   bool? selectCurrency(Currency selected, {required bool isInput}) {
     final Currency current = isInput
         ? fromCurrency.currency
@@ -239,6 +284,14 @@ class ConverterController extends GetxController {
     calculator(amount);
   }
 
+  /// Flips the pair, **carrying each figure with its currency**.
+  ///
+  /// The figure belongs to its currency, so `USD 2 | VES 1653` inverts to
+  /// `VES 1653 | USD 2`, not to `VES 2`. Leaving the amount behind would silently
+  /// change the question — it would ask what two bolívares are worth and answer
+  /// `0.00`, which reads as a broken converter rather than a correct answer to a
+  /// question nobody asked. The detail sheet's quick converter follows the same
+  /// model.
   void swapCurrencies() {
     final ConvertibleCurrency temp = fromCurrency;
     fromCurrency = toCurrency;
@@ -246,6 +299,17 @@ class ConverterController extends GetxController {
     calculator(fromCurrency.convertedValue.toString());
   }
 
+  /// Parses what the user typed and publishes the converted result.
+  ///
+  /// Takes the **raw string**, not a number: `1.` and `1.0` are the same value
+  /// and not the same text, and writing a parsed value back would move the caret.
+  /// It is also the single place that decides what a string means — empty field,
+  /// lone separator, decimal comma — which is why [preloadFromDetail] routes
+  /// through here instead of parsing the handed-over amount itself.
+  ///
+  /// The full precision is kept in state; rounding happens only at display, in
+  /// `CurrencyHelpers.castAmount`. That order is the fix for the converter's
+  /// original rounding bug and must not be inverted.
   void calculator(String value) {
     if (value.isEmpty) {
       fromCurrency = fromCurrency.copyWith(convertedValue: 0.0);

--- a/lib/features/converter/presentation/page/converter_page.dart
+++ b/lib/features/converter/presentation/page/converter_page.dart
@@ -24,6 +24,13 @@ part '../widget/converter_buttons.dart';
 part '../widget/converter_modals.dart';
 part '../widget/converter_widgets.dart';
 
+/// The full converter: a pair of rates, an amount and the result.
+///
+/// Reads `ConverterController`, whose pair **survives between visits to this tab**
+/// — deliberately, so a calculation can be returned to. The one thing allowed to
+/// replace it is the detail sheet's hand-off
+/// ([#103](https://github.com/Teixeira49/bcv_tracker_app/issues/103)), and only on
+/// an explicit tap.
 class ConverterPage extends StatelessWidget {
   const ConverterPage({super.key});
 

--- a/lib/features/currency_detail/presentation/widgets/currency_detail_slots.dart
+++ b/lib/features/currency_detail/presentation/widgets/currency_detail_slots.dart
@@ -44,7 +44,7 @@ part of '../page/currency_detail_sheet.dart';
 /// The empty sliver every unfilled slot renders.
 const Widget _noSection = SliverToBoxAdapter(child: SizedBox.shrink());
 
-/// Historical evolution of the rate — **reserved for [#5]**.
+/// Historical evolution of the rate — **reserved for [#5](https://github.com/Teixeira49/bcv_tracker_app/issues/5)**.
 ///
 /// Blocked upstream: there is no historical endpoint yet
 /// (`bcv_tracker_backend#14`). When it exists, the series is fetched by
@@ -67,7 +67,7 @@ class CurrencyDetailChartSlot extends StatelessWidget {
   Widget build(BuildContext context) => _noSection;
 }
 
-/// Share and save — **reserved for [#7]**.
+/// Share and save — **reserved for [#7](https://github.com/Teixeira49/bcv_tracker_app/issues/7)**.
 ///
 /// A row of actions on the rate: share it as text or image, pin it as a
 /// favourite. Saving needs somewhere to persist to — `SettingsController` and
@@ -77,7 +77,7 @@ class CurrencyDetailChartSlot extends StatelessWidget {
 /// Placed under the facts so the sheet reads as *information first, actions
 /// after*.
 ///
-/// **Still empty after [#103].** That issue's one action —hand the rate to the
+/// **Still empty after [#103](https://github.com/Teixeira49/bcv_tracker_app/issues/103).** That issue's one action —hand the rate to the
 /// full converter— is not an action *on the rate*, it is a continuation of the
 /// quick converter, so it lives in that section's heading row instead of here.
 /// See [_OpenInConverterButton].
@@ -149,7 +149,7 @@ class _OpenInConverterButton extends StatelessWidget {
   );
 }
 
-/// Converter dedicated to this rate — **filled by [#39]**.
+/// Converter dedicated to this rate — **filled by [#39](https://github.com/Teixeira49/bcv_tracker_app/issues/39)**.
 ///
 /// An amount field that converts against [currency] only: the sheet already
 /// fixed which currency this is about, so offering a selector here would be

--- a/lib/features/dashboard/presentation/page/dashboard_page.dart
+++ b/lib/features/dashboard/presentation/page/dashboard_page.dart
@@ -7,6 +7,12 @@ import 'package:get/get.dart';
 import '../../../../config/theme/colors/colors_values.dart';
 import '../../../../shared/presentation/widgets/custom_bottom_navigator_bar.dart';
 
+/// The two tabs and the bar that switches them.
+///
+/// Uses an **`IndexedStack`**, so both pages stay mounted and each keeps its scroll
+/// position, its text field and its controller state while the other is showing.
+/// That is what makes leaving the converter and coming back to a half-finished
+/// calculation work, and it is the reason tabs are not routes.
 class DashboardPage extends GetView<NavigationController> {
   final List<Widget> pages = [const HomePage(), const ConverterPage()];
 

--- a/lib/features/home/domain/entities/currency_country.dart
+++ b/lib/features/home/domain/entities/currency_country.dart
@@ -1,10 +1,35 @@
+/// The country dressing that a currency code alone cannot supply.
+///
+/// A rate arrives from the backend as a code and a number; a card has to show a
+/// flag, a symbol and a translated name. This carries that, and it is built by
+/// `CurrencyHelpers.castCurrencyCountry` from the code — a lookup, not data the
+/// backend sends.
+///
+/// It lives under `features/home/` because the BCV card is what needs it: the
+/// average tab identifies rates by market instead, so it reads
+/// `CurrencyHelpers.castCurrencyDisplayName` and never touches this.
 class CurrencyCountry {
+  /// Country the currency belongs to, for context beside the code.
+  ///
+  /// **Hardcoded in Spanish** in `castCurrencyCountry` and not run through
+  /// `AppMessages`, which is a gap rather than a decision: it is the one string
+  /// here that does not follow `.agents/rules/i18n-convention.md`.
   final String countryName;
+
+  /// ISO code the lookup was made with, or `-` when the code is unknown.
   final String currencyCode;
+
+  /// Translated name of the currency, from `AppMessages`. This is what the card
+  /// titles itself with.
   final String currencyCountryName;
+
+  /// Asset path of the currency's symbol glyph, from `AppIcons`.
   final String currencySymbol;
+
+  /// Asset path of the country's flag, from `AppIcons`.
   final String countryFlag;
 
+  /// Groups the dressing for one currency code.
   CurrencyCountry({
     required this.countryName,
     required this.currencyCode,

--- a/lib/features/home/presentation/controller/home_controller.dart
+++ b/lib/features/home/presentation/controller/home_controller.dart
@@ -2,12 +2,34 @@ import 'package:get/get.dart';
 import '../../../../shared/data/repositories/currency_repository.dart';
 import '../../../../shared/domain/entities/currency.dart';
 
+/// Feeds the Home screen from [CurrencyRepository].
+///
+/// **Holds no state of its own.** Every getter unwraps an observable the service
+/// owns, and `onInit` bridges each one to `update()` so the `GetBuilder`s in the
+/// view repaint. That is the architecture's boundary: the view never names an
+/// `Rx` type, and there is exactly one copy of the rates in the app.
+///
+/// A consequence worth knowing before adding reactive state to the service: **if
+/// you add an observable here and forget its `ever`, the screen silently stops
+/// refreshing.** Nothing fails; it just never updates. See
+/// `.agents/skills/getx-architecture`.
 class HomeController extends GetxController {
   final CurrencyRepository _repository = Get.find<CurrencyRepository>();
 
+  /// Parallel market rates for the average tab, unwrapped.
+  ///
+  /// While [hasAverageData] is `false` these are the skeleton placeholders, not
+  /// rates — the view shimmers them rather than reading their numbers.
   List<Currency> get averageCurrencies => _repository.averageCurrencies;
+
+  /// Official rates for the BCV tab. Same placeholder contract, flagged by
+  /// [hasBcvData].
   List<Currency> get bcvCurrencies => _repository.bcvCurrencies;
+
+  /// Effective date of the official rates, as the BCV published it.
   String get bcvCurrentDate => _repository.bcvCurrentDate.value;
+
+  /// Whether a refresh is in flight, for the shimmer and the pull-to-refresh.
   bool get isLoading => _repository.isLoading.value;
 
   /// Detail of the last failed refresh, or `null` if the last one succeeded.
@@ -15,8 +37,18 @@ class HomeController extends GetxController {
 
   /// Whether each tab already has real rates to render (see [CurrencyRepository]).
   bool get hasAverageData => _repository.hasAverageData.value;
+
+  /// See [hasAverageData]; its counterpart for the BCV tab.
   bool get hasBcvData => _repository.hasBcvData.value;
 
+  /// Wires the service's observables to `update()`.
+  ///
+  /// Four workers, one per value the view reads. They are **not disposed**, which
+  /// is the leak catalogued in
+  /// [#45](https://github.com/Teixeira49/bcv_tracker_app/issues/45): `get` 4.7.3
+  /// disposes none on its own and this controller is registered `fenix`, so a
+  /// listener accumulates on every recreation against a `permanent` service. Any
+  /// new worker added here belongs in an `onClose` that this class still owes.
   @override
   void onInit() {
     super.onInit();
@@ -27,6 +59,8 @@ class HomeController extends GetxController {
     ever(_repository.errorMessage, (_) => update());
   }
 
+  /// Refetches both sides. Bound to pull-to-refresh and to the error state's
+  /// retry; the service is what decides what a partial failure means.
   Future<void> refreshHomeData() async {
     await _repository.refreshData();
   }

--- a/lib/features/home/presentation/page/home_page.dart
+++ b/lib/features/home/presentation/page/home_page.dart
@@ -22,6 +22,12 @@ part '../widgets/home_tab_bar.dart';
 
 part '../widgets/home_widgets.dart';
 
+/// The rate list, in two tabs: the parallel average and the official BCV rates.
+///
+/// The app's landing screen. Which tab opens first is the user's saved preference
+/// (`SettingsController.favMarketIndex`), and tapping a card opens the detail sheet
+/// with a **snapshot** of that rate — this list already holds the freshest copy the
+/// app has, so the sheet does not re-fetch.
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
 

--- a/lib/features/settings/presentation/page/settings_modal.dart
+++ b/lib/features/settings/presentation/page/settings_modal.dart
@@ -16,6 +16,14 @@ part '../widgets/settings_inputs.dart';
 
 part '../widgets/settings_widgets.dart';
 
+/// Language, theme and default market, in a centred dialog.
+///
+/// A **modal, not a route**: opened with `showBlurredDialog` and closed with
+/// `Get.back()`, so it is not registered in `AppPages`. Its selectors read
+/// `SettingsController` with `Obx` rather than `GetBuilder` — the controller is a
+/// `GetxService` since
+/// [#59](https://github.com/Teixeira49/bcv_tracker_app/issues/59) and `GetBuilder`
+/// is bound to `GetxController`.
 class SettingsModal extends StatelessWidget {
   const SettingsModal({super.key});
 

--- a/lib/features/splash/presentation/page/splash_page.dart
+++ b/lib/features/splash/presentation/page/splash_page.dart
@@ -11,6 +11,22 @@ import '../../../../core/constants/constants.dart';
 
 part '../widgets/splash_body.dart';
 
+/// The first Flutter screen: the brand, then Home.
+///
+/// It is the **second** of three screens on launch, not the first — the OS paints a
+/// native one before Flutter draws anything, and matching the two is what
+/// [#102](https://github.com/Teixeira49/bcv_tracker_app/issues/102) did.
+///
+/// Waits `Constants.splashDuration` and then `Get.offAllNamed(AppRoutes.home)`,
+/// clearing the stack so back does not return here. The fade belongs to the home
+/// route, not to this call. The wait also has to outlast the entry animation in
+/// `_SplashBody` (2200 ms): shortening one means shortening both.
+///
+/// It no longer covers anything functional. Until
+/// [#59](https://github.com/Teixeira49/bcv_tracker_app/issues/59) it accidentally
+/// hid the window in which the saved theme and language had not loaded yet; those
+/// are now awaited before the first frame, so this is a welcome screen and nothing
+/// more.
 class SplashPage extends StatefulWidget {
   const SplashPage({super.key});
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -64,6 +64,14 @@ class ConfigurationErrorApp extends StatelessWidget {
   }
 }
 
+/// The app itself, once the configuration is known to be usable.
+///
+/// Wires the routing table, the ten translations and the two themes. The theme and
+/// the locale come **from `SettingsController`, already loaded** — `main` awaits
+/// `InitialBinding.initServices()` before this can exist — and they are *passed*
+/// rather than applied, because `GetMaterialApp.initState` assigns `Get.locale`
+/// from its own argument and would overwrite anything set earlier
+/// ([#59](https://github.com/Teixeira49/bcv_tracker_app/issues/59)).
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 

--- a/lib/navigation/navigation_controller.dart
+++ b/lib/navigation/navigation_controller.dart
@@ -1,8 +1,24 @@
 import 'package:get/get.dart';
 
+/// Which tab of the dashboard is showing.
+///
+/// **Tabs are not routes.** `DashboardPage` keeps both pages alive in an
+/// `IndexedStack` and switches between them by this index, so moving between Home
+/// and the converter preserves each one's scroll position and state — and never
+/// touches the navigation stack. Changing tab is `changeIndex`, never
+/// `Get.toNamed`; see `.agents/rules/navigation-convention.md`.
+///
+/// The index maps to `DashboardPage.pages`: `0` Home, `1` the converter.
 class NavigationController extends GetxController {
+  /// Index of the visible tab. Observed directly with `Obx` by the dashboard and
+  /// the bottom bar, which are the only two widgets that care.
   var selectedIndex = 0.obs;
 
+  /// Shows the tab at [index].
+  ///
+  /// Also the way in from elsewhere: the detail sheet's "open in the converter"
+  /// action calls this after loading the rate
+  /// ([#103](https://github.com/Teixeira49/bcv_tracker_app/issues/103)).
   void changeIndex(int index) {
     selectedIndex.value = index;
   }

--- a/lib/shared/data/datasource/dollar_api/dollar_api.dart
+++ b/lib/shared/data/datasource/dollar_api/dollar_api.dart
@@ -1,7 +1,21 @@
 import '../../model/model.dart';
 
+/// The HTTP calls the app makes for exchange rates.
+///
+/// One step below `IDollarRepository` and the mirror of it in the data layer:
+/// this one traffics in **models**, that one in entities, and `DollarRepository`
+/// is the seam where `.toEntity()` runs. Splitting them is what lets a test fake
+/// the transport (`DollarApiRest` with a fake `HttpManager`) separately from
+/// faking the data (`IDollarRepository`).
+///
+/// Implementations throw `ApiException`, never a `DioException`: mapping the
+/// transport's own failures is the datasource's job, and
+/// `.agents/rules/test-coverage.md` requires a test for each of non-2xx,
+/// timeout and empty body.
 abstract class IDollarApi {
+  /// `GET`s the official rates and their effective date, unparsed into entities.
   Future<BcvCurrenciesModel> getCurrentBCVDollar();
 
+  /// `GET`s the parallel market rates, unparsed into entities.
   Future<List<CurrencyModel>> getCurrentDollar();
 }

--- a/lib/shared/data/datasource/dollar_api/dollar_api_rest.dart
+++ b/lib/shared/data/datasource/dollar_api/dollar_api_rest.dart
@@ -21,6 +21,10 @@ import '../../model/model.dart';
 /// canned response and no network. `.agents/rules/test-coverage.md` requires that,
 /// plus a case each for non-2xx, timeout and empty body.
 class DollarApiRest implements IDollarApi {
+  /// Takes the backend base URL and, optionally, the client to send through.
+  ///
+  /// [client] defaults to a fresh [HttpManager]; a test passes a fake instead,
+  /// which is how the outgoing path and method get asserted without a network.
   DollarApiRest({required String apiUrl, HttpManager? client})
     : _apiUrl = apiUrl,
       _client = client ?? HttpManager();

--- a/lib/shared/data/datasource/dollar_api/dollar_api_rest.dart
+++ b/lib/shared/data/datasource/dollar_api/dollar_api_rest.dart
@@ -10,6 +10,16 @@ import '../../../../core/network/http_manager.dart';
 import '../../../../core/network/http_operation.dart';
 import '../../model/model.dart';
 
+/// [IDollarApi] over REST, through [HttpManager].
+///
+/// Builds the request from `DollarEndpoints`, deserialises with the models, and
+/// turns every transport failure into `ApiException` — nothing Dio-shaped leaves
+/// here.
+///
+/// The `HttpManager` is injectable for exactly one reason: it is what lets a test
+/// assert the **outgoing contract** — the path and the method actually sent — with a
+/// canned response and no network. `.agents/rules/test-coverage.md` requires that,
+/// plus a case each for non-2xx, timeout and empty body.
 class DollarApiRest implements IDollarApi {
   DollarApiRest({required String apiUrl, HttpManager? client})
     : _apiUrl = apiUrl,

--- a/lib/shared/data/datasource/dollar_api/dollar_endpoints.dart
+++ b/lib/shared/data/datasource/dollar_api/dollar_endpoints.dart
@@ -50,5 +50,10 @@ class DollarEndpoints {
     },
   };
 
+  /// Official BCV rates plus the effective date the institution reported.
+  ///
+  /// `with-memory` is the variant that answers from the backend's stored copy when
+  /// the BCV's own page is unreachable — which it regularly is, since that side
+  /// scrapes HTML. It is why the app can open on official rates during an outage.
   static const String currentBCVDollar = '$_apiEndpoints/bcv/with-memory';
 }

--- a/lib/shared/data/mapper/currency_normalizer.dart
+++ b/lib/shared/data/mapper/currency_normalizer.dart
@@ -18,6 +18,13 @@ class CurrencyNormalizer {
   static const String _buySuffix = '-buy';
   static const String _sellSuffix = '-sell';
 
+  /// The rows the average tab should show, from what the backend actually sent.
+  ///
+  /// Three problems in one pass, all of them real rather than defensive: markets
+  /// the app does not list are dropped, the `-buy`/`-sell` pair each P2P market
+  /// publishes is merged into one row, and duplicates the database occasionally
+  /// repeats are removed. Without this the tab shows Binance three times and the
+  /// average is dragged by whichever side repeated.
   static List<Currency> forAverageTab(List<Currency> currencies) {
     final allowed = currencies.where(
       (currency) => Markets.averageTab.contains(currency.platform),

--- a/lib/shared/data/model/bcv_currencies_model.dart
+++ b/lib/shared/data/model/bcv_currencies_model.dart
@@ -1,6 +1,12 @@
 import '../../domain/entities/bcv_currencies.dart';
 import 'currency_model.dart';
 
+/// Wire format of the official rates, and the seam back to `BcvCurrencies`.
+///
+/// **It extends the entity**, which is convenient and is also the trap: a model
+/// satisfies every signature that asks for an entity, so the compiler cannot
+/// tell you when one leaks upwards. [currencyModels] and [toEntity] exist
+/// precisely to make that conversion checkable — see their own comments.
 class BcvCurrenciesModel extends BcvCurrencies {
   BcvCurrenciesModel({
     required super.date,

--- a/lib/shared/data/model/bcv_currencies_model.dart
+++ b/lib/shared/data/model/bcv_currencies_model.dart
@@ -8,6 +8,11 @@ import 'currency_model.dart';
 /// tell you when one leaks upwards. [currencyModels] and [toEntity] exist
 /// precisely to make that conversion checkable — see their own comments.
 class BcvCurrenciesModel extends BcvCurrencies {
+  /// Takes the deserialised rows at their real type.
+  ///
+  /// [currencies] is a `List<CurrencyModel>` on purpose: the inherited field is
+  /// declared `List<Currency>`, and accepting that type here is what let models
+  /// travel upward unnoticed. See [currencyModels].
   BcvCurrenciesModel({
     required super.date,
     required List<CurrencyModel> currencies,

--- a/lib/shared/data/model/currency_model.dart
+++ b/lib/shared/data/model/currency_model.dart
@@ -1,6 +1,18 @@
 import 'package:bcv_tracker_app/core/helpers/backend_date.dart';
 import 'package:bcv_tracker_app/shared/domain/entities/entities.dart';
 
+/// Wire format of one rate, and the seam back to [Currency].
+///
+/// Where the backend's shape is dealt with and then left behind: optional fields
+/// read with a fallback, `platform_img` empty strings turned into `null`, `num`
+/// widened to `double`, and dates normalised **once**. Nothing above the data layer
+/// should ever normalise something that came off the network.
+///
+/// It **extends the entity**, so a `CurrencyModel` satisfies every signature that
+/// asks for a `Currency` and the compiler cannot tell you when one leaks upward.
+/// `.toEntity()` is therefore mandatory even though returning `this` would compile
+/// — see `.agents/rules/entities-vs-models.md`, and the four places a new field has
+/// to touch.
 class CurrencyModel extends Currency {
   CurrencyModel({
     required super.name,

--- a/lib/shared/data/model/currency_model.dart
+++ b/lib/shared/data/model/currency_model.dart
@@ -14,6 +14,8 @@ import 'package:bcv_tracker_app/shared/domain/entities/entities.dart';
 /// — see `.agents/rules/entities-vs-models.md`, and the four places a new field has
 /// to touch.
 class CurrencyModel extends Currency {
+  /// Builds a model directly. Normally reached through [fromJson]; the explicit
+  /// constructor is what the mapping tests construct expectations with.
   CurrencyModel({
     required super.name,
     required super.keyName,
@@ -53,6 +55,13 @@ class CurrencyModel extends Currency {
     return url.isEmpty ? null : url;
   }
 
+  /// Returns a plain [Currency] with the same values.
+  ///
+  /// **Mandatory even though `return this` would compile.** The model extends the
+  /// entity, so returning itself type-checks and leaves an object of the data
+  /// layer alive in the domain — where nothing would fail until this class grew
+  /// state of its own. Constructing a new [Currency] is what makes the boundary
+  /// real instead of nominal.
   Currency toEntity() {
     return Currency(
       name: name,

--- a/lib/shared/data/repositories/currency_repository.dart
+++ b/lib/shared/data/repositories/currency_repository.dart
@@ -116,6 +116,11 @@ class CurrencyRepository extends GetxService {
     }
   }
 
+  /// Fetches the parallel rates, normalises them and publishes them.
+  ///
+  /// Public so [refreshData] can await the two sides independently and let one
+  /// succeed while the other fails. Throws whatever the repository throws — the
+  /// caller is what decides that a partial failure is still a usable state.
   Future<void> getAveragedCurrencies() async {
     final List<Currency> result = await _dollarRepository.getCurrentDollar();
     // saved-currencies answers with every market the backend knows, one row per
@@ -125,6 +130,10 @@ class CurrencyRepository extends GetxService {
     hasAverageData.value = true;
   }
 
+  /// Fetches the official rates and their effective date, and publishes both.
+  ///
+  /// The counterpart of [getAveragedCurrencies], with the same contract: it throws
+  /// rather than swallowing, so [refreshData] can report which side went down.
   Future<void> getBCVCurrencies() async {
     // The currentBCVDollar endpoint returns every official BCV rate plus the
     // effective date reported by the institution.

--- a/lib/shared/data/repositories/currency_repository.dart
+++ b/lib/shared/data/repositories/currency_repository.dart
@@ -7,18 +7,54 @@ import '../../domain/entities/entities.dart';
 import '../../domain/repositories/dollar_repositories.dart';
 import '../mapper/currency_normalizer.dart';
 
+/// The app's live exchange-rate state, shared by every feature.
+///
+/// A **`GetxService` registered `permanent`** in `initial_bindings.dart`, and the
+/// only place `Rx` rate state lives. Home, the converter and the detail sheet all
+/// observe this one instance rather than fetching for themselves, which is what
+/// keeps two screens from showing two different numbers for the same rate.
+///
+/// **Feature controllers do not expose these observables.** They read them and
+/// bridge changes with `ever(...) => update()`, so views use `GetBuilder` and
+/// never name an `Rx` type. That boundary is a retained decision — the audit
+/// proposed granular `Obx` and it was declined in
+/// [#60](https://github.com/Teixeira49/bcv_tracker_app/issues/60) — and its price
+/// is that **every worker must be disposed in `onClose`**
+/// ([#45](https://github.com/Teixeira49/bcv_tracker_app/issues/45)): `get` 4.7.3
+/// disposes none on its own, and this service outliving its observers means
+/// listeners otherwise accumulate on each `fenix` recreation.
+///
+/// See `.agents/skills/getx-architecture`.
 class CurrencyRepository extends GetxService {
   final IDollarRepository _dollarRepository = Get.find<IDollarRepository>();
 
+  /// Parallel market rates, one per market and currency.
+  ///
+  /// Starts as five [Currency.emptySkeletonizer] placeholders so the first frame
+  /// can draw a shimmering list the right shape. They are **not data** — check
+  /// [hasAverageData] before treating them as such, which is also why widget
+  /// tests clear these lists instead of letting the placeholder image resolve.
   final RxList<Currency> averageCurrencies = List.generate(
     5,
     (e) => Currency.emptySkeletonizer,
   ).obs;
+
+  /// Official BCV rates. Same placeholder contract as [averageCurrencies], with
+  /// [hasBcvData] as its flag.
   final RxList<Currency> bcvCurrencies = List.generate(
     5,
     (e) => Currency.emptySkeletonizer,
   ).obs;
+
+  /// Effective date the BCV reported, as published — empty until the first
+  /// successful refresh.
+  ///
+  /// Kept as the raw string for the reason `BcvCurrencies.date` explains: it
+  /// names a day for Venezuela, and converting it to a local `DateTime` moves it
+  /// a day west of Caracas.
   final RxString bcvCurrentDate = ''.obs;
+
+  /// Whether a refresh is in flight. Drives the shimmer and disables retry.
   final RxBool isLoading = false.obs;
 
   /// Detail of the last failed refresh, or `null` when the last one succeeded.
@@ -30,15 +66,33 @@ class CurrencyRepository extends GetxService {
 
   /// Whether each list already holds real rates. While `false` it still holds
   /// the `emptySkeletonizer` placeholders, which must not be shown as data.
+  ///
+  /// A flag rather than an `isEmpty` check, because the lists are **never**
+  /// empty: they start full of placeholders, so emptiness cannot distinguish
+  /// "still loading" from "loaded and genuinely nothing there".
   final RxBool hasAverageData = false.obs;
+
+  /// See [hasAverageData]; this is its counterpart for [bcvCurrencies].
   final RxBool hasBcvData = false.obs;
 
+  /// Kicks off the first fetch.
+  ///
+  /// `onReady` rather than `onInit` deliberately: it runs after the first frame,
+  /// so the shimmering placeholders are already on screen when the request
+  /// starts instead of the app opening on a blank panel.
   @override
   void onReady() {
     super.onReady();
     refreshData();
   }
 
+  /// Refetches both sides and republishes the state.
+  ///
+  /// **A partial failure is a real outcome, not an error.** The two requests hit
+  /// different upstream sources, so one can answer while the other is down; the
+  /// side that succeeded is published and [errorMessage] describes the side that
+  /// did not. Awaiting them together without `eagerError` is what makes that
+  /// possible — see the comment in the body.
   Future<void> refreshData() async {
     isLoading.value = true;
     try {

--- a/lib/shared/data/repositories/dollar_repositories.dart
+++ b/lib/shared/data/repositories/dollar_repositories.dart
@@ -3,7 +3,19 @@ import 'package:bcv_tracker_app/shared/data/datasource/dollar_api/dollar.dart';
 import 'package:bcv_tracker_app/shared/domain/entities/entities.dart';
 import 'package:bcv_tracker_app/shared/domain/repositories/repositories.dart';
 
+/// [IDollarRepository] over the REST datasource.
+///
+/// Two jobs, and nothing else: **convert models to entities**, so no object of
+/// the data layer escapes upwards (see `.agents/rules/entities-vs-models.md`),
+/// and **log the boundary** before letting the failure through.
+///
+/// It deliberately does not catch. The datasource has already turned transport
+/// problems into `ApiException`; swallowing one here would leave
+/// `CurrencyRepository` unable to tell a genuine empty market from a failed
+/// request, and the screen would show "no data" for what is really an outage.
 class DollarRepository implements IDollarRepository {
+  /// Takes the datasource it reads from. Resolved by the binding, never
+  /// constructed here — that is what makes it substitutable in tests.
   DollarRepository({required IDollarApi dollarApi}) : _dollarApi = dollarApi;
 
   final IDollarApi _dollarApi;

--- a/lib/shared/domain/entities/bcv_currencies.dart
+++ b/lib/shared/domain/entities/bcv_currencies.dart
@@ -1,10 +1,28 @@
 import 'currency.dart';
 
+/// The official rates, with the one date that applies to all of them.
+///
+/// A separate entity from a plain `List<Currency>` because the BCV publishes a
+/// **single effective date for the whole set**, not one per rate: it fixes a rate
+/// for a business day. Folding that date into each [Currency] would repeat it
+/// eight times and invite the four copies to drift.
+///
+/// Built from `BcvCurrenciesModel.toEntity()`.
 class BcvCurrencies {
   /// Effective date reported by the BCV. Optional in the backend contract
   /// (`BcvResponseData.date`): it is `null` when no platform date is stored yet.
+  ///
+  /// A **string**, not a `DateTime`, and deliberately so: it names a *day for
+  /// Venezuela*, not an instant. Parsing it to a local `DateTime` would move it
+  /// to the previous day for anyone west of Caracas, which is why
+  /// `CurrencyHelpers.parseDate` goes through `BackendDate.asPublished` and keeps
+  /// the wall clock.
   final String? date;
+
+  /// The official rates for [date] — the dollar, but also the euro, the yuan,
+  /// the lira and the rouble.
   final List<Currency> currencies;
 
+  /// Groups [currencies] under the [date] they are all effective on.
   BcvCurrencies({required this.date, required this.currencies});
 }

--- a/lib/shared/domain/entities/currency.dart
+++ b/lib/shared/domain/entities/currency.dart
@@ -1,13 +1,76 @@
+/// One exchange rate, as the app reasons about it.
+///
+/// The unit of the whole domain: Home lists these, the converter converts
+/// between two of them, and the detail sheet renders one. A rate is identified
+/// by **[keyName] + [platform]**, never by [keyName] alone — several markets
+/// quote the same currency at different prices, and matching on the code would
+/// silently pick whichever came first.
+///
+/// Built from `CurrencyModel.toEntity()`. Nothing in `features/` or in a
+/// controller should ever hold the model: see
+/// `.agents/rules/entities-vs-models.md` for the four places a new field has to
+/// touch, and why the compiler cannot catch that leak on its own.
 class Currency {
+  /// Human-readable name **as the source spells it**, in Spanish.
+  ///
+  /// Not for display on its own: the backend names rates in Spanish ("Dolar",
+  /// "Promedio"), so rendering this raw left the average tab untranslated in the
+  /// other nine languages. Go through `CurrencyHelpers.castCurrencyDisplayName`,
+  /// which falls back to this only for codes it does not know.
   final String name;
+
+  /// Code the source identifies the rate by — usually ISO 4217 (`USD`, `EUR`),
+  /// sometimes not.
+  ///
+  /// Exchange Monitor uses its own codes (`em`, `average`, `md`) even though all
+  /// of them quote the dollar, and the crypto markets quote `USDT`/`USDC`. Use
+  /// `CurrencyHelpers.castCurrencyDisplayCode` to show it, and
+  /// `Markets.dollarEquivalentCodes` to decide whether it counts as a dollar.
   final String keyName;
+
+  /// Market the rate comes from, verbatim from the backend
+  /// (`Banco Central de Venezuela`, `Binance`, `Yadio.io`…).
+  ///
+  /// Half of the identity of a rate, and what `CurrencyHelpers.isOfficialRate`
+  /// matches on. Compared against the constants in `Markets` rather than typed
+  /// literals, so a market renamed upstream fails visibly instead of quietly
+  /// changing category.
   final String platform;
+
+  /// Price in bolívares for one unit of this currency.
+  ///
+  /// **Can legitimately be `0.0`**: [empty] declares it, and the backend answers
+  /// with markets that have no data yet. Dividing by it does not throw in Dart —
+  /// it yields `Infinity`, or `NaN` when the dividend is zero too — so every
+  /// conversion goes through `CurrencyConversion`, which guards it.
   final double value;
+
+  /// Logo of the market, or `null` when the source publishes none.
+  ///
+  /// Optional in the contract, so it cannot be dereferenced. Also carries the
+  /// `placehold.co` placeholder while the first refresh is in flight, which is
+  /// why widget tests clear the skeleton lists instead of letting them resolve a
+  /// network image.
   final String? imgUrl;
+
+  /// When the source first published this rate, or `null` if it does not say.
+  ///
+  /// Absent from `bcv/with-memory`, so the detail sheet drops the row rather
+  /// than dashing it out.
   final DateTime? createDate;
+
+  /// When the rate was last refreshed, or `null` if the source does not say.
   final DateTime? updateDate;
+
+  /// Signed percentage change the source reports, or `null` when it reports none.
+  ///
+  /// `null` is **not** zero, and the difference matters on screen: `0%` reads as
+  /// "the rate held", while the absence means "nobody said". That is why
+  /// `CurrencyHelpers.castTendency` degrades to a placeholder instead.
   final double? tendency;
 
+  /// Creates a rate. `const` so [empty] and the fixtures can be compile-time
+  /// constants.
   const Currency({
     required this.name,
     required this.keyName,
@@ -41,6 +104,11 @@ class Currency {
     );
   }
 
+  /// A rate with nothing in it, for a slot that has no data and is not loading.
+  ///
+  /// Distinct from [emptySkeletonizer] on purpose: this one is **blank**, and
+  /// its `value: 0.00` is what makes `CurrencyConversion`'s guard reachable
+  /// through an ordinary path rather than only in tests.
   static const empty = Currency(
     name: '',
     platform: '',
@@ -50,6 +118,12 @@ class Currency {
     tendency: 0.00,
   );
 
+  /// A rate with plausible-looking content, to be covered by the shimmer while
+  /// the first request is in flight.
+  ///
+  /// Every field is filled — including the dates — because the skeleton draws
+  /// the **shape** of a loaded card, and a null date would collapse the row it
+  /// is meant to be standing in for. Not `const`: `DateTime.now()` is not.
   static final emptySkeletonizer = Currency(
     name: 'name',
     keyName: 'keyName',
@@ -61,6 +135,13 @@ class Currency {
     tendency: 1.0,
   );
 
+  /// The bolívar, and the axis every conversion turns on.
+  ///
+  /// The app converts through a pivot rather than between arbitrary pairs: every
+  /// rate the backend publishes is quoted **in bolívares**, so `USD → EUR` is
+  /// `USD → VES → EUR` and there is no cross-rate to invent. Its `value: 1.0` is
+  /// what makes the pivot disappear from the arithmetic. `ConverterController`
+  /// enforces that one side of the pair is always this.
   static final pivotCurrency = Currency(
     keyName: 'VES',
     name: 'Bolivares',

--- a/lib/shared/domain/entities/currency.dart
+++ b/lib/shared/domain/entities/currency.dart
@@ -82,6 +82,12 @@ class Currency {
     this.tendency,
   });
 
+  /// A copy with the given fields replaced.
+  ///
+  /// Used by the converter to move an amount onto a rate without rebuilding the
+  /// rate itself. Note it cannot **clear** an optional field — passing `null` keeps
+  /// the current value — which is the usual `copyWith` trade-off and has not been
+  /// a problem because nothing here needs to un-set a date or a tendency.
   Currency copyWith({
     String? name,
     String? keyName,

--- a/lib/shared/domain/entities/language.dart
+++ b/lib/shared/domain/entities/language.dart
@@ -1,9 +1,38 @@
-// Puedes poner esta clase en un archivo de modelos o al principio del archivo de la página de ajustes.
+/// One entry of the language selector in Settings.
+///
+/// A presentation-shaped entity: the app ships ten translations and this is how
+/// each is offered. Deliberately **not** derived from `AppTranslations.keys` —
+/// [name] and [flag] are copy for the user, and a locale code cannot produce
+/// either. `SettingsController.languageOptions` holds the list.
 class LanguageOption {
-  final String code; // ej: 'es', 'en'
-  final String name; // ej: 'Español', 'English'
-  final String flag; // ej: '🇪🇸', '🇬🇧' (emoji) o una ruta a un asset
+  /// Store-shaped locale code, `xx_YY`, matching a key `AppTranslations`
+  /// registers **exactly**.
+  ///
+  /// Exactness matters: it is what lets
+  /// `SettingsController.resolveDeviceLanguage` answer "does the device's locale
+  /// match a language we publish?" by comparison. Two of these used to be
+  /// invalid (`en_EN`, `ja_JA`) and only worked because GetX falls back on the
+  /// language code alone — corrected in
+  /// [#98](https://github.com/Teixeira49/bcv_tracker_app/issues/98), which also
+  /// added the migration for installs that had stored the old ones.
+  final String code;
 
+  /// The language's name **in that language** ("Español", "日本語").
+  ///
+  /// Never translated: someone looking for their own language scans for the word
+  /// they know, not for its name in a language they cannot read.
+  final String name;
+
+  /// Flag emoji shown beside [name].
+  ///
+  /// An emoji rather than an asset, so it needs no file per language and picks up
+  /// the platform's own rendering. Typed as `String` for that reason.
+  final String flag;
+
+  /// Creates an option. `const` so `SettingsController.defaultLanguage` can be a
+  /// compile-time constant and therefore identical by reference — which
+  /// `DropdownButtonFormField` relies on, since this class does not override
+  /// `==`.
   const LanguageOption({
     required this.code,
     required this.name,

--- a/lib/shared/domain/repositories/dollar_repositories.dart
+++ b/lib/shared/domain/repositories/dollar_repositories.dart
@@ -1,7 +1,29 @@
 import '../entities/entities.dart';
 
+/// What the app needs from a source of exchange rates.
+///
+/// The boundary between the domain and the network: everything above this
+/// depends on the interface, and `DollarRepository` is registered against it in
+/// `initial_bindings.dart` — which is what lets tests inject a fake with
+/// `Get.put<IDollarRepository>(...)` and never touch the network.
+///
+/// **Two methods and not one** because the two sides of the app are two
+/// requests: the official rates arrive with a shared effective date
+/// ([BcvCurrencies]) and the parallel ones do not. Merging them here would mean
+/// inventing a date for the markets that publish none.
+///
+/// Implementations return **entities and throw `ApiException`**. A `DioException`
+/// must never cross this line: the layers above have no business knowing which
+/// HTTP client fetched the data.
 abstract class IDollarRepository {
+  /// The official rates and the day they are effective on.
+  ///
+  /// Throws `ApiException` on a non-2xx, a timeout or an unparseable body.
   Future<BcvCurrencies> getCurrentBCVDollar();
 
+  /// The parallel market rates, one per market and currency.
+  ///
+  /// Already normalised by `CurrencyNormalizer`, so duplicates are merged and
+  /// markets the app does not list are dropped. Throws `ApiException` on failure.
   Future<List<Currency>> getCurrentDollar();
 }

--- a/lib/shared/presentation/widgets/base_bottom_sheet.dart
+++ b/lib/shared/presentation/widgets/base_bottom_sheet.dart
@@ -7,8 +7,8 @@ import '../../../core/i18n/app_messages.dart';
 
 /// Container of the app's draggable bottom sheets.
 ///
-/// Introduced with the currency detail ([#38]) and extracted here when the
-/// converter's currency selector moved to the same shape ([#40]) — the issue
+/// Introduced with the currency detail ([#38](https://github.com/Teixeira49/bcv_tracker_app/issues/38)) and extracted here when the
+/// converter's currency selector moved to the same shape ([#40](https://github.com/Teixeira49/bcv_tracker_app/issues/40)) — the issue
 /// itself asked for the container to be shared if the two ended up alike, and
 /// they did. `BaseModal` (an `AlertDialog`) stays for the centred dialogs:
 /// this is not a replacement for it, it is the other half of the pair.
@@ -40,7 +40,7 @@ import '../../../core/i18n/app_messages.dart';
 /// keyboard and the extents below are fractions of the height that is left.
 /// **Do not add that padding again** — it would apply twice and leave a gap the
 /// height of the keyboard. A sheet that opens with a field focused (the search
-/// of [#41]) will want a larger [initialExtent], since that fraction is taken
+/// of [#41](https://github.com/Teixeira49/bcv_tracker_app/issues/41)) will want a larger [initialExtent], since that fraction is taken
 /// from the reduced height.
 class BaseBottomSheet extends StatelessWidget {
   const BaseBottomSheet({

--- a/lib/shared/presentation/widgets/base_layout.dart
+++ b/lib/shared/presentation/widgets/base_layout.dart
@@ -7,11 +7,30 @@ import '../../../config/theme/colors/colors_values.dart';
 import '../../../config/theme/icons/icons_constants.dart';
 import '../../../features/settings/presentation/page/settings_modal.dart';
 
+/// The branded frame every top-level screen sits in.
+///
+/// Draws the dark strip with the logo, the title and the settings button, and
+/// hosts [child] underneath. Screens compose this rather than each building their
+/// own `Scaffold`, which is what keeps the strip identical between Home and the
+/// converter.
+///
+/// It measures against its own **box**, not the screen. That is not incidental:
+/// against `MediaQuery` the title kept its absolute offset while the body shrank
+/// under the keyboard, and ended up clipped behind the panel.
 class BaseLayout extends StatelessWidget {
+  /// Content below the branded strip. Null renders the frame alone, which is what
+  /// the splash and the error page want.
   final Widget? child;
+
+  /// Heading inside the strip. Must come from `AppMessages`
+  /// (`.agents/rules/i18n-convention.md`).
   final String? title;
+
+  /// Insets applied to [child], so each screen decides its own gutter without
+  /// touching the frame.
   final EdgeInsetsGeometry margins;
 
+  /// Wraps [child] in the branded frame.
   const BaseLayout({super.key, this.child, required this.margins, this.title});
 
   /// Where the title sits inside the branded strip, as a share of the height.

--- a/lib/shared/presentation/widgets/base_modal.dart
+++ b/lib/shared/presentation/widgets/base_modal.dart
@@ -3,7 +3,15 @@ import 'package:get/get.dart';
 
 import '../../../config/theme/colors/colors_values.dart';
 
+/// A centred dialog in the app's dressing.
+///
+/// The **centred** half of the modal story: use this for a short, self-contained
+/// choice like Settings, and `BaseBottomSheet` for anything that scrolls or that
+/// belongs to something the user tapped. `DESIGN.md` states which applies where.
+/// Opened through `showBlurredDialog`, never `Get.dialog` by hand, and closed
+/// with `Get.back()`.
 class BaseModal extends StatelessWidget {
+  /// Builds the dialog around [child].
   const BaseModal({
     super.key,
     required this.title,

--- a/lib/shared/presentation/widgets/custom_badged.dart
+++ b/lib/shared/presentation/widgets/custom_badged.dart
@@ -1,6 +1,11 @@
 import 'package:flutter/material.dart';
 
+/// A rounded, coloured pill around [child].
+///
+/// The app's one badge shape. Used for the variation indicator and the rate-type
+/// label, so those two cannot drift apart in radius or padding.
 class CustomBadged extends StatelessWidget {
+  /// Wraps [child] in a pill of [color].
   const CustomBadged({
     super.key,
     required this.child,
@@ -27,7 +32,13 @@ class CustomBadged extends StatelessWidget {
   );
 }
 
+/// [CustomBadged] that responds to a tap.
+///
+/// A separate class rather than a nullable `onTap` on [CustomBadged]: a pill that
+/// might be tappable is a pill whose ink and semantics are conditional, and the
+/// two read very differently to assistive tech.
 class CustomBadgedButton extends StatelessWidget {
+  /// Wraps [child] in a tappable pill of [color].
   const CustomBadgedButton({
     super.key,
     required this.child,

--- a/lib/shared/presentation/widgets/custom_bottom_navigator_bar.dart
+++ b/lib/shared/presentation/widgets/custom_bottom_navigator_bar.dart
@@ -6,7 +6,19 @@ import 'package:get/get.dart';
 import '../../../config/theme/colors/colors_values.dart';
 import '../../../navigation/navigation_controller.dart';
 
+/// The app's bottom tab bar.
+///
+/// **Kept as a custom component on purpose.** It is not a `BottomNavigationBar`,
+/// so the Material 3 migration
+/// ([#44](https://github.com/Teixeira49/bcv_tracker_app/issues/44)) left it alone
+/// and its colours still come from `ColorValues` rather than from
+/// `Theme.of(context).colorScheme`.
+///
+/// It **switches tabs, it does not navigate**: tapping moves
+/// `NavigationController.selectedIndex`, and `DashboardPage` keeps both pages
+/// alive in an `IndexedStack`. See `.agents/rules/navigation-convention.md`.
 class CustomBottomNavigatorBar extends StatelessWidget {
+  /// Builds the bar for [pageButtons], driven by [navigationController].
   const CustomBottomNavigatorBar({
     super.key,
     required this.navigationController,
@@ -109,9 +121,15 @@ class _CustomBottomNavigatorItem extends StatelessWidget {
   );
 }
 
+/// The sliding indicator above the selected tab.
+///
+/// Public only because it is built from the item widget; nothing outside this file
+/// should need it.
 class AnimatedBar extends StatelessWidget {
+  /// Draws the indicator, expanded when [isActive].
   const AnimatedBar({super.key, required this.isActive});
 
+  /// Whether this is the selected tab.
   final bool isActive;
 
   @override

--- a/lib/shared/presentation/widgets/custom_refresh_indicator.dart
+++ b/lib/shared/presentation/widgets/custom_refresh_indicator.dart
@@ -1,9 +1,25 @@
 import 'package:bcv_tracker_app/config/theme/colors/colors_values.dart';
 import 'package:flutter/material.dart';
 
-enum CustomRefreshIndicatorType { classic, adaptive, noSpinner }
+/// Which pull-to-refresh affordance [CustomRefreshIndicator] draws.
+enum CustomRefreshIndicatorType {
+  /// Material's own spinner.
+  classic,
 
+  /// The platform's spinner — Material on Android, Cupertino on iOS.
+  adaptive,
+
+  /// No spinner at all: the gesture still refreshes, but the screen shows its own
+  /// loading state instead. Used where a shimmer is already saying it.
+  noSpinner,
+}
+
+/// Pull-to-refresh in one place, with a choice of affordance.
+///
+/// Wraps the platform indicators so [indicatorType] is the only decision a screen
+/// makes, and so `onRefresh` has one signature across the app.
 class CustomRefreshIndicator extends StatelessWidget {
+  /// Wraps [child] in a refresh gesture that calls `onRefresh`.
   const CustomRefreshIndicator({
     required this.onRefresh,
     required this.child,

--- a/lib/shared/presentation/widgets/custom_skeletonizer.dart
+++ b/lib/shared/presentation/widgets/custom_skeletonizer.dart
@@ -3,7 +3,14 @@ import 'package:skeletonizer/skeletonizer.dart';
 
 import '../../../config/theme/colors/colors_values.dart';
 
+/// Shimmer placeholder in the brand's colours.
+///
+/// Wraps `skeletonizer` so the shimmer is one decision instead of a per-screen
+/// choice of greys. Its input is a **real widget tree filled with placeholder
+/// data** — `Currency.emptySkeletonizer`, not empty strings — because the shimmer
+/// traces the shape of what is coming, and a blank field collapses to nothing.
 class CustomSkeletonizer extends StatelessWidget {
+  /// Shimmers [child] while [isLoading]; renders it untouched otherwise.
   const CustomSkeletonizer({
     super.key,
     required this.isLoading,

--- a/lib/shared/presentation/widgets/performance_indicator_widget.dart
+++ b/lib/shared/presentation/widgets/performance_indicator_widget.dart
@@ -3,9 +3,21 @@ import 'package:flutter/material.dart';
 
 import 'custom_badged.dart';
 
+/// The signed percentage badge on a rate — an arrow, a figure and a colour.
+///
+/// Only rendered when the source actually reported a change: a rate whose
+/// `tendency` is `null` shows **no badge at all**, because `0%` reads as "the rate
+/// held" and that is a claim the source did not make. Callers decide; this widget
+/// takes a non-null [value].
+///
+/// Guarded by a golden test in light and dark, since the three states are colour
+/// decisions.
 class PerformanceIndicatorWidget extends StatelessWidget {
+  /// The change to show, as a percentage. Zero renders the neutral state, which is
+  /// a real answer — not the same as an absent one.
   final double value;
 
+  /// Shows [value] as a badge.
   const PerformanceIndicatorWidget({super.key, required this.value});
 
   @override


### PR DESCRIPTION
# Descripción

> ⚠️ **Va encima de #111** (`docs/DTA-039`, issue #4), que aún no está mergeada. Esta regla describe el estado que #4 crea, así que la rama sale de ahí para poder **comprobar que el invariante que afirma es cierto** antes de mergear. **Mergea #111 primero**; después el diff de esta queda en un solo commit. Apunta a `development` directamente, no a otra rama — el apilamiento apuntando a la rama padre es lo que hizo que #108 no llegara a `development`.

`DTA-040`. #4 llevó `lib/` de **31 de 75** tipos públicos documentados a **75 de 75**, y `dart doc` de 8 avisos a **0**. Nada impide que eso retroceda: la clase que alguien añada la semana que viene puede llegar sin docstring y el árbol seguirá compilando, `flutter analyze` seguirá limpio y CI seguirá verde.

Es el fallo que `documentation-convention.md` ya nombra —«una clase nueva que se agrega **después** de un pase de documentación queda con lagunas»— y que un pase no arregla por sí solo, porque el pase es un momento y esto es un hábito.

`.agents/rules/documentation-coverage.md` es la **gemela** de `documentation-convention.md`, con la misma relación que [`test-coverage.md`](.agents/rules/test-coverage.md) tiene con una guía de estilo de tests: una dice **cómo** se escribe, esta dice **qué no se puede perder**.

## El invariante, con números y no con adjetivos

| Ámbito | Exigencia | Estado |
|---|---|---|
| Todo `lib/` | Cada **tipo** público con docstring | 75/75 |
| `shared/domain/` y `shared/data/` | Además, cada **miembro** público | **0 huecos** |
| Todo `lib/` | `dart doc` sin avisos | 0 avisos |

Las capas de contrato son más estrictas porque es donde un docstring ausente cuesta de verdad: un campo opcional que alguien desreferencia, una normalización que se repite porque nadie sabía que ya estaba hecha, un `.toEntity()` que parece redundante y no lo es.

**Tenían 9 huecos de miembro y se cierran en este PR.** No es de más: una regla que nace ya incumplida es la forma más rápida de enseñar que las reglas del repo son decorativas. Los nueve son `copyWith`, los dos constructores de modelo, `toEntity`, `forAverageTab`, `currentBCVDollar`, el constructor de `DollarApiRest` y los dos `get*Currencies` del servicio — y ninguno era obvio: el de `toEntity` explica por qué es obligatorio aunque `return this` compilaría, y el de `forAverageTab` los tres problemas distintos que resuelve en una pasada.

## La parte que más vale leer: las exenciones

`ColorValues` (77 accesores), `AppMessages` (76 getters) y `AppIcons` (17 rutas) están **exentas a nivel de miembro**, y concentran **170 de los 303** miembros sin docstring del proyecto. Documentarlos uno a uno produce exactamente el ruido que la convención prohíbe (`/// El color blanco del texto` sobre `textWhite`), y ese ruido tapa las líneas que sí informan.

La decisión ya se tomó en #4; lo que hace este PR es ponerla **en una tabla, en un solo sitio**, en vez de dejar que la reconstruya quien vuelva a medir. Con una advertencia explícita al lado: la exención vale para un registro mecánico y para nada más, y una cuarta se discute en la PR o no existe.

Y de ahí se sigue por qué `public_member_api_docs` **sigue apagado**: activarlo forzaría esos 170 comentarios, y como CI corre `flutter analyze` sin `--no-fatal-*`, no sería un aviso sino el build roto hasta escribirlos.

## Y la mitad que ningún script puede medir

**La documentación rancia es peor que la ausente.** Un comentario que describe el comportamiento anterior miente con autoridad: quien lo lee deja de comprobar el código. Así que la regla exige que, al cambiar lo que hace un símbolo documentado, **su docstring entre en el mismo diff** — y da las cuatro señales de que uno se quedó viejo (nombra un símbolo que ya no existe, explica un borde que desapareció, cita un issue con el estado equivocado, o da un número que el cambio movió).

## Lo que esta regla no tiene, dicho en la regla

**No tiene dientes.** Se evaluó un test en `test/` —el patrón que `translation_parity_test.dart` ya usa para fallar el build ante una deriva de i18n— y se decidió dejarla como documento por ahora.

La regla lo dice explícitamente en su propia sección en vez de insinuar un enforcement que no existe, y dice qué hacer si la cobertura empieza a bajar: convertirla en ese test, no reescribirla con más énfasis. Queda anotado aquí porque es la limitación conocida de este PR, no un descuido.

## Cableado para que cargue de verdad

Una regla que nadie abre no es una regla:

- Tabla de reglas path-scoped en `CLAUDE.md` / `AGENTS.md` (byte-idénticos; el conteo en prosa pasa de «fourteen» a «fifteen»).
- Catálogo de `.agents/README.md`.
- **Symlink por regla** en `.claude/rules/`, como todas las demás — commiteado como enlace (`120000`), no como copia.
- `CONTRIBUTING.md` gana la tabla de las dos reglas y el invariante en una línea, para quien no va a abrir `.agents/`.

Su `paths:` cubre `lib/**/*.dart`, `analysis_options.yaml` y `CONTRIBUTING.md`, así que carga al tocar lo que gobierna.

No hay dependencias nuevas ni variables de entorno nuevas. No cambia ninguna lógica: el diff de `lib/` son nueve docstrings.

Issue de GitHub relacionado: Closes #112

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad (cambio no-breaking que agrega funcionalidad)
- [ ] 🛠️ Corrección de errores (cambio no-breaking que arregla un error)
- [ ] ❌ Cambio importante (arreglo o característica que haría que la funcionalidad existente no funcionara como se esperaba)
- [x] 📝 Actualización de la documentación
- [ ] 🧹 Code refactoring (modificación de la estructura interna del código sin modificar las APIs)
- [ ] ✅ Build configuration change (modificación de los archivos para hacer deploy)
- [ ] 🗑️ Chore (actividades que no modifican la interacción con la app, por ejemplo, modificar el archivo de lints)

## ¿Cómo se ha probado esto?

- [x] **`flutter analyze` limpio** y **337 tests en verde**.
- [x] **`dart doc .` → `Found 0 warnings and 0 errors`.** `doc/api/` borrado después; está gitignored.
- [x] **75/75 tipos**, con el script que publica `CONTRIBUTING.md`, ejecutado desde ahí.
- [x] **0 huecos de miembro en `shared/domain/` + `shared/data/`**, medido activando el lint un momento y restaurando `analysis_options.yaml` (verificado con `git diff --quiet`). Eran 9 antes de este PR.
- [x] **El symlink resuelve** y se commitea como enlace: `git ls-files -s` da modo `120000`.
- [x] **Los enlaces internos de la regla resuelven** — las tres reglas que cita y los dos anclajes de `CONTRIBUTING.md`.
- [x] `CLAUDE.md` y `AGENTS.md` byte-idénticos (`diff` sin salida).

**Configuración de prueba**: macOS, Flutter 3.38.3. Sin dispositivo: no hay nada que ver en pantalla.

## Lista de Verificación

- [x] He agregado las nuevas dependencias (`pubspec.yaml`) en la descripción — no hay
- [x] He agregado las nuevas variables de entorno (solo los nombres) a la descripción — no hay
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código, particularmente en áreas difíciles de entender
- [x] He realizado los cambios correspondientes a la documentación — es el objeto del PR: la regla, el catálogo de `.agents/`, la tabla path-scoped y `CONTRIBUTING.md`
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente con mis cambios
- [ ] La app compila y el flujo afectado se probó en un dispositivo o emulador real — **no aplica**: no hay flujo afectado
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas — no hay copy nueva
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper de cálculo, incluí sus tests en este mismo PR — no cambió ninguna lógica; los nueve docstrings no alteran comportamiento
- [x] No introduje modelos (`shared/data/model/`) en la UI ni en los controladores
