### PR TITLE
[🗑️ Chore: DTA-041] - Preparar release v1.1.0

### DIFF
--- a/.agents/rules/version-value-proposal.md
+++ b/.agents/rules/version-value-proposal.md
@@ -76,7 +76,9 @@ Si el usuario indica otro número, se usa el suyo sin discutir: la versión es u
 No hay API pública que romper, así que el criterio es **qué deja de funcionar en un teléfono que ya tiene la app**:
 
 - Formato incompatible de lo persistido en `SharedPreferences` (claves de tema, idioma, mercados seguidos) sin migración.
-- Subir `minSdkVersion` (hoy 23) o el deployment target de iOS (hoy 12.0): dispositivos que dejan de recibir la actualización.
+- Subir `minSdkVersion` (hoy 23) o el deployment target de iOS (hoy **15.0**): dispositivos que dejan de recibir la actualización.
+
+  > ⚠️ **Comprueba antes si hay algo que romper.** En `v1.1.0` el target de iOS subió de 13.0 a 15.0 —lo exige el Firebase iOS SDK que arrastra `firebase_core`— y **no** se publicó como MAJOR: iOS nunca se ha distribuido (bundle `com.example.*`, workflows desactivados), así que no había ninguna instalación que dejara de actualizar, y iOS 15 soporta el mismo hardware que iOS 13. La cláusula existe por el daño, no por el número: si el daño no puede ocurrir, dilo en el release note y no infles la versión. La desviación se documenta siempre — ver `docs/release/RELEASE_v1.1.0.md`.
 - Exigir una versión de backend que la anterior no soportaba — si el usuario no actualiza, o si el backend aún no está desplegado, la app queda inservible.
 - Retirar un mercado o una divisa que la gente estaba consultando.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,61 @@ Todos los cambios notables de este proyecto se documentan en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/),
 y el proyecto sigue [Semantic Versioning](https://semver.org/lang/es/).
 
+## [1.1.0] - 2026-08-18
+
+Primera versión que añade funcionalidad para el usuario tras la `v1.0.1`, que
+había dejado la app funcionando y con red de pruebas. Tocar una tasa abre su
+detalle, se puede convertir desde ahí y buscar una moneda por nombre o mercado;
+y el arranque lleva la marca desde el primer fotograma.
+
+### Added
+- Detalle de moneda como hoja inferior, abierto desde las tarjetas de Home, con
+  cabecera, tabla de datos y los huecos reservados para el histórico y las
+  acciones.
+- Conversor rápido dentro del detalle, fijado a esa tasa y con inversión de
+  sentido; comparte la aritmética con el conversor completo (`CurrencyConversion`).
+- Acción «abrir en el conversor», que pasa la tasa al conversor completo
+  llevándose el monto y el sentido.
+- Buscador en el selector de divisas: filtra por código, nombre y mercado,
+  ignorando mayúsculas y acentos, con estado propio de «sin resultados».
+- Splash con el logo de marca animado (icono y wordmark por separado) y pantalla
+  de arranque **nativa** con el navy de marca en Android e iOS.
+- `lib/` documentado con dartdoc: 75 de 75 tipos públicos, y una regla de
+  cobertura para que no retroceda.
+
+### Changed
+- **iOS requiere ahora 15.0** (antes 13.0), porque `firebase_core: ^4.10.0`
+  arrastra el Firebase iOS SDK 12.14.0. No cae ningún dispositivo (iOS 15 soporta
+  el mismo hardware que iOS 13) y iOS no se ha publicado nunca; ver la sección de
+  compatibilidad del release note.
+- El selector de divisas pasa de diálogo centrado a hoja inferior, con contenedor
+  compartido (`BaseBottomSheet`) y una sola cadena de gestos.
+- `SettingsController` pasa a ser un `GetxService` inicializado con `Get.putAsync`
+  y esperado antes de `runApp`: el tema y el idioma guardados están puestos en el
+  primer frame.
+- Los códigos de idioma `en_EN` y `ja_JA` se corrigen a `en_US` y `ja_JP`, con
+  migración de las instalaciones que guardaban los antiguos.
+- La conversión pivote sale del controlador a `shared/domain/conversion.dart`.
+- Las notas del tester en Firebase salen de `release_notes.json` en vez de
+  `Build #N – rama master`.
+- Flutter fijado en 3.38.3 en los cuatro sitios que deben moverse juntos, en vez
+  de seguir `stable`.
+
+### Fixed
+- En una instalación nueva, el selector de idioma mostraba «Español» mientras la
+  app se veía en el idioma del dispositivo, y tocar ese idioma no hacía nada.
+- El conversor redondea al mostrar y no al calcular, así que un resultado ya no
+  aparece con catorce decimales ni pierde precisión al invertirse.
+- El campo de monto filtra lo que acepta, incluso desde un teclado físico o un
+  pegado.
+- «Dólar» se escribe con tilde en español en las tarjetas de Home y en el selector.
+- El botón de intercambio se queda en la costura entre las tarjetas del conversor
+  aunque la de salida crezca, y el conversor no desborda al abrirse el teclado.
+- El contenido de las hojas inferiores tiene su propio `Material`, así que la
+  tinta de los toques se pinta donde debe.
+- La pestaña de Home ya no destruye el servicio de ajustes de toda la app al
+  descartarse.
+
 ## [1.0.1] - 2026-08-07
 
 Primera versión de producción funcional tras `v1.0.0` (que solo contenía el
@@ -47,4 +102,5 @@ de pruebas y CI.
 - La lista de divisas del BCV se convierte correctamente en `toEntity()`.
 - Un `.env` ilegible se reporta en vez de tumbar el arranque.
 
+[1.1.0]: https://github.com/Teixeira49/bcv_tracker_app/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/Teixeira49/bcv_tracker_app/compare/v1.0.0...v1.0.1

--- a/README.md
+++ b/README.md
@@ -142,5 +142,5 @@ Las convenciones de flujo de trabajo son **idénticas a las del backend** (mismo
 
 ---
 
-**Versión actual del proyecto:** 1.0.1+2
+**Versión actual del proyecto:** 1.1.0+3
 **SDK de Dart compatible:** ^3.9.0

--- a/docs/release/RELEASE_v1.1.0.md
+++ b/docs/release/RELEASE_v1.1.0.md
@@ -1,0 +1,184 @@
+# Release Notes - v1.1.0 🚀
+
+**Fecha de lanzamiento:** 18 de Agosto de 2026
+
+## Visión General
+
+`v1.0.1` dejó la app funcionando y con red de pruebas. `v1.1.0` es la primera
+versión que **añade cosas que el usuario puede hacer**, y son tres:
+
+1. **Tocar una tasa y verla entera.** Las tarjetas de Home abren un detalle con
+   mercado, par, tipo de tasa, variación y fechas — datos que la tarjeta no cabía
+   mostrar.
+2. **Convertir sin salir de ahí**, y llevarse la cuenta al conversor completo si
+   se quiere seguir con otras divisas.
+3. **Buscar una moneda** por nombre o por mercado, en vez de recorrer la lista.
+
+Y el arranque deja de parecer dos aplicaciones encadenadas: la pantalla que pinta
+el sistema operativo ya lleva la marca, el logo entra animado, y el tema y el
+idioma guardados están puestos **desde el primer fotograma**.
+
+Por debajo, la versión cierra tres defectos que se notaban y no se entendían: el
+selector de idioma decía «Español» mientras la app estaba en inglés, el conversor
+mostraba resultados con catorce decimales, y las tasas del promedio se ordenaban
+por un plegado de acentos que nunca se ejecutaba porque ningún nombre llevaba
+tilde.
+
+## Registro de Cambios
+
+### Nuevas funcionalidades
+
+- **Detalle de moneda como hoja inferior** ([#38]): se abre tocando cualquier
+  tarjeta de Home, con cabecera, tabla de datos y las secciones reservadas para
+  el histórico ([#5]) y las acciones ([#7]).
+- **Conversor rápido dentro del detalle** ([#39]), fijado a esa tasa, con inversión
+  de sentido. Comparte la aritmética con el conversor completo
+  (`CurrencyConversion`), así que los dos dan el mismo número por construcción.
+- **Abrir en el conversor** ([#103]): pasa la tasa al conversor completo llevándose
+  el monto y el sentido, para continuar la cuenta en vez de reiniciarla.
+- **Buscador en el selector de divisas** ([#41]): filtra por código, nombre y
+  mercado, ignorando mayúsculas y acentos, con un estado propio de «sin
+  resultados».
+
+### UI/UX
+
+- El **selector de divisas** pasa de diálogo centrado a **hoja inferior** ([#40]),
+  con contenedor compartido (`BaseBottomSheet`) y una sola cadena de gestos entre
+  el arrastre y el scroll.
+- **Splash con el logo de marca** ([#10]): icono y wordmark animados por separado,
+  renderizados desde el SVG y no desde un PNG estirado.
+- **Pantalla de arranque nativa con la marca** ([#102]) en Android e iOS: el
+  destello blanco del sistema desaparece y la transición al splash de Flutter deja
+  de mostrar un cambio brusco de color.
+- El **icono de la app** se regenera desde el vector, nítido en todas las
+  densidades ([#10]).
+- El botón de intercambio del conversor se queda en la costura entre las tarjetas
+  aunque la de salida crezca; el conversor ya no desborda al abrirse el teclado.
+
+### Correcciones
+
+- **El selector de idioma decía la verdad a medias** ([#98]): en una instalación
+  nueva la app se veía en el idioma del dispositivo mientras el selector mostraba
+  «Español», y tocar ese idioma no hacía nada. Ahora la app **sigue al
+  dispositivo** hasta que el usuario elige, y el selector muestra el idioma que
+  se está viendo. Los códigos `en_EN` y `ja_JA` se corrigen a `en_US` y `ja_JP`,
+  **migrando** las instalaciones que ya guardaban los antiguos.
+- **El conversor redondea al mostrar, no al calcular** ([#39]): `864.0962999999999`
+  se muestra como `864.10` y la precisión se mantiene en el cálculo, incluso al
+  invertir el sentido.
+- El campo de monto **filtra lo que acepta** (dígitos y un separador), incluso
+  desde un teclado físico o un pegado.
+- «Dólar» se escribe **con tilde** en español ([#104]) en las tarjetas de Home y
+  en el selector.
+- El contenido de las hojas inferiores tiene su propio `Material`, así que la
+  tinta de los toques se pinta donde debe.
+
+### Ingeniería / Estructura
+
+- **Los ajustes se cargan antes del primer frame** ([#59]): `SettingsController`
+  pasa a ser un `GetxService` inicializado con `Get.putAsync` y esperado antes de
+  `runApp`. El tema y el idioma guardados ya no aterrizan *después* de que la UI
+  empiece a construirse — una ventana que los tres segundos del splash tapaban
+  por accidente.
+- La **conversión pivote** sale del controlador a `shared/domain/conversion.dart`
+  ([#39]), que es lo que hace verificable que los dos conversores coincidan.
+- Un **bug de ciclo de vida** que el refactor destapó: la pestaña de Home
+  destruía el servicio de ajustes de toda la app al descartarse.
+
+### CI / Distribución
+
+- **Las notas del tester salen de `release_notes.json`** ([#93]): los tres
+  workflows derivan un `.txt` del JSON y lo pasan al CLI de Firebase, en vez del
+  `Build #N – rama master` que no decía nada. Si el JSON está mal, el build cae en
+  segundos y no distribuye notas vacías.
+- **Flutter fijado en 3.38.3** en los cuatro sitios que tienen que moverse juntos,
+  en vez de seguir `stable` — que ya hizo que CI corriera por delante de las
+  máquinas de desarrollo.
+- `all-platforms-firebase` adjunta el `.sha1` del APK, que era el único de los
+  tres que no lo hacía.
+
+### Documentación
+
+- **Todo `lib/` documentado con dartdoc** ([#4]): de 31 de 75 tipos públicos a
+  **75 de 75**, y `dart doc` de 8 avisos a **0**.
+- **Regla de cobertura de documentación** ([#112]) para que ese nivel no retroceda
+  en silencio, con el invariante, las tres exenciones declaradas y qué hacer
+  cuando un docstring se queda rancio.
+- `assets/brand/README.md` documenta las tres pantallas del arranque y los cuatro
+  sitios donde vive el navy de marca.
+
+## Evolución de la Arquitectura
+
+| | v1.0.1 | v1.1.0 |
+|---|---|---|
+| Aritmética de conversión | En `ConverterController` | En `shared/domain/conversion.dart`, compartida por los dos conversores |
+| Ajustes | `GetxController`, cargados en `onInit` sin esperar | `GetxService` con `Get.putAsync`, **esperado antes de `runApp`** |
+| Registro de dependencias | Solo `dependencies()` | `dependencies()` + `initServices()`, porque GetX **no espera** al primero |
+| Hojas inferiores | No había | `BaseBottomSheet` compartido, contenido en slivers |
+| Idioma inicial | `Get.deviceLocale` en la UI, `es_ES` en el selector | Un solo valor: el dispositivo resuelto dentro de `favLanguageCode` |
+| Tipos documentados | 31 / 75 | **75 / 75** |
+| Tests | 226 | **337** |
+
+## Compatibilidad
+
+### ⚠️ iOS requiere ahora **15.0** (antes 13.0)
+
+`firebase_core: ^4.10.0` arrastra el **Firebase iOS SDK 12.14.0**, que exige iOS
+15, así que el deployment target subió de `13.0` a `15.0`. **No fue una decisión
+del proyecto**: entró como efecto de un `pod install`, y revertirlo rompería la
+resolución de pods.
+
+**Por qué esta versión es `1.1.0` y no `2.0.0`.** `version-value-proposal.md`
+clasifica una subida del deployment target como MAJOR, porque deja dispositivos
+sin actualización. Ese motivo no puede aplicar aquí, y conviene que quede escrito:
+
+- **iOS nunca se ha publicado.** El bundle identifier sigue siendo
+  `com.example.bcvTrackerApp` ([#22] bloquea la subida a las tiendas) y los dos
+  workflows de iOS están desactivados (`triggering: events: []`). No hay ninguna
+  instalación de iOS que pueda quedarse atrás.
+- **No cae ningún dispositivo.** iOS 15 soporta el mismo hardware que iOS 13
+  (iPhone 6s en adelante). Solo afectaría a quien no haya actualizado el sistema
+  — en una plataforma donde la app no existe.
+
+La desviación se documenta aquí en vez de ajustarse en silencio, como exige la
+regla de asimetría. El seguimiento del requisito queda en [#114].
+
+### Sin cambios en el resto
+
+- **Android**: `minSdkVersion` sigue en 23. Ningún dispositivo pierde soporte.
+- **Backend**: mismo contrato que `v1.0.1` (`saved-currencies` vía POST con
+  `MarketSelection`).
+- **Datos locales**: las claves de `SharedPreferences` no cambian. Los valores de
+  idioma `en_EN` y `ja_JA` **se migran** a `en_US` y `ja_JP` en el primer arranque,
+  así que una instalación existente conserva el idioma que había elegido.
+
+## Próximos Pasos
+
+- **[#22]** — identificadores de bundle reales, que es lo que desbloquea publicar.
+- **[#5]** y **[#7]** — el histórico y las acciones del detalle, cuyos huecos esta
+  versión ya deja cableados en su sitio.
+- **[#45]** — la disposición de workers de GetX, hoy una obligación de convención
+  en cada controlador nuevo.
+
+[#4]: https://github.com/Teixeira49/bcv_tracker_app/issues/4
+[#5]: https://github.com/Teixeira49/bcv_tracker_app/issues/5
+[#7]: https://github.com/Teixeira49/bcv_tracker_app/issues/7
+[#10]: https://github.com/Teixeira49/bcv_tracker_app/issues/10
+[#22]: https://github.com/Teixeira49/bcv_tracker_app/issues/22
+[#38]: https://github.com/Teixeira49/bcv_tracker_app/issues/38
+[#39]: https://github.com/Teixeira49/bcv_tracker_app/issues/39
+[#40]: https://github.com/Teixeira49/bcv_tracker_app/issues/40
+[#41]: https://github.com/Teixeira49/bcv_tracker_app/issues/41
+[#45]: https://github.com/Teixeira49/bcv_tracker_app/issues/45
+[#59]: https://github.com/Teixeira49/bcv_tracker_app/issues/59
+[#93]: https://github.com/Teixeira49/bcv_tracker_app/issues/93
+[#98]: https://github.com/Teixeira49/bcv_tracker_app/issues/98
+[#102]: https://github.com/Teixeira49/bcv_tracker_app/issues/102
+[#103]: https://github.com/Teixeira49/bcv_tracker_app/issues/103
+[#104]: https://github.com/Teixeira49/bcv_tracker_app/issues/104
+[#112]: https://github.com/Teixeira49/bcv_tracker_app/issues/112
+[#114]: https://github.com/Teixeira49/bcv_tracker_app/issues/114
+
+---
+
+*DolarTracker - Monitorizando la economía con precisión y elegancia.*

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.1+2
+version: 1.1.0+3
 
 environment:
   sdk: ^3.9.0

--- a/release_notes.json
+++ b/release_notes.json
@@ -1,10 +1,10 @@
 [
   {
     "language": "en-US",
-    "text": "The average-market rates load again, and the app now shows a clear message with a retry button when something fails or you're offline, instead of a blank screen.\n\n• Redesigned error and empty states\n• The converter no longer shows wrong results\n• Stability, security and translation fixes"
+    "text": "Tap any rate to open its full detail, convert right there, and carry the amount over to the full converter to keep going.\n\n• Rate detail: market, pair, type, change and dates\n• Quick converter inside the detail, with a direction switch\n• Search the currency list by name or market\n• Branded start-up: no more white flash before the logo\n• The language selector now matches the language you see\n• Converted amounts no longer show fourteen decimals"
   },
   {
     "language": "es-ES",
-    "text": "Vuelven a cargar las tasas del mercado promedio, y ahora la app te muestra un mensaje claro con un botón para reintentar cuando algo falla o no hay conexión, en vez de quedarse en blanco.\n\n• Estados de error y vacío rediseñados\n• El conversor ya no muestra resultados erróneos\n• Correcciones de estabilidad, seguridad y traducciones"
+    "text": "Toca cualquier tasa para ver su detalle completo, convertir ahí mismo y llevarte el monto al conversor completo para seguir la cuenta.\n\n• Detalle de la tasa: mercado, par, tipo, variación y fechas\n• Conversor rápido en el detalle, con cambio de sentido\n• Busca en la lista de monedas por nombre o mercado\n• Arranque con la marca: se acabó el destello blanco\n• El selector de idioma ya coincide con el que ves\n• Los montos convertidos ya no salen con catorce decimales"
   }
 ]

--- a/test/tool/release_notes_txt_test.dart
+++ b/test/tool/release_notes_txt_test.dart
@@ -172,7 +172,18 @@ void main() {
     });
 
     test('the tester gets Spanish', () {
-      expect(renderReleaseNotes(source), contains('tasas'));
+      // Asserted against the file's own `es-ES` entry rather than against a word
+      // that happens to be in it. An earlier version of this test looked for
+      // "tasas", which tied it to one release's prose and broke on the next —
+      // the kind of test people delete instead of fixing.
+      final List<dynamic> entries = jsonDecode(source) as List<dynamic>;
+      final String spanish =
+          entries.cast<Map<String, dynamic>>().firstWhere(
+                (Map<String, dynamic> e) => e['language'] == 'es-ES',
+              )['text']
+              as String;
+
+      expect(renderReleaseNotes(source), '${spanish.trim()}\n');
     });
 
     test('every language fits the 500 characters Google Play allows', () {


### PR DESCRIPTION
# Descripción

`DTA-041`. Preparación de la promoción `development` → `master`: **13 PRs (#95→#113)** y **14 issues** desde `v1.0.1`.

Este PR no cambia comportamiento. Es el papeleo de release que, según `release-versioning.md`, tiene que entrar **antes** de la promoción, porque el tag debe apuntar a un commit donde `pubspec.yaml` ya declare la versión nueva.

## La versión: v1.1.0, y por qué no v2.0.0

Mecánicamente es **MINOR** (7 `feat`, 11 `fix`, 7 `docs`, 4 `refactor`, 3 `ci`) → `v1.1.0`. La frase de valor, que es la que abre `release_notes.json`:

> El usuario puede tocar cualquier tasa para ver su detalle completo, convertir ahí mismo y llevarse el monto al conversor completo para seguir la cuenta.

**Pero hay un detalle que la regla clasifica como MAJOR.** El deployment target de iOS subió de `13.0` a `15.0` dentro de esta tanda, y `version-value-proposal.md` dice que eso es MAJOR porque «dispositivos dejan de recibir la actualización». Ese motivo no puede aplicar aquí:

- **iOS nunca se ha distribuido.** Bundle `com.example.bcvTrackerApp` (#22 bloquea las tiendas) y los dos workflows de iOS desactivados (`triggering: events: []`). Cero instalaciones que dejar atrás.
- **No cae ningún dispositivo.** iOS 15 soporta el mismo hardware que iOS 13 (iPhone 6s en adelante). Solo afectaría a quien no haya actualizado el SO, en una plataforma donde la app no existe.

La regla exige que una desviación se justifique por escrito y no en silencio, así que va en la sección de compatibilidad del release note y en el CHANGELOG. Inflar a `v2.0.0` haría que MAJOR signifique «importante» en vez de «incompatible» para quien lea el historial dentro de un año.

### Y ese cambio de iOS no fue una decisión de nadie

Entró por un `pod install`, **dentro de un commit `📝 docs(tests)`** de la PR #97 — un cambio de plataforma viajando en un commit de documentación, que es donde nadie lo busca. La causa: `firebase_core: ^4.10.0` → Firebase iOS SDK 12.14.0 → exige iOS 15. Revertirlo rompería la resolución de pods. Queda en **#114**, y `version-value-proposal.md` se anota con el caso y con **su propio número corregido**: decía «hoy 12.0», dos versiones desactualizado.

## Archivos, según `version-sources.md`

| Archivo | Cambio |
|---|---|
| `pubspec.yaml` | `1.0.1+2` → `1.1.0+3`. **La única fuente que se edita** |
| `README.md` | La línea de versión actual, que nada sincroniza |
| `docs/release/RELEASE_v1.1.0.md` | El documento extenso, con tabla de evolución de arquitectura y compatibilidad |
| `CHANGELOG.md` | Entrada Keep a Changelog + enlace de comparación |
| `release_notes.json` | **Lo que lee el tester**. 446 y 467 caracteres, bajo el límite de 500 de Google Play, sin `<` ni `>` |

`android/`, `ios/` y `codemagic.yaml` **no se tocan** — derivan la versión de `pubspec.yaml`. Verificado con `git diff --quiet`: si el diff los tocara, algo iría mal.

## Un arreglo que no es papeleo

El test de derivación de notas que dejó #93 afirmaba que el texto español contenía la palabra «tasas». Eso lo ataba a la prosa de **una** versión y habría fallado en todas las siguientes — el tipo de test que se borra en vez de arreglarse. Ahora compara contra la entrada `es-ES` del propio archivo, que es lo que siempre quiso comprobar. Se detectó justo al escribir estas notas, que es cuando tenía que detectarse.

Issue de GitHub relacionado: Sin issue vinculado (preparación de release, mismo patrón que #91 para `v1.0.1`)

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad (cambio no-breaking que agrega funcionalidad)
- [ ] 🛠️ Corrección de errores (cambio no-breaking que arregla un error)
- [ ] ❌ Cambio importante (arreglo o característica que haría que la funcionalidad existente no funcionara como se esperaba)
- [x] 📝 Actualización de la documentación
- [ ] 🧹 Code refactoring (modificación de la estructura interna del código sin modificar las APIs)
- [ ] ✅ Build configuration change (modificación de los archivos para hacer deploy)
- [x] 🗑️ Chore (actividades que no modifican la interacción con la app, por ejemplo, modificar el archivo de lints)

## ¿Cómo se ha probado esto?

- [x] `flutter analyze` limpio y **337 tests en verde**.
- [x] `pubspec.yaml` y `README.md` declaran lo mismo: `1.1.0+3`.
- [x] `android/`, `ios/` y `codemagic.yaml` intactos (`git diff --quiet`).
- [x] `release_notes.json` validado contra los límites de la regla: 446 (en-US) y 467 (es-ES) caracteres, sin ángulos, `en-US` presente.
- [x] **La derivación real**: `dart run tool/release_notes_txt.dart` produce el texto español que verá el tester, verbatim y con las viñetas intactas.
- [x] El build number sube (`+2` → `+3`) y nunca baja, aunque el SemVer suba.

**Configuración de prueba**: macOS, Flutter 3.38.3. Sin dispositivo: no cambia nada de la app.

## Lo que queda después de mergear esto

1. PR de promoción `development` → `master` con el release note como cuerpo.
2. El merge de esa promoción **cierra los 14 issues de golpe** (las keywords `Closes #N` solo disparan contra la rama por defecto).
3. Tag `v1.1.0` + GitHub Release — pendiente de tu aprobación escrita, que es lo que exige `triggerMode: "ask"`.
4. Codemagic construye y distribuye al hacer push a `master`, tomando `--build-name` de `pubspec.yaml`. **Es el primer build que estrena las notas de tester de #93.**

## Lista de Verificación

- [x] He agregado las nuevas dependencias (`pubspec.yaml`) en la descripción — ninguna nueva; solo cambia `version:`
- [x] He agregado las nuevas variables de entorno (solo los nombres) a la descripción — no hay
- [x] Mi código sigue las pautas de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código, particularmente en áreas difíciles de entender
- [x] He realizado los cambios correspondientes a la documentación — es el objeto del PR
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente con mis cambios
- [ ] La app compila y el flujo afectado se probó en un dispositivo o emulador real — **no aplica**: no cambia nada de la app
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas — no hay copy de UI; `release_notes.json` no es UI
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper de cálculo, incluí sus tests en este mismo PR
- [x] No introduje modelos (`shared/data/model/`) en la UI ni en los controladores
