### PR TITLE
[📝 Doc: DTA-043] - Documentar la v1.0.0 en el changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,9 +62,10 @@ y el arranque lleva la marca desde el primer fotograma.
 
 ## [1.0.1] - 2026-08-07
 
-Primera versión de producción funcional tras `v1.0.0` (que solo contenía el
-andamiaje inicial). Restaura la carga de tasas, endurece la app y añade la red
-de pruebas y CI.
+Versión de mantenimiento sobre `v1.0.0`. El promedio había dejado de cargar
+cuando el backend movió `saved-currencies` de GET a POST; esta versión lo
+restaura, endurece la app y le pone la red de pruebas y el CI que la anterior
+no tenía.
 
 ### Added
 - Mensajes de error diferenciados por tipo de fallo (sin conexión, timeout,
@@ -102,5 +103,23 @@ de pruebas y CI.
 - La lista de divisas del BCV se convierte correctamente en `toEntity()`.
 - Un `.env` ilegible se reporta en vez de tumbar el arranque.
 
+## [1.0.0] - 2026-04-09
+
+Primera versión publicada. La app completa: las tasas del BCV y del mercado
+paralelo en dos pestañas, conversor, ajustes e interfaz en diez idiomas.
+
+### Added
+- Pantalla de inicio con dos pestañas —promedio del mercado paralelo y tasas
+  oficiales del BCV—, sobre los endpoints `saved-currencies` (GET) y
+  `bcv/with-memory`.
+- Conversor con regla pivote en bolívares: cualquier par se resuelve como
+  `X → VES → Y`, porque el backend solo publica tasas contra VES.
+- Ajustes con idioma, tema (claro / oscuro / sistema) y mercado de arranque,
+  persistidos en `SharedPreferences`.
+- Interfaz en **diez idiomas** mediante GetX Translations.
+- Splash, barra de navegación inferior propia y el sistema de color de cuatro
+  modos (`ColorValues`).
+
 [1.1.0]: https://github.com/Teixeira49/bcv_tracker_app/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/Teixeira49/bcv_tracker_app/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/Teixeira49/bcv_tracker_app/releases/tag/v1.0.0


### PR DESCRIPTION
# Descripción

Cierra el único criterio de aceptación de #25 que quedaba a medias, y corrige una afirmación falsa que el `CHANGELOG.md` llevaba desde entonces.

El criterio pedía documentar retroactivamente las versiones publicadas, **«al menos la 1.0.0»**. El changelog arrancaba en `[1.0.1]` y despachaba la anterior en la prosa de entrada: *«tras `v1.0.0` (que solo contenía el andamiaje inicial)»*.

**Esa frase no describe lo que se publicó.** Comprobado contra el tag:

| | `v1.0.0` |
|---|---|
| Commits | 80 |
| Archivos Dart en `lib/` | 77 |
| Features | `home`, `converter`, `settings`, `splash`, `dashboard` |
| Idiomas | 10 |
| Archivos de test | **1** |
| Publicada | Release de GitHub el 2026-04-09 |

Es la app entera. Lo que la dejó atrás no fue salir del andamiaje: fue que el backend movió `saved-currencies` de GET a POST y el promedio dejó de cargar — que es exactamente lo que la sección `Fixed` de `1.0.1` ya decía, contradiciendo a su propia entradilla dos párrafos más arriba.

Lo que **sí** era cierto es el único archivo de test, y ahora está donde se puede comprobar: por eso la entrada de `1.0.1` habla de «la red de pruebas y el CI que la anterior no tenía».

Cambios:

1. **Sección `## [1.0.0] - 2026-04-09`** con lo que realmente traía, en `Added`: las dos pestañas y sus endpoints, el conversor con la regla pivote, los ajustes persistidos, los diez idiomas y el sistema de color de cuatro modos.
2. **Entradilla de `1.0.1` reescrita** para que no afirme lo que no pasó.
3. **Enlace `[1.0.0]:` al pie**, que faltaba. Apunta al **tag**, no a un `compare`: la primera versión no compara contra nada.

Issue de GitHub relacionado: Closes #25

## Un hallazgo aparte, que no arreglo aquí

**`v1.1.0` no está etiquetada ni publicada.** `master` lleva `version: 1.1.0+3` y el changelog tiene su entrada fechada el 2026-08-18, pero el último release de GitHub es `v1.0.1` y el tag `v1.1.0` no existe. Consecuencia: el enlace del pie

```
[1.1.0]: .../compare/v1.0.1...v1.1.0
```

**está roto ahora mismo**.

No lo toco en esta PR, y a propósito: cambiar el enlace taparía el problema en vez de resolverlo. Lo que falta es el paso 7 de `release-versioning.md` —crear el GitHub Release sobre `master`—, que es trabajo de release y no de #25. Queda dicho para que se decida aparte.

## Tipo de cambio

- [ ] ✨ Nueva funcionalidad (cambio no-breaking que agrega funcionalidad)
- [ ] 🛠️ Corrección de errores (cambio no-breaking que arregla un error)
- [ ] ❌ Cambio importante (arreglo o característica que haría que la funcionalidad existente no funcionara como se esperaba)
- [x] 📝 Actualización de la documentación
- [ ] 🧹 Code refactoring (modificación de la estructura interna del código sin modificar las APIs)
- [ ] ✅ Build configuration change (modificación de los archivos para hacer deploy)
- [ ] 🗑️ Chore (actividades que no modifican la interacción con la app, por ejemplo, modificar el archivo de lints)

## ¿Cómo se ha probado esto?

Cambio de documentación: no toca `lib/` ni `test/`. Lo que se verificó es que lo escrito **es verdad**, contra el repositorio y no contra la memoria:

- [x] `git ls-tree -r v1.0.0 -- lib` → 77 archivos Dart; `lib/features` → las cinco features listadas
- [x] `git ls-tree -r v1.0.0 -- test` → 1 archivo, que sostiene la frase sobre la red de pruebas
- [x] `git show v1.0.0:lib/.../dollar_endpoints.dart` → `saved-currencies` con query params (GET) y `bcv/with-memory`, tal como dice la entrada
- [x] `git show v1.0.0:pubspec.yaml` → `version: 1.0.0+1`, coherente con el tag
- [x] `gh release list` → `v1.0.0` publicada el 2026-04-09, que es la fecha de la sección
- [x] `flutter analyze` limpio y `flutter test` en verde (337), para constatar que nada se rompió

**Configuración de prueba**: no aplica — sin cambios de UI ni de comportamiento.

## Lista de Verificación

- [x] He agregado las nuevas dependencias (`pubspec.yaml`) en la descripción — ninguna
- [x] He agregado las nuevas variables de entorno (solo los nombres) a la descripción — ninguna
- [x] Mi código sigue las pautas de estilo de este proyecto — formato Keep a Changelog, como pide `release-versioning.md` Paso 5
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código, particularmente en áreas difíciles de entender — no aplica
- [x] He realizado los cambios correspondientes a la documentación — este PR **es** la documentación
- [x] `flutter analyze` no reporta nuevas advertencias
- [x] `flutter test` pasa localmente con mis cambios
- [ ] La app compila y el flujo afectado se probó en un dispositivo — **no aplica**: no hay flujo afectado
- [x] Si agregué copy nueva a la UI, la clave existe en los 10 idiomas — no hay copy de UI
- [x] Si agregué o modifiqué una fuente de datos, un controlador o un helper de cálculo, incluí sus tests — no se tocó ninguno
- [x] No introduje modelos (`shared/data/model/`) en la UI ni en los controladores
